### PR TITLE
Add type to content library item data source

### DIFF
--- a/vsphere/data_source_vsphere_content_library_item.go
+++ b/vsphere/data_source_vsphere_content_library_item.go
@@ -20,7 +20,13 @@ func dataSourceVSphereContentLibraryItem() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "ID of the content library to contain item",
+				Description: "ID of the content library to contain item.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Type of content library item.",
 			},
 		},
 	}
@@ -33,6 +39,7 @@ func dataSourceVSphereContentLibraryItemRead(d *schema.ResourceData, meta interf
 	if err != nil {
 		return provider.ProviderError(d.Get("name").(string), "dataSourceVSphereContentLibraryItemRead", err)
 	}
+	d.Set("type", item.Type)
 	d.SetId(item.ID)
 	return nil
 }

--- a/website/docs/d/content_library_item.html.markdown
+++ b/website/docs/d/content_library_item.html.markdown
@@ -37,6 +37,5 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-The only attribute this resource exports is the `id` of the resource, which is
-a combination of the [managed object reference ID][docs-about-morefs] of the
-cluster, and the name of the virtual machine group.
+* `id` - The UUID of the Content Library item.
+* `type` - The Content Library type. Can be ovf, iso, or vm-template.

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -16,6 +16,12 @@
             <li<%= sidebar_current("docs-vsphere-data-source-compute-cluster.html") %>>
               <a href="/docs/providers/vsphere/d/compute_cluster.html">vsphere_compute_cluster</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-content-library.html") %>>
+              <a href="/docs/providers/vsphere/d/compute_cluster.html">vsphere_content_library</a>
+            </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-content-library-item.html") %>>
+              <a href="/docs/providers/vsphere/d/compute_cluster.html">vsphere_content_library_item</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-data-source-custom-attribute") %>>
               <a href="/docs/providers/vsphere/d/custom_attribute.html">vsphere_custom_attribute</a>
             </li>


### PR DESCRIPTION
Adding `type` to `content_library_item` so that different logic can be used based on the `type`.

Based on #1183. Will be size/S when that is merged.

#1126