### PR TITLE
Fixing port group resource to enable LACP only in virtual switch, not in port group.

### DIFF
--- a/vsphere/distributed_port_group_structure.go
+++ b/vsphere/distributed_port_group_structure.go
@@ -165,7 +165,7 @@ func expandDVPortgroupConfigSpec(d *schema.ResourceData) types.DVPortgroupConfig
 		Name:                         d.Get("name").(string),
 		NumPorts:                     int32(d.Get("number_of_ports").(int)),
 		PortNameFormat:               d.Get("port_name_format").(string),
-		DefaultPortConfig:            expandVMwareDVSPortSetting(d),
+		DefaultPortConfig:            expandVMwareDVSPortSetting(d, "distributed_port_group"),
 		Description:                  d.Get("description").(string),
 		Type:                         d.Get("type").(string),
 		Policy:                       expandVMwareDVSPortgroupPolicy(d),

--- a/vsphere/distributed_virtual_port_setting_structure.go
+++ b/vsphere/distributed_virtual_port_setting_structure.go
@@ -556,7 +556,11 @@ func flattenDVSTrafficShapingPolicyEgress(d *schema.ResourceData, obj *types.DVS
 
 // expandVMwareDVSPortSetting reads certain ResourceData keys and
 // returns a VMwareDVSPortSetting.
-func expandVMwareDVSPortSetting(d *schema.ResourceData) *types.VMwareDVSPortSetting {
+func expandVMwareDVSPortSetting(d *schema.ResourceData, resourceType string) *types.VMwareDVSPortSetting {
+	var lacpPolicy *types.VMwareUplinkLacpPolicy = nil
+	if resourceType == "distributed_virtual_switch" {
+		lacpPolicy = expandVMwareUplinkLacpPolicy(d)
+	}
 	obj := &types.VMwareDVSPortSetting{
 		DVPortSetting: types.DVPortSetting{
 			Blocked:                 structure.GetBoolPolicy(d, "block_all_ports"),
@@ -569,7 +573,7 @@ func expandVMwareDVSPortSetting(d *schema.ResourceData) *types.VMwareDVSPortSett
 		SecurityPolicy:      expandDVSSecurityPolicy(d),
 		IpfixEnabled:        structure.GetBoolPolicy(d, "netflow_enabled"),
 		TxUplink:            structure.GetBoolPolicy(d, "tx_uplink"),
-		LacpPolicy:          expandVMwareUplinkLacpPolicy(d),
+		LacpPolicy:          lacpPolicy,
 	}
 
 	if structure.AllFieldsEmpty(obj) {

--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -537,7 +537,7 @@ func expandVMwareDVSConfigSpec(d *schema.ResourceData) *types.VMwareDVSConfigSpe
 		DVSConfigSpec: types.DVSConfigSpec{
 			Name:                                d.Get("name").(string),
 			ConfigVersion:                       d.Get("config_version").(string),
-			DefaultPortConfig:                   expandVMwareDVSPortSetting(d),
+			DefaultPortConfig:                   expandVMwareDVSPortSetting(d, "distributed_virtual_switch"),
 			Host:                                expandSliceOfDistributedVirtualSwitchHostMemberConfigSpec(d),
 			Description:                         d.Get("description").(string),
 			Contact:                             expandDVSContactInfo(d),


### PR DESCRIPTION
### Description
LACP policy setting is allowed only at the virtual switch level and not in the port level.
Fixing the code so that the lacp changes are done only for virtual switch resource.


```release-note
Fixing distributed port group resource so that lacp change are done only for virtual switch and not for port group.
```
### References

<!---
https://github.com/hashicorp/terraform-provider-vsphere/issues/919
--->
