### PR TITLE
Add host_thumbprint data source

### DIFF
--- a/vsphere/data_source_vsphere_host_thumbprint.go
+++ b/vsphere/data_source_vsphere_host_thumbprint.go
@@ -1,0 +1,49 @@
+package vsphere
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"crypto/tls"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceVSphereHostThumbprint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereHostThumbprintRead,
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The address of the ESXi to extract the thumbprint from.",
+			},
+			"port": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "443",
+				Description: "The port to connect to on the ESXi host.",
+			},
+		},
+	}
+}
+
+func dataSourceVSphereHostThumbprintRead(d *schema.ResourceData, meta interface{}) error {
+	config := &tls.Config{}
+	config.InsecureSkipVerify = true
+	conn, err := tls.Dial("tcp", d.Get("address").(string)+":"+d.Get("port").(string), config)
+	if err != nil {
+		return err
+	}
+	cert := conn.ConnectionState().PeerCertificates[0]
+	fingerprint := sha1.Sum(cert.Raw)
+
+	var buf bytes.Buffer
+	for i, f := range fingerprint {
+		if i > 0 {
+			fmt.Fprintf(&buf, ":")
+		}
+		fmt.Fprintf(&buf, "%02X", f)
+	}
+	d.SetId(buf.String())
+	return nil
+}

--- a/vsphere/data_source_vsphere_host_thumbprint.go
+++ b/vsphere/data_source_vsphere_host_thumbprint.go
@@ -23,13 +23,18 @@ func dataSourceVSphereHostThumbprint() *schema.Resource {
 				Default:     "443",
 				Description: "The port to connect to on the ESXi host.",
 			},
+			"insecure": {
+				Type: schema.TypeBool,
+				Optional: true,
+				Description: "Boolean that can be set to true to disable SSL certificate verification.",
+			},
 		},
 	}
 }
 
 func dataSourceVSphereHostThumbprintRead(d *schema.ResourceData, meta interface{}) error {
 	config := &tls.Config{}
-	config.InsecureSkipVerify = true
+	config.InsecureSkipVerify = d.Get("insecure").(bool)
 	conn, err := tls.Dial("tcp", d.Get("address").(string)+":"+d.Get("port").(string), config)
 	if err != nil {
 		return err

--- a/vsphere/data_source_vsphere_host_thumbprint.go
+++ b/vsphere/data_source_vsphere_host_thumbprint.go
@@ -24,8 +24,8 @@ func dataSourceVSphereHostThumbprint() *schema.Resource {
 				Description: "The port to connect to on the ESXi host.",
 			},
 			"insecure": {
-				Type: schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
 				Description: "Boolean that can be set to true to disable SSL certificate verification.",
 			},
 		},

--- a/vsphere/data_source_vsphere_host_thumbprint_test.go
+++ b/vsphere/data_source_vsphere_host_thumbprint_test.go
@@ -1,0 +1,43 @@
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceVSphereHostThumbprint_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereHostThumbprintPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereHostThumbprintConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vsphere_host_thumbprint.thumb", "id", regexp.MustCompile("([0-9A-F]{2}:)+[0-9A-F]{2}")),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVSphereHostThumbprintPreCheck(t *testing.T) {
+	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
+		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_host_thumbprint acceptance tests")
+	}
+}
+
+func testAccDataSourceVSphereHostThumbprintConfig() string {
+	return fmt.Sprintf(`
+data "vsphere_host_thumbprint" "thumb" {
+  address = "%s"
+}`,
+		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
+	)
+}

--- a/vsphere/internal/helper/testhelper/testing.go
+++ b/vsphere/internal/helper/testhelper/testing.go
@@ -1,6 +1,9 @@
 package testhelper
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 func CombineConfigs(configs ...string) string {
 	var config string
@@ -29,7 +32,7 @@ data "vsphere_datacenter" "dc2" {
 func ConfigResDC1() string {
 	return fmt.Sprintf(`
 resource "vsphere_datacenter" "dc1" {
-  name = "testdc1"
+  name = "testacc-dc1"
   tags = [vsphere_tag.tag1.id, vsphere_tag.tag2.id]
 }
 `)
@@ -38,7 +41,7 @@ resource "vsphere_datacenter" "dc1" {
 func ConfigResDC2() string {
 	return fmt.Sprintf(`
 resource "vsphere_datacenter" "dc2" {
-  name = "testdc2"
+  name = "testacc-dc2"
   tags = [ vsphere_tag.tag1.id, vsphere_tag.tag3.id ]
 }
 `)
@@ -47,7 +50,7 @@ resource "vsphere_datacenter" "dc2" {
 func ConfigResTagCat1() string {
 	return fmt.Sprintf(`
 resource "vsphere_tag_category" "category1" {
-  name        = "cat1"
+  name        = "testacc-cat1"
   description = "cat1"
   cardinality = "MULTIPLE"
 
@@ -61,7 +64,7 @@ resource "vsphere_tag_category" "category1" {
 func ConfigResTagCat2() string {
 	return fmt.Sprintf(`
 resource "vsphere_tag_category" "category2" {
-  name        = "cat2"
+  name        = "testacc-cat2"
   description = "cat2"
   cardinality = "MULTIPLE"
 
@@ -72,10 +75,19 @@ resource "vsphere_tag_category" "category2" {
 `)
 }
 
+func ConfigDataRootDS1() string {
+	return fmt.Sprintf(`
+data "vsphere_datastore" "rootds1"{
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  name          = "%s"
+}
+`, os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+}
+
 func ConfigResTag1() string {
 	return fmt.Sprintf(`
 resource "vsphere_tag" "tag1" {
-  name        = "tag1"
+  name        = "testacc-tag1"
   category_id = vsphere_tag_category.category1.id
 }
 `)
@@ -84,7 +96,7 @@ resource "vsphere_tag" "tag1" {
 func ConfigResTag2() string {
 	return fmt.Sprintf(`
 resource "vsphere_tag" "tag2" {
-  name        = "tag2"
+  name        = "testacc-tag2"
   category_id = vsphere_tag_category.category2.id
 }
 `)
@@ -93,7 +105,146 @@ resource "vsphere_tag" "tag2" {
 func ConfigResTag3() string {
 	return fmt.Sprintf(`
 resource "vsphere_tag" "tag3" {
-  name        = "tag2"
+  name        = "testacc-tag2"
   category_id = vsphere_tag_category.category1.id
 }`)
+}
+
+func ConfigDataRootDC1() string {
+	return fmt.Sprintf(`
+data "vsphere_datacenter" "rootdc1" {
+  name = "%s"
+}
+`, os.Getenv("TF_VAR_VSPHERE_DATACENTER"))
+}
+
+func ConfigDataRootHost1() string {
+	return fmt.Sprintf(`
+data "vsphere_host" "roothost1" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_ESXI1"))
+}
+
+func ConfigDataRootHost2() string {
+	return fmt.Sprintf(`
+data "vsphere_host" "roothost2" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_ESXI2"))
+}
+
+func ConfigResDS1() string {
+	return fmt.Sprintf(`
+resource "vsphere_nas_datastore" "ds1" {
+  name            = "testacc-nfsds1"
+  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  type            = "NFS"
+  remote_hosts    = ["%s"]
+  remote_path     = "%s"
+}
+`, os.Getenv("TF_VAR_VSPHERE_NAS_HOST"), os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"))
+}
+
+func ConfigDataRootComputeCluster1() string {
+	return fmt.Sprintf(`
+data "vsphere_compute_cluster" "rootcompute_cluster1" {
+	name          = "%s"
+	datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_CLUSTER"))
+}
+
+func ConfigResResourcePool1() string {
+	return fmt.Sprintf(`
+resource "vsphere_resource_pool" "pool1" {
+  name                    = "testacc-resource-pool1"
+  parent_resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster.resource_pool_id
+}
+`)
+}
+
+func ConfigDataRootPortGroup1() string {
+	return fmt.Sprintf(`
+data "vsphere_network" "network1" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_PG_NAME"))
+}
+
+func ConfigDataRootVMNet() string {
+	return fmt.Sprintf(`
+data "vsphere_network" "vmnet" {
+  name          = "VM Network"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`)
+}
+
+func ConfigResNestedEsxi() string {
+	return fmt.Sprintf(`
+resource "vsphere_virtual_machine" "nested-esxi1" {
+  name             = "testacc-n-esxi1"
+  resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.rootds1.id
+  datacenter_id    = data.vsphere_datacenter.rootdc1.id
+  host_system_id   = data.vsphere_host.roothost2.id
+
+  nested_hv_enabled = true
+  firmware          = "efi"
+  enable_disk_uuid  = true
+
+  num_cpus = 2
+  memory   = 6144
+  guest_id = "other3xLinux64Guest"
+
+  wait_for_guest_net_timeout = -1
+
+  network_interface {
+    network_id = data.vsphere_network.vmnet.id
+  }
+
+  ovf_deploy {
+    remote_ovf_url = "https://download3.vmware.com/software/vmw-tools/Nested_ESXi6.7u3_Appliance_Template_v1.0/Nested_ESXi6.7u3_Appliance_Template_v1.ovf"
+    ovf_network_map = {
+      "VM Network" = data.vsphere_network.vmnet.id
+    }
+  }
+  disk {
+    label = "disk0"
+    size  = 2
+  }
+
+  disk {
+    label = "disk1"
+    size  = 4
+  }
+
+  disk {
+    label = "disk2"
+    size  = 8
+  }
+
+  cdrom {
+    client_device = true
+  }
+}
+
+data "vsphere_host_thumbprint" "thumb" {
+  address = vsphere_virtual_machine.nested-esxi1.default_ip_address
+}
+
+resource "vsphere_host" "nested-esxi1" {
+  hostname                   = vsphere_virtual_machine.nested-esxi1.default_ip_address
+  username                   = "root"
+  password                   = "VMware1!"
+  license                    = "%s"
+  force                      = true
+  thumbprint                 = data.vsphere_host_thumbprint.thumb.id
+  datacenter                 = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_LICENSE"))
 }

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -146,6 +146,7 @@ func Provider() terraform.ResourceProvider {
 			"vsphere_folder":                     dataSourceVSphereFolder(),
 			"vsphere_host":                       dataSourceVSphereHost(),
 			"vsphere_host_pci_device":            dataSourceVSphereHostPciDevice(),
+			"vsphere_host_thumbprint":            dataSourceVSphereHostThumbprint(),
 			"vsphere_network":                    dataSourceVSphereNetwork(),
 			"vsphere_resource_pool":              dataSourceVSphereResourcePool(),
 			"vsphere_storage_policy":             dataSourceVSphereStoragePolicy(),

--- a/website/docs/d/host_thumbprint.html.markdown
+++ b/website/docs/d/host_thumbprint.html.markdown
@@ -10,7 +10,8 @@ description: |-
 
 The `vsphere_thumbprint` data source can be used to discover the host
 thumbprint of an ESXi host. This can be used when adding the `vsphere_host`
-resource.
+resource. If the host is using a certificate chain, the first one returned
+will be used to generate the thumbprint.
 
 ## Example Usage
 
@@ -26,7 +27,10 @@ The following arguments are supported:
 
 * `address` - (Required) The address of the ESXi host to retrieve the
 thumbprint from.
-* `port` - (Optional) The port to use connecting to the ESXi host.
+* `port` - (Optional) The port to use connecting to the ESXi host. Default: 443
+* `insecure` - (Optional) Boolean that can be set to true to disable SSL 
+certificate verification. Default: false
+
 ## Attribute Reference
 
 The only exported attribute is `id`, which is the thumbprint of the ESXi

--- a/website/docs/d/host_thumbprint.html.markdown
+++ b/website/docs/d/host_thumbprint.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_host_thumbprint"
+sidebar_current: "docs-vsphere-data-source-datacenter"
+description: |-
+  A data source that can be used to get the thumbprint of an ESXi host.
+---
+
+# vsphere\_host\_thumbprint
+
+The `vsphere_thumbprint` data source can be used to discover the host
+thumbprint of an ESXi host. This can be used when adding the `vsphere_host`
+resource.
+
+## Example Usage
+
+```hcl
+data "vsphere_host_thumbprint" "thumbprint" {
+  address = "esxi.example.internal"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `address` - (Required) The address of the ESXi host to retrieve the
+thumbprint from.
+* `port` - (Optional) The port to use connecting to the ESXi host.
+## Attribute Reference
+
+The only exported attribute is `id`, which is the thumbprint of the ESXi
+host.

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -34,6 +34,9 @@
             <li<%= sidebar_current("docs-vsphere-data-source-host") %>>
               <a href="/docs/providers/vsphere/d/host.html">vsphere_host</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-host-thumbprint") %>>
+              <a href="/docs/providers/vsphere/d/host_thumbprint.html">vsphere_host_thumbprint</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-data-source-network") %>>
               <a href="/docs/providers/vsphere/d/network.html">vsphere_network</a>
             </li>


### PR DESCRIPTION
Needed for adding new hosts when the thumbprint is not known ahead of time.