### PR TITLE
Use Dockerhub Mirror.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2
+
+references:
+  images:
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/circleci/golang:1.13
+
 jobs:
   build:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: ~/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -28,7 +33,7 @@ jobs:
           make build
   linters:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: $GOPATH/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -44,7 +49,7 @@ jobs:
           tfproviderlint -AT00{1..3} -R00{2..4} -S0{{01..12},{14..19}}  ./...
   revert_snapshot:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: $GOPATH/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -65,7 +70,7 @@ jobs:
           $GOPATH/src/github.com/hashicorp/terraform-provider-vsphere/scripts/revert_snapshot.sh
   test_acc_Client:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -93,7 +98,7 @@ jobs:
 
   test_acc_DataSourceVSphereComputeCluster:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -121,7 +126,7 @@ jobs:
 
   test_acc_DataSourceVSphereCustomAttribute:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -149,7 +154,7 @@ jobs:
 
   test_acc_DataSourceVSphereDatacenter:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -177,7 +182,7 @@ jobs:
 
   test_acc_DataSourceVSphereDatastore:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -205,7 +210,7 @@ jobs:
 
   test_acc_DataSourceVSphereDatastoreCluster:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -233,7 +238,7 @@ jobs:
 
   test_acc_DataSourceVSphereDistributedVirtualSwitch:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -261,7 +266,7 @@ jobs:
 
   test_acc_DataSourceVSphereFolder:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -289,7 +294,7 @@ jobs:
 
   test_acc_DataSourceVSphereHost:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -317,7 +322,7 @@ jobs:
 
   test_acc_DataSourceVSphereNetwork:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -345,7 +350,7 @@ jobs:
 
   test_acc_DataSourceVSphereResourcePool:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -373,7 +378,7 @@ jobs:
 
   test_acc_DataSourceVSphereTag:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -401,7 +406,7 @@ jobs:
 
   test_acc_DataSourceVSphereTagCategory:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -429,7 +434,7 @@ jobs:
 
   test_acc_DataSourceVSphereVAppContainer:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -457,7 +462,7 @@ jobs:
 
   test_acc_DataSourceVSphereVirtualMachine:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -485,7 +490,7 @@ jobs:
 
   test_acc_DataSourceVSphereVmfsDisks:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -513,7 +518,7 @@ jobs:
 
   test_acc_ResourceVSphereComputeCluster:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -541,7 +546,7 @@ jobs:
 
   test_acc_ResourceVSphereComputeClusterHostGroup:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -569,7 +574,7 @@ jobs:
 
   test_acc_ResourceVSphereComputeClusterVMAffinityRule:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -597,7 +602,7 @@ jobs:
 
   test_acc_ResourceVSphereComputeClusterVMAntiAffinityRule:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -625,7 +630,7 @@ jobs:
 
   test_acc_ResourceVSphereComputeClusterVMDependencyRule:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -653,7 +658,7 @@ jobs:
 
   test_acc_ResourceVSphereComputeClusterVMGroup:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -681,7 +686,7 @@ jobs:
 
   test_acc_ResourceVSphereComputeClusterVMHostRule:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -709,7 +714,7 @@ jobs:
 
   test_acc_ResourceVSphereCustomAttribute:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -737,7 +742,7 @@ jobs:
 
   test_acc_ResourceVSphereDatacenter:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -765,7 +770,7 @@ jobs:
 
   test_acc_ResourceVSphereDatastoreCluster:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -793,7 +798,7 @@ jobs:
 
   test_acc_ResourceVSphereDatastoreClusterVMAntiAffinityRule:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -821,7 +826,7 @@ jobs:
 
   test_acc_ResourceVSphereDistributedPortGroup:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -849,7 +854,7 @@ jobs:
 
   test_acc_ResourceVSphereDistributedVirtualSwitch:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -877,7 +882,7 @@ jobs:
 
   test_acc_ResourceVSphereDPMHostOverride:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -905,7 +910,7 @@ jobs:
 
   test_acc_ResourceVSphereDRSVMOverride:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -933,7 +938,7 @@ jobs:
 
   test_acc_ResourceVSphereFile:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -961,7 +966,7 @@ jobs:
 
   test_acc_ResourceVSphereFolder:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -989,7 +994,7 @@ jobs:
 
   test_acc_ResourceVSphereHAVMOverride:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1017,7 +1022,7 @@ jobs:
 
   test_acc_ResourceVSphereHost:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1045,7 +1050,7 @@ jobs:
 
   test_acc_ResourceVSphereHostPortGroup:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1073,7 +1078,7 @@ jobs:
 
   test_acc_ResourceVSphereHostVirtualSwitch:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1101,7 +1106,7 @@ jobs:
 
   test_acc_ResourceVSphereLicense:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1129,7 +1134,7 @@ jobs:
 
   test_acc_ResourceVSphereNasDatastore:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1157,7 +1162,7 @@ jobs:
 
   test_acc_ResourceVSphereResourcePool:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1185,7 +1190,7 @@ jobs:
 
   test_acc_ResourceVSphereStorageDrsVMOverride:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1213,7 +1218,7 @@ jobs:
 
   test_acc_ResourceVSphereTag:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1241,7 +1246,7 @@ jobs:
 
   test_acc_ResourceVSphereTagCategory:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1269,7 +1274,7 @@ jobs:
 
   test_acc_ResourceVSphereVAppContainer:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1297,7 +1302,7 @@ jobs:
 
   test_acc_ResourceVSphereVAppEntity:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1325,7 +1330,7 @@ jobs:
 
   test_acc_ResourceVSphereVirtualDisk:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1353,7 +1358,7 @@ jobs:
 
   test_acc_ResourceVSphereVirtualMachine:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1381,7 +1386,7 @@ jobs:
 
   test_acc_ResourceVSphereVirtualMachineSnapshot:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout
@@ -1409,7 +1414,7 @@ jobs:
 
   test_acc_ResourceVSphereVmfsDatastore:
     docker:
-    - image: circleci/golang:1.13
+    - image: *GOLANG_IMAGE
     working_directory: /home/circleci/src/github.com/hashicorp/terraform-provider-vsphere
     steps:
     - checkout


### PR DESCRIPTION
### Description

Dockerhub is going to rate limit unauthenticated pulls.

Use internal mirror for CI and Dockerfiles built in CI.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
