### PR TITLE
Added the label and unit_number fields to the disk-subresource schema.

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -74,6 +74,10 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"label": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"size": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -84,6 +88,10 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 						},
 						"thin_provisioned": {
 							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"unit_number": {
+							Type:     schema.TypeInt,
 							Computed: true,
 						},
 					},

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1186,9 +1186,16 @@ func ReadDiskAttrsForDataSource(l object.VirtualDeviceList, d *schema.ResourceDa
 		if backing.ThinProvisioned != nil {
 			thin = *backing.ThinProvisioned
 		}
+		if di, ok := disk.DeviceInfo.(*types.Description); ok {
+			m["label"] = di.Label
+		} else {
+			m["label"] = fmt.Sprintf("Disk %d", i)
+		}
+
 		m["size"] = diskCapacityInGiB(disk)
 		m["eagerly_scrub"] = eager
 		m["thin_provisioned"] = thin
+		m["unit_number"] = disk.UnitNumber
 		out = append(out, m)
 	}
 	log.Printf("[DEBUG] ReadDiskAttrsForDataSource: Attributes returned: %+v", out)
@@ -1486,6 +1493,12 @@ func (r *DiskSubresource) DiffExisting() error {
 
 	// Ensure that there is no change in either eagerly_scrub or thin_provisioned
 	// - these values cannot be changed once set.
+	if _, err = r.GetWithVeto("label"); err != nil {
+		return fmt.Errorf("virtual disk %q: %s", name, err)
+	}
+	if _, err = r.GetWithVeto("unit_number"); err != nil {
+		return fmt.Errorf("virtual disk %q: %s", name, err)
+	}
 	if _, err = r.GetWithVeto("eagerly_scrub"); err != nil {
 		return fmt.Errorf("virtual disk %q: %s", name, err)
 	}
@@ -1548,6 +1561,8 @@ func (r *DiskSubresource) DiffGeneral() error {
 		switch {
 		case r.Get("datastore_id").(string) == "":
 			return fmt.Errorf("datastore_id for disk %q is required when attach is set", name)
+		case r.Get("label").(int) > 0:
+			return fmt.Errorf("label for disk %q cannot be defined when attach is set", name)
 		case r.Get("size").(int) > 0:
 			return fmt.Errorf("size for disk %q cannot be defined when attach is set", name)
 		case r.Get("eagerly_scrub").(bool):


### PR DESCRIPTION
### Description
This PR allows the unit_number and label to be computable from the `vsphere_virtual_machine` that the disk is being cloned from. This removes the need to hardcode any of these fields using a variable or any other names as they're now exported by the disk resource's schema. This is useful if your disk naming scheme is actually imposed by the templates that are made available to you (which is how my environment is unfortunately).

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added? (No, but I can totally add them if there's interest in this PR)
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References
None that I know of...