### PR TITLE
Add import for vsphere_virtual_disk

### DIFF
--- a/vsphere/resource_vsphere_virtual_disk_test.go
+++ b/vsphere/resource_vsphere_virtual_disk_test.go
@@ -31,6 +31,19 @@ func TestAccResourceVSphereVirtualDisk_basic(t *testing.T) {
 					testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", true),
 				),
 			},
+			{
+				ResourceName:      "vsphere_virtual_disk.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdPrefix: fmt.Sprintf("/%s/[%s] ",
+					os.Getenv("TF_VAR_VSPHERE_DATACENTER"),
+					os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"),
+				),
+				Config: testAccCheckVSphereVirtuaDiskConfig_basic(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", true),
+				),
+			},
 		},
 	})
 }
@@ -101,6 +114,20 @@ func TestAccResourceVSphereVirtualDisk_withParent(t *testing.T) {
 		CheckDestroy: testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", false),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccCheckVSphereVirtuaDiskConfig_withParent(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", true),
+				),
+			},
+			{
+				ResourceName:            "vsphere_virtual_disk.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"create_directories"},
+				ImportStateIdPrefix: fmt.Sprintf("/%s/[%s] ",
+					os.Getenv("TF_VAR_VSPHERE_DATACENTER"),
+					os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"),
+				),
 				Config: testAccCheckVSphereVirtuaDiskConfig_withParent(rString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", true),

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -70,3 +70,19 @@ vSphere provider.
 ~> **NOTE:** Any directory created as part of the operation when
 `create_directories` is enabled will not be deleted when the resource is
 destroyed.
+
+## Importing
+
+An existing virtual disk can be [imported][docs-import] into this resource
+via supplying the full datastore path to the virtual disk. An example is below:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import vsphere_virtual_disk.disk /dc1/[ds1] disk1_vmdk_path
+```
+
+The above would import the virtual disk located at `disk1_vmdk_path` in the `ds1`
+datastore of the `dc1` datacenter.
+
+~> **NOTE:** Import is not supported if using the **deprecated** `adapter_type` field.


### PR DESCRIPTION

### Description
Add function to import a vsphere_virtual_disk resource via `terraform import`.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)
        https://gist.github.com/skevir/1a5df485691d979a2e26b489a393e93f (only ran TestAccResourceVSphereVirtualDisk tests)

### References
https://github.com/hashicorp/terraform-provider-vsphere/issues/1113