### PR TITLE
Make API timeout configurable when building VMs

### DIFF
--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -493,9 +493,10 @@ func blockUntilReadyForMethod(method string, vm *object.VirtualMachine, ctx cont
 
 // Create wraps the creation of a virtual machine and the subsequent waiting of
 // the task. A higher-level virtual machine object is returned.
-func Create(c *govmomi.Client, f *object.Folder, s types.VirtualMachineConfigSpec, p *object.ResourcePool, h *object.HostSystem) (*object.VirtualMachine, error) {
+func Create(c *govmomi.Client, f *object.Folder, s types.VirtualMachineConfigSpec, p *object.ResourcePool,
+	h *object.HostSystem, timeout time.Duration) (*object.VirtualMachine, error) {
 	log.Printf("[DEBUG] Creating virtual machine %q", fmt.Sprintf("%s/%s", f.InventoryPath, s.Name))
-	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	var task *object.Task
 	// Check to see if the resource pool is a vApp
@@ -511,7 +512,7 @@ func Create(c *govmomi.Client, f *object.Folder, s types.VirtualMachineConfigSpe
 	if err != nil {
 		return nil, err
 	}
-	tctx, tcancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	tctx, tcancel := context.WithTimeout(context.Background(), timeout)
 	defer tcancel()
 	result, err := task.WaitForResult(tctx, nil)
 	if err != nil {

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -91,6 +91,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_VIM_KEEP_ALIVE", 10),
 				Description: "Keep alive interval for the VIM session in minutes",
 			},
+			"api_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_API_TIMEOUT", 5),
+				Description: "API timeout in minutes (Default: 5)",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1278,7 +1278,8 @@ func resourceVSphereVirtualMachineCreateBareWithSDRS(
 		return nil, fmt.Errorf("error getting datastore cluster: %s", err)
 	}
 
-	vm, err := storagepod.CreateVM(client, fo, spec, pool, hs, pod)
+	timeout := meta.(*VSphereClient).timeout
+	vm, err := storagepod.CreateVM(client, fo, spec, pool, hs, pod, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("error creating virtual machine on datastore cluster %q: %s", pod.Name(), err)
 	}
@@ -1307,7 +1308,8 @@ func resourceVSphereVirtualMachineCreateBareStandard(
 		VmPathName: fmt.Sprintf("[%s]", ds.Name()),
 	}
 
-	vm, err := virtualmachine.Create(client, fo, spec, pool, hs)
+	timeout := meta.(*VSphereClient).timeout
+	vm, err := virtualmachine.Create(client, fo, spec, pool, hs, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("error creating virtual machine: %s", err)
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -115,6 +115,9 @@ The following arguments are used to configure the VMware vSphere Provider:
   10 minutes to ensure that operations that take a longer than 30 minutes
   without API interaction do not result in a session timeout. Can also be
   specified with the `VSPHERE_VIM_KEEP_ALIVE` environment variable.
+* `api_timeout` - (Optional) Sets the number of minutes to wait for operations
+  to complete. The default timeout is 5 minutes. Currently it will override
+  the timeout for all VM creation operations.
 
 ### Session persistence options
 


### PR DESCRIPTION

    Sometimes creating new VMs can take a while, especially when building
    bare VMs that have their OS provisioned by an external system. If that
    takes more than 5 minutes then the VM creation fails with a timeout.

    For this reason we are adding an `api_timeout` parameter in the
    provider's configuration schema that will allow users to override that
    timeout. The default value remains five (5) minutes.