### PR TITLE
r/host_port_group: Add support for importing

### DIFF
--- a/vsphere/host_port_group_structure.go
+++ b/vsphere/host_port_group_structure.go
@@ -58,6 +58,7 @@ func expandHostPortGroupSpec(d *schema.ResourceData) *types.HostPortGroupSpec {
 // the passed in ResourceData.
 func flattenHostPortGroupSpec(d *schema.ResourceData, obj *types.HostPortGroupSpec) error {
 	d.Set("vlan_id", obj.VlanId)
+	d.Set("virtual_switch_name", obj.VswitchName)
 	if err := flattenHostNetworkPolicy(d, &obj.Policy); err != nil {
 		return err
 	}

--- a/vsphere/resource_vsphere_host_port_group.go
+++ b/vsphere/resource_vsphere_host_port_group.go
@@ -48,6 +48,9 @@ func resourceVSphereHostPortGroup() *schema.Resource {
 		Read:   resourceVSphereHostPortGroupRead,
 		Update: resourceVSphereHostPortGroupUpdate,
 		Delete: resourceVSphereHostPortGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceVSphereHostPortGroupImport,
+		},
 		Schema: s,
 	}
 }
@@ -146,4 +149,20 @@ func resourceVSphereHostPortGroupDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
+}
+
+func resourceVSphereHostPortGroupImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	hsID, name, err := portGroupIDsFromResourceID(d)
+
+	err = d.Set("host_system_id", hsID)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = d.Set("name", name)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -130,3 +130,16 @@ The following attributes are exported:
   explaining the effective policy for this port group.
 * `key` - The key for this port group as returned from the vSphere API.
 * `ports` - A list of ports that currently exist and are used on this port group.
+
+## Importing 
+
+An existing host port group can be [imported][docs-import] into this resource
+using the host port group's ID. An example is below:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import vsphere_host_port_group.management tf-HostPortGroup:host-123:Management
+```
+
+The above would import the `Management` host port group from host with ID `host-123`.

--- a/website/docs/r/vnic.html.markdown
+++ b/website/docs/r/vnic.html.markdown
@@ -134,4 +134,4 @@ via supplying the vNic's ID. An example is below:
 terraform import vsphere_vnic.v1 host-123_vmk2
 ```
 
-The above would import the the vnic `vmk2` from host with ID `host-123`.
+The above would import the vnic `vmk2` from host with ID `host-123`.


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Adds support for importing `vsphere_host_port_group`.

**Bonus**: Fix typo in the `vnic` import documentation.

#### TODO
- [x] Update docs

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/host_port_group`: Add support for importing host port group.
```