### PR TITLE
r/datastore_cluster: Fix missing field in import

### DIFF
--- a/vsphere/internal/helper/datacenter/datacenter_helper.go
+++ b/vsphere/internal/helper/datacenter/datacenter_helper.go
@@ -3,6 +3,7 @@ package datacenter
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
@@ -16,4 +17,18 @@ func FromPath(client *govmomi.Client, path string) (*object.Datacenter, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
 	defer cancel()
 	return finder.Datacenter(ctx, path)
+}
+
+// DatacenterFromInventoryPath returns the Datacenter object which is part of a given InventoryPath
+func DatacenterFromInventoryPath(client *govmomi.Client, inventoryPath string) (*object.Datacenter, error) {
+	dcPath, err := folder.RootPathParticleDatastore.SplitDatacenter(inventoryPath)
+	if err != nil {
+		return nil, err
+	}
+	dc, err := FromPath(client, dcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return dc, nil
 }

--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure"
@@ -302,7 +303,14 @@ func resourceVSphereDatastoreClusterImport(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return nil, fmt.Errorf("error loading datastore cluster: %s", err)
 	}
+	client := meta.(*VSphereClient).vimClient
+	dc, err := datacenter.DatacenterFromInventoryPath(client, pod.InventoryPath)
+	if err != nil {
+		return nil, fmt.Errorf("error getting datacenter of datastore cluster: %s", err)
+	}
+
 	d.SetId(pod.Reference().Value)
+	d.Set("datacenter_id", dc.Reference().Value)
 	return []*schema.ResourceData{d}, nil
 }
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

After importing a `vsphere_datastore_cluster`, the subsequent `terraform plan` showed the imported resource marked for 'replacement'. This was because one of the required fields `datacenter_id` was not being set as part of the `import`. Below is an example of this issue:

`vsphere_datastore_cluster` resource config:

```terraform
resource "vsphere_datastore_cluster" "ds_cluster1" {
  name                  = "datastore-cluster1"
  datacenter_id         = "datacenter-2"
  sdrs_enabled          = true
  sdrs_automation_level = "manual"

  sdrs_space_utilization_threshold       = 85
  sdrs_free_space_utilization_difference = 30

  sdrs_advanced_options = {
    "IgnoreAffinityRulesForMaintenance" = "1"
  }

  # Override default settings
  sdrs_io_load_balance_enabled = false
}
```

After `import`ing the resource, the subsequent `plan` showed the following:

```
  # vsphere_datastore_cluster.ds_cluster1 must be replaced
-/+ resource "vsphere_datastore_cluster" "ds_cluster1" {                                                                     
      - custom_attributes                      = {} -> null
      + datacenter_id                          = "datacenter-2" # forces replacement
      ~ id                                     = "group-p118" -> (known after apply)
        name                                   = "datastore-cluster1"
        sdrs_advanced_options                  = {
            "IgnoreAffinityRulesForMaintenance" = "1"
        }                                                                                                                    
        sdrs_automation_level                  = "manual"
        sdrs_default_intra_vm_affinity         = true
        sdrs_enabled                           = true
      + sdrs_free_space_threshold              = 50
        sdrs_free_space_threshold_mode         = "utilization"
        sdrs_free_space_utilization_difference = 30
        sdrs_io_latency_threshold              = 15
        sdrs_io_load_balance_enabled           = false       
      ~ sdrs_io_load_imbalance_threshold       = 75 -> 5      
        sdrs_io_reservable_percent_threshold   = 60
        sdrs_io_reservable_threshold_mode      = "automated"
        sdrs_load_balance_interval             = 480                                                                         
        sdrs_space_utilization_threshold       = 85                                                                          
      - tags                                   = [] -> null
    }
```
The important part here is the `datacenter_id` field being shown as added even though this information should be available during the `import`. This leads to the resource being marked for replacement.

This MR addresses this by setting the `datacenter_id` field to the correct value which is derived from the datacenter name in the import path.

This fix is similar to https://github.com/hashicorp/terraform-provider-vsphere/pull/1162.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

**Note:** Haven't run the acceptance testing but did test the fix manually.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/datastore_cluster`: Fix missing fields on datastore cluster import.
```