### PR TITLE
r/vm: Set guest_id before customization

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -252,7 +252,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"guest_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "other-64",
+			Computed:    true,
 			Description: "The guest ID for the operating system.",
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 				if len(d.Get("ovf_deploy").([]interface{})) > 0 {


### PR DESCRIPTION
Switch `guest_id` to `computed`, and set the default in `CustomizeDiff` in order to support leaving the field empty for Content Library template sources.

Fixes #1119