### PR TITLE
If cloning do not perform DiskDiffOperation

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -902,8 +902,10 @@ func resourceVSphereVirtualMachineCustomizeDiff(d *schema.ResourceDiff, meta int
 
 	// Validate and normalize disk sub-resources when not deploying from ovf
 	if len(d.Get("ovf_deploy").([]interface{})) == 0 {
-		if err := virtualdevice.DiskDiffOperation(d, client); err != nil {
-			return err
+		if len(d.Get("clone").([]interface{})) == 0 {
+			if err := virtualdevice.DiskDiffOperation(d, client); err != nil {
+				return err
+			}
 		}
 	}
 	// When a VM is a member of a vApp container, it is no longer part of the VM


### PR DESCRIPTION
# Description

When cloning a virtual machine with a storage policy defined the DiskDiffOperation provides incorrect values for `eager` and `thin` causing the errors listed in #1028 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

Resolves #1028
