### PR TITLE
Import ditributed port group using moid

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ To contribute, please read the [contribution guidelines](_about/CONTRIBUTING.md)
 Also available are some answers to [Frequently Asked Questions](_about/FAQ.md).
 
 
+

--- a/README.md
+++ b/README.md
@@ -47,4 +47,3 @@ To contribute, please read the [contribution guidelines](_about/CONTRIBUTING.md)
 Also available are some answers to [Frequently Asked Questions](_about/FAQ.md).
 
 
-

--- a/vsphere/resource_vsphere_distributed_port_group.go
+++ b/vsphere/resource_vsphere_distributed_port_group.go
@@ -226,8 +226,8 @@ func resourceVSphereDistributedPortGroupImport(d *schema.ResourceData, meta inte
 	if err := viapi.ValidateVirtualCenter(client); err != nil {
 		return nil, err
 	}
-	p := d.Id()
-	pg, err := dvportgroup.FromPath(client, p, nil)
+	moId := d.Id()
+	pg, err := dvportgroup.FromMOID(client, moId)
 	if err != nil {
 		return nil, fmt.Errorf("error locating portgroup: %s", err)
 	}

--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -235,14 +235,13 @@ ID][docs-about-morefs] to another resource, be sure to use the `id` field.
 
 ## Importing
 
-An existing port group can be [imported][docs-import] into this resource via
-the path to the port group, via the following command:
+An existing port group can be [imported][docs-import] into this resource using
+the managed object id of the port group, via the following command:
 
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 ```
-terraform import vsphere_distributed_port_group.pg /dc1/network/pg
+terraform import vsphere_distributed_port_group.pg dvportgroup-67
 ```
 
-The above would import the port group named `pg` that is located in the `dc1`
-datacenter.
+The above would import the port group named `pg` with managed object id `dvportgroup-67`.


### PR DESCRIPTION
### Description

Import distributed port group using Managed object ID.
The import function for distributed port groups takes the path as argument, but there could exist
two port groups with same name and same path which creates ambiguity.
This is to fix the import function using Moid which is unique.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?



### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Changing import function for distributed port group resource using managed object Id instead of path as argument.
...
```
