### PR TITLE
Make storage_policy_id computed.

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -219,6 +219,7 @@ func DiskSubresourceSchema() map[string]*schema.Schema {
 		"storage_policy_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 			Description: "The ID of the storage policy to assign to the virtual disk in VM.",
 		},
 		"controller_type": {

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -323,6 +323,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"storage_policy_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 			Description: "The ID of the storage policy to assign to the virtual machine home directory.",
 		},
 		"hardware_version": {


### PR DESCRIPTION
Now that `storage_policy_id` is managed by Terraform, datastores with default storage policies will result in the provider trying to continually change it, even if no policy is specified.

Fixes #995