### PR TITLE
Fixed a typo in the docs

### DIFF
--- a/website/docs/d/dynamic.html.markdown
+++ b/website/docs/d/dynamic.html.markdown
@@ -18,7 +18,7 @@ The `vsphere_dynamic` data source can be used to get the [managed object
 ## Example Usage
 
 ```hcl
-data "vsphere_tag_cetegory" "cat" {
+data "vsphere_tag_category" "cat" {
   name = "SomeCategory"
 }
 


### PR DESCRIPTION
### Description

There was a typo, and now there is none.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
