### PR TITLE
Fix ova deploy and tests

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -80,6 +80,7 @@ func DiskSubresourceSchema() map[string]*schema.Schema {
 		"datastore_id": {
 			Type:          schema.TypeString,
 			Optional:      true,
+			Computed:      true,
 			ConflictsWith: []string{"datastore_cluster_id"},
 			Description:   "The datastore ID for this virtual disk, if different than the virtual machine.",
 		},

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1690,7 +1690,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 			return fmt.Errorf(formatVirtualMachineCustomizationWaitError, vm.InventoryPath, err)
 		}
 	}
-	return nil
+	return resourceVSphereVirtualMachineRead(d, meta)
 }
 
 // resourceVSphereVirtualMachineCreateCloneWithSDRS runs the clone part of

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -7178,11 +7178,17 @@ resource "vsphere_virtual_machine" "vm" {
   datacenter_id              = data.vsphere_datacenter.rootdc1.id
   host_system_id             = data.vsphere_host.roothost1.id
   wait_for_guest_net_timeout = 0
-  wait_for_guest_ip_timeout  = 1
+  wait_for_guest_ip_timeout  = 0
   num_cpus                   = 2
   ovf_deploy {
     remote_ovf_url = "%s"
   }
+	disk{
+		size           = 40
+		unit_number    = 0
+		label          = "disk0"
+		io_share_count = 1000
+	}
   cdrom {
     client_device = true
   }


### PR DESCRIPTION
Alloow `datastore_id` to be computed since it is not required for ovf deployment, and then run VM read at the end of creation.