### PR TITLE
Networking additions [WIP]

### DIFF
--- a/vsphere/distributed_virtual_port_setting_structure.go
+++ b/vsphere/distributed_virtual_port_setting_structure.go
@@ -91,7 +91,7 @@ func schemaVMwareDVSPortSetting() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Optional:    true,
 			Computed:    true,
-			Description: "List of active uplinks used for load balancing, matching the names of the uplinks assigned in the DVS.",
+			Description: "List of standby uplinks used for load balancing, matching the names of the uplinks assigned in the DVS.",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 

--- a/website/docs/r/distributed_virtual_switch.html.markdown
+++ b/website/docs/r/distributed_virtual_switch.html.markdown
@@ -128,9 +128,9 @@ The following arguments are supported:
   if changed.
 * `description` - (Optional) A detailed description for the DVS.
 * `contact_name` - (Optional) The name of the person who is responsible for the
-  DVS. 
+  DVS.
 * `contact_detail` - (Optional) The detailed contact information for the person
-  who is responsible for the DVS. 
+  who is responsible for the DVS.
 * `ipv4_address` - (Optional) An IPv4 address to identify the switch. This is
   mostly useful when used with the [Netflow arguments](#netflow-arguments) found
   below.
@@ -157,13 +157,13 @@ The following arguments are supported:
 ~> **NOTE:** Tagging support requires vCenter 6.0 or higher.
 
 * `custom_attributes` - (Optional) Map of custom attribute ids to attribute
-  value strings to set for virtual switch. See 
-  [here][docs-setting-custom-attributes] for a reference on how to set values 
+  value strings to set for virtual switch. See
+  [here][docs-setting-custom-attributes] for a reference on how to set values
   for custom attributes.
 
 [docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
 
-~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections
 and require vCenter.
 
 ### Uplink arguments
@@ -183,6 +183,19 @@ and require vCenter.
  * `devices` - (Required) The list of NIC devices to map to uplinks on the DVS,
    added in order they are specified.
 
+### Private VLAN mapping arguments
+
+* `ignore_other_pvlan_mappings` - (Optional) Whether to ignore existing PVLAN
+  mappings not managed by this resource. Defaults to false.
+* `pvlan_mapping` - (Optional) Use the `pvlan_mapping` block to declare a
+  private VLAN mapping. The options are:
+ * `primary_vlan_id` - (Required) The primary VLAN ID. The VLAN IDs of 0 and
+   4095 are reserved and cannot be used in this property.
+ * `secondary_vlan_id` - (Required) The secondary VLAN ID. The VLAN IDs of 0
+   and 4095 are reserved and cannot be used in this property.
+ * `pvlan_type` - (Required) The private VLAN type. Valid values are
+   promiscuous, community and isolated.
+
 ### Netflow arguments
 
 The following options control settings that you can use to configure Netflow on
@@ -190,7 +203,7 @@ the DVS:
 
 * `netflow_active_flow_timeout` - (Optional) The number of seconds after which
   active flows are forced to be exported to the collector. Allowed range is
-  `60` to `3600`. Default: `60`. 
+  `60` to `3600`. Default: `60`.
 * `netflow_collector_ip_address` - (Optional) IP address for the Netflow
   collector, using IPv4 or IPv6. IPv6 is supported in vSphere Distributed
   Switch Version 6.0 or later. Must be set before Netflow can be enabled.


### PR DESCRIPTION
### Description

**This is a work in progress**

As set out in #1145, I would like to help improve the functionality of the networking resources in this library. If these are already being worked on or there's a reason why I shouldn't bother with a particular thing, let me know. Equally I'm happy to work with others and would like feedback as this is my first contribution to a Terraform provider.

Specifically:
- PVLAN mappings
- VSPAN (port mirroring) sessions
- Standalone resources so that pvlan mappings and vspan sessions can be configured outside of the main DVS resource. This would be similar to the AWS provider's route_table/route and security_group/security_group_rule. 

Maybes:
- Filter policies
- Support LACP Groups for DVS (might help with #919)
- Network data resources split (as suggested in https://github.com/hashicorp/terraform-provider-vsphere/issues/1143#issuecomment-663842900)
  - vsphere_distributed_port_group
  - vsphere_host_port_group
  - vsphere_opaque_network

### TODO

- [X] PVLAN mapping support on DVS resource
  - [ ] Acceptance tests
- [ ] Standalone PVLAN mapping resource
  - [ ] Acceptance tests
- [ ] VSPAN mapping support on DVS resource
  - [ ] Acceptance tests
- [ ] Standalone VSPAN session resource
  - [ ] Acceptance tests

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
