### PR TITLE
Allow performing a linked-clone from a template without requiring snapshots

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -91,9 +91,13 @@ func ValidateVirtualMachineClone(d *schema.ResourceDiff, c *govmomi.Client) erro
 		// to be a single snapshot on the template for it to be eligible.
 		linked := d.Get("clone.0.linked_clone").(bool)
 		if linked {
-			log.Printf("[DEBUG] ValidateVirtualMachineClone: Checking snapshots on %s for linked clone eligibility", tUUID)
-			if err := validateCloneSnapshots(vprops); err != nil {
-				return err
+			if vprops.Config.Template {
+				log.Printf("[DEBUG] ValidateVirtualMachineClone: Virtual machine %s is marked as a template and satisfies linked clone eligibility", tUUID)
+			} else {
+				log.Printf("[DEBUG] ValidateVirtualMachineClone: Checking snapshots on %s for linked clone eligibility", tUUID)
+				if err := validateCloneSnapshots(vprops); err != nil {
+					return err
+				}
 			}
 		}
 		// Check to make sure the disks for this VM/template line up with the disks

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1042,11 +1042,10 @@ The options available in the `clone` block are:
 
 * `template_uuid` - (Required) The UUID of the source virtual machine or
   template.
-* `linked_clone` - (Optional) Clone this virtual machine from a snapshot.
-  Templates must have a single snapshot only in order to be eligible. Default:
-  `false`.
-* `timeout` - (Optional) The timeout, in minutes, to wait for the virtual
-  machine clone to complete. Default: 30 minutes.
+* `linked_clone` - (Optional) Clone this virtual machine from a snapshot or
+  a template. Default: `false`.
+* `timeout` - (Optional) The timeout, in minutes, to wait for the cloning
+  process to complete. Default: 30 minutes.
 * `customize` - (Optional) The customization spec for this clone. This allows
   the user to configure the virtual machine post-clone. For more details, see
   [virtual machine customization](#virtual-machine-customization).


### PR DESCRIPTION
### Description
This PR allows performing a linked clone from a template by using the "moveAllDiskBackingAndAllowSharing" option. When performing a clone, the source virtual machine is checked if it's marked as a template. If so, then it sets the option and proceeds with the clone. If it is not marked as a template, then it will proceed with the original logic which validates that a snapshot exists.

The documentation was updated to remove reference to the snapshot constraint.

### Acceptance tests
There were no tests for the cloning functionality, and so I wasn't sure how to proceed here.

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References
This closes issue #1156.