### PR TITLE
Fix vnic import

### DIFF
--- a/vsphere/resource_vsphere_vnic.go
+++ b/vsphere/resource_vsphere_vnic.go
@@ -61,6 +61,7 @@ func resourceVsphereNicRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("mtu", vnic.Spec.Mtu)
 	_ = d.Set("mac", vnic.Spec.Mac)
 
+	// Do we have any ipv4 config ?
 	// IpAddress will be an empty string if ipv4 is off
 	if vnic.Spec.Ip.IpAddress != "" {
 		// if DHCP is true then we should ignore whatever addresses are set here.
@@ -79,6 +80,7 @@ func resourceVsphereNicRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	// Do we have any ipv6 config ?
 	// IpV6Config will be nil if ipv6 is off
 	if vnic.Spec.Ip.IpV6Config != nil {
 		ipv6dict := map[string]interface{}{

--- a/vsphere/resource_vsphere_vnic.go
+++ b/vsphere/resource_vsphere_vnic.go
@@ -54,6 +54,7 @@ func resourceVsphereNicRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	_ = d.Set("netstack", vnic.Spec.NetStackInstanceKey)
 	_ = d.Set("portgroup", vnic.Portgroup)
 	if vnic.Spec.DistributedVirtualPort != nil {
 		_ = d.Set("distributed_switch_port", vnic.Spec.DistributedVirtualPort.SwitchUuid)
@@ -62,8 +63,8 @@ func resourceVsphereNicRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("mtu", vnic.Spec.Mtu)
 	_ = d.Set("mac", vnic.Spec.Mac)
 
-	// Do we have any ipv4 config ?
-	if _, ok := d.GetOk("ipv4"); ok {
+	// IpAddress will be an empty string if ipv4 is off
+	if vnic.Spec.Ip.IpAddress != "" {
 		// if DHCP is true then we should ignore whatever addresses are set here.
 		ipv4dict := make(map[string]interface{})
 		ipv4dict["dhcp"] = vnic.Spec.Ip.Dhcp
@@ -80,8 +81,8 @@ func resourceVsphereNicRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// Do we have any ipv6 config ?
-	if _, ok := d.GetOk("ipv6"); ok {
+	// IpV6Config will be nil if ipv6 is off
+	if vnic.Spec.Ip.IpV6Config != nil {
 		ipv6dict := map[string]interface{}{
 			"dhcp":       *vnic.Spec.Ip.IpV6Config.DhcpV6Enabled,
 			"autoconfig": *vnic.Spec.Ip.IpV6Config.AutoConfigurationEnabled,


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
After importing a `vsphere_vnic`, I noticed couple of things in the subsequent `terraform plan` indicating some sort of 'incomplete' import:

- the `host` field was showing as being added, even though the value for `host` is technically in the `id` used for importing (note that this causes a replacement of the resource which was kind of a show stopper for trying to import the nic)
- the same behavior was observed for both the `netstack` and `ipv4` fields and I suspect it would be the same for `ipv6`, although in my case, the vnic I was importing didn't have any IPv6 settings configured.

Below is an example of the observed behavior :

The `vsphere_vnic` config:

```hcl
resource "vsphere_vnic" "management" {
  host      = "host-4109"
  portgroup = "Management Network"
  netstack  = "defaultTcpipStack"

  ipv4 {
    dhcp    = false
    ip      = "172.20.9.15"
    netmask = "255.255.255.0"
    gw      = "172.20.9.1"
  }
}
```

The `management` vnic I am trying to import here is `vmk0` so the import command I used was:

`terraform import vsphere_vnic.management host-4109_vmk0`

The subsequent `terraform plan` was showing the following:

```
  # vsphere_vnic.management must be replaced
-/+ resource "vsphere_vnic" "management" {
      + host      = "host-4109" # forces replacement
      ~ id        = "host-4109_vmk0" -> (known after apply)
      ~ mac       = "24:6e:96:2c:8b:34" -> (known after apply)
      ~ mtu       = 1500 -> (known after apply)
      + netstack  = "defaultTcpipStack" # forces replacement
        portgroup = "Management Network"

      + ipv4 {
          + dhcp    = false
          + gw      = "172.20.9.1"
          + ip      = "172.20.9.15"
          + netmask = "255.255.255.0"
        }
    }
```

The `ipv4` settings that are shown as "added" shouldn't be there, the vnic already has those settings.

This MR is an attempt at fixing this behavior. I have done this in two ways:

1. Modify the 'read' function to set the `netstack`, `ipv4` and `ipv6` values from the `vnic.Spec` returned by the vSphere Client.
2. Change the `Importer` from the standard `ImportStatePassthrough` to a custom func which handles setting the `host` field.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)
