### PR TITLE
Support for no disks in config

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1690,7 +1690,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 			return fmt.Errorf(formatVirtualMachineCustomizationWaitError, vm.InventoryPath, err)
 		}
 	}
-	return resourceVSphereVirtualMachineRead(d, meta)
+	return nil
 }
 
 // resourceVSphereVirtualMachineCreateCloneWithSDRS runs the clone part of


### PR DESCRIPTION
When no disks are specified in the config, they should be added after deploying an ova.