### PR TITLE
Ignore thin_provisioned and eagerly_scrub during DiskPostCloneOperation

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1036,7 +1036,7 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 			//
 			// TODO: Remove "name" after 2.0.
 			switch k {
-			case "label", "path", "name", "datastore_id", "uuid":
+			case "label", "path", "name", "datastore_id", "uuid", "thin_provisioned", "eagerly_scrub":
 				continue
 			case "io_share_count":
 				if src["io_share_level"] != string(types.SharesLevelCustom) {


### PR DESCRIPTION
### Description
In some environments the disk provisioning type can change silently when cloning due to vSphere storage policies.  Thin provisioning cannot be managed by Terraform and therefore should not attempt to set these value after cloning.

Error message:
```
ERROR                                              
ERROR Error: error reconfiguring virtual machine: error processing disk changes post-clone: disk.0: cannot change the value of "thin_provisioned" - (old: false new: true) 
ERROR                                              
ERROR   on ../../../../../tmp/openshift-install-068412821/master/main.tf line 1, in resource "vsphere_virtual_machine" "vm": 
ERROR    1: resource "vsphere_virtual_machine" "vm" { 
ERROR                                              
```

Attempting to ignore these changes have been unsuccessful using the following:
```
lifecycle {
    ignore_changes = [
      disk.0.eagerly_scrub,
      disk.0.thin_provisioned,
      ]
  }
```

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References
https://github.com/hashicorp/terraform-provider-vsphere/issues/1028
https://github.com/hashicorp/terraform-provider-vsphere/pull/1075
https://github.com/hashicorp/terraform-provider-vsphere/issues/1125

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
