### PR TITLE
add deployment ovf option

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
@@ -36,6 +36,12 @@ func VirtualMachineOvfDeploySchema() map[string]*schema.Schema {
 			Description: "An optional disk provisioning. If set, all the disks in the deployed ovf will have the same specified disk type (e.g., thin provisioned).",
 			ForceNew:    true,
 		},
+		"deployment": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "A specifc OVA deployment to use if multiple are available.",
+			ForceNew:    true,
+		},
 		"ovf_network_map": {
 			Type:        schema.TypeMap,
 			Optional:    true,

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1373,6 +1373,8 @@ The options available in the `ovf_deploy` block are:
    VI infrastructure.
 * `allow_unverified_ssl_cert` - (Optional) Allow unverified ssl certificates while deploying ovf/ova from url.
    Defaults true.   
+* `deployment` - (Optional) If the ova/ovf specifies multiple deployment options, specifying one will select it to be
+   used instead of the default deployment option specified in the ova/ovf.
 
 ### Using vApp properties to supply OVF/OVA configuration
 


### PR DESCRIPTION
### Description

This allows for the selection of a deployment size for OVA/OVFs that contain it such as vCenter Server Appliance and NSX-T Universal Appliance.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
```

I have not had much luck getting tests to run in my home lab.  Additionally, I have yet to find a freely available OVA that contains a deployment to use for a new test.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/virtual_machine: Add selecting deployment size for OVA/OVF deployment (#1209)
```
### References

#1209
