### PR TITLE
Set SCSI controller type to unknown when nil

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -724,7 +724,7 @@ func ReadSCSIBusSharing(l object.VirtualDeviceList, count int) string {
 		}
 	}
 	log.Printf("[DEBUG] ReadSCSIBusSharing: SCSI controller layout for first %d controllers: %s", count, scsiControllerListString(ctlrs))
-	if len(ctlrs) == 0 {
+	if len(ctlrs) == 0 || ctlrs[0] == nil {
 		return subresourceControllerSharingUnknown
 	}
 	last := ctlrs[0].(types.BaseVirtualSCSIController).GetVirtualSCSIController().SharedBus


### PR DESCRIPTION
There can be fewer controllers than expected when deploying from content library or ovf. Setting the controller type to unknown will block further use without crashing.