### PR TITLE
Enabling VBS (vbsEnabled) and I/O MMU (vvtdEnabled)

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -889,6 +889,18 @@ func resourceVSphereVirtualMachineCustomizeDiff(_ context.Context, d *schema.Res
 		}
 	}
 
+	if d.Get("vbs_enabled").(bool) {
+		if version.Older(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 7}) {
+			return fmt.Errorf("vbs_enabled is only supported on vSphere 6.7 and higher")
+		}
+	}
+
+	if d.Get("vvtd_enabled").(bool) {
+		if version.Older(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 7}) {
+			return fmt.Errorf("vvtd_enabled is only supported on vSphere 6.7 and higher")
+		}
+	}
+
 	// Validate cdrom sub-resources when not deploying from ovf
 	if len(d.Get("ovf_deploy").([]interface{})) == 0 {
 		if err := virtualdevice.CdromDiffOperation(d, client); err != nil {

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -114,7 +114,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"vvtd_enabled": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "Flag to specify if Intel Virtualization Technology for Directed I/O is enabled for this virtual machine",
+			Description: "Flag to specify if I/O MMU virtualization, also called Intel Virtualization Technology for Directed I/O (VT-d) and AMD I/O Virtualization (AMD-Vi or IOMMU), is enabled.",
 		},
 		"hv_mode": {
 			Type:         schema.TypeString,
@@ -372,8 +372,8 @@ func flattenVirtualMachineBootOptions(d *schema.ResourceData, obj *types.Virtual
 func expandVirtualMachineFlagInfo(d *schema.ResourceData) *types.VirtualMachineFlagInfo {
 	obj := &types.VirtualMachineFlagInfo{
 		DiskUuidEnabled:  getBoolWithRestart(d, "enable_disk_uuid"),
-		VbsEnabled:  getBoolWithRestart(d, "vbs_enabled"),
-		VvtdEnabled:  getBoolWithRestart(d, "vvtd_enabled"),
+		VbsEnabled:       getBoolWithRestart(d, "vbs_enabled"),
+		VvtdEnabled:      getBoolWithRestart(d, "vvtd_enabled"),
 		VirtualExecUsage: getWithRestart(d, "hv_mode").(string),
 		VirtualMmuUsage:  getWithRestart(d, "ept_rvi_mode").(string),
 		EnableLogging:    getBoolWithRestart(d, "enable_logging"),

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -106,6 +106,16 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Expose the UUIDs of attached virtual disks to the virtual machine, allowing access to them in the guest.",
 		},
+		"vbs_enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Flag to specify if Virtualization-based security is enabled for this virtual machine.",
+		},
+		"vvtd_enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Flag to specify if Intel Virtualization Technology for Directed I/O is enabled for this virtual machine",
+		},
 		"hv_mode": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -362,6 +372,8 @@ func flattenVirtualMachineBootOptions(d *schema.ResourceData, obj *types.Virtual
 func expandVirtualMachineFlagInfo(d *schema.ResourceData) *types.VirtualMachineFlagInfo {
 	obj := &types.VirtualMachineFlagInfo{
 		DiskUuidEnabled:  getBoolWithRestart(d, "enable_disk_uuid"),
+		VbsEnabled:  getBoolWithRestart(d, "vbs_enabled"),
+		VvtdEnabled:  getBoolWithRestart(d, "vvtd_enabled"),
 		VirtualExecUsage: getWithRestart(d, "hv_mode").(string),
 		VirtualMmuUsage:  getWithRestart(d, "ept_rvi_mode").(string),
 		EnableLogging:    getBoolWithRestart(d, "enable_logging"),
@@ -373,6 +385,8 @@ func expandVirtualMachineFlagInfo(d *schema.ResourceData) *types.VirtualMachineF
 // VirtualMachineFlagInfo into the passed in ResourceData.
 func flattenVirtualMachineFlagInfo(d *schema.ResourceData, obj *types.VirtualMachineFlagInfo) error {
 	d.Set("enable_disk_uuid", obj.DiskUuidEnabled)
+	d.Set("vbs_enabled", obj.VbsEnabled)
+	d.Set("vvtd_enabled", obj.VvtdEnabled)
 	d.Set("hv_mode", obj.VirtualExecUsage)
 	d.Set("ept_rvi_mode", obj.VirtualMmuUsage)
 	d.Set("enable_logging", obj.EnableLogging)

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -772,6 +772,13 @@ behavior.
 
 * `enable_disk_uuid` - (Optional) Expose the UUIDs of attached virtual disks to
   the virtual machine, allowing access to them in the guest. Default: `false`.
+* `vbs_enabled` - (Optional) Enable Virtualization Based Security. Requires
+  `firmware` to be `efi`, and `vvtd_enabled`, `nested_hv_enabled` and
+  `efi_secure_boot_enabled` must all have a value of `true`. Supported on
+  vSphere 6.7 and higher. Default: `false`.
+* `vvtd_enabled` - (Optional) Flag to specify if Intel Virtualization Technology 
+  for Directed I/O is enabled for this virtual machine (_I/O MMU_ in the
+  vSphere Client). Supported on vSphere 6.7 and higher. Default: `false`.
 * `hv_mode` - (Optional) The (non-nested) hardware virtualization setting for
   this virtual machine. Can be one of `hvAuto`, `hvOn`, or `hvOff`. Default:
   `hvAuto`.


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Virtualization Based Security (VBS) is an option for Windows VMs that enables a security feature that is part of any security baseline for Windows (DoD/DISA, CISecurity, Microsoft). VBS is in turn contingent on another unsupported (by the provider) option, I/O MMU. 

In this PR, VBS and I/O MMU are implemented as 
```hcl
resource "vsphere_virtual_machine" "cloned_virtual_machine" {
  ...
  vvtd_enabled = true
  vbs_enabled = true
  ...
}
```
They target the api-flags _vvtdEnabled_ (I/O MMU) and _vbsEnabled_ (VBS) respectively.

The [VMware vSphere API reference's documentation of the Data Object VirtualMachineFlagInfo(vim.vm.FlagInfo)](https://vdc-download.vmware.com/vmwb-repository/dcr-public/3325c370-b58c-4799-99ff-58ae3baac1bd/45789cc5-aba1-48bc-a320-5e35142b50af/doc/vim.vm.FlagInfo.html) states about _vbsEnabled_ that: 

"Flag to specify if Virtualization-based security is enabled for this virtual machine. If set to true when creating a new VM, the following VM properties might be modified automatically: - If vim.vm.FlagInfo.vvtdEnabled is not set to false, it is set to true. Else error is returned. - If vim.vm.ConfigSpec.nestedHVEnabled is not set to false, it is set to true. Else error is returned. - If vim.vm.BootOptions.efiSecureBootEnabled is not set to false, it is set to true. Else error is returned. - If vim.vm.firmware is not set to bios, it is set to efi. Else error is returned"

Notable is the formulation _the following VM properties might be modified automatically_ with an emphasis on _might_. 

At first I implemented `vbs_enabled` alone, believing that _if_ the api-option vbsEnabled is switched to `true`, that will alter the dependency options _I/O MMU_ (`vvtd_enabled`), _Secure Boot_(`efi_secure_boot_enabled`), and _Hardware Virtualization passthru_ (`nested_hv_enabled`) - setting those options automatically to `true`. That is not the case, however.  Setting the vbsEnabled alone seemed to work with the provider, and probably the flag is set - however, it has no effect, since I/O MMU (`vvtd_enabled`) is still unset, or probably `false`. This may be a deficiancy with the api? 

Anyway, if  the provider should be responsible for this logic, i.e. setting the contingent properties to the correct values, then more code will have to be added for that.  

Also, I understand that vSphere 6.5 (and ESXi 6.5) is used for testing the provider? That will of course not work with these options, other than verifying that the provider correctly throws an error stating that `vbs_enabled` and `vvtd_enabled` is only supported on vSphere 6.7 and higher. 

Feel free to give advice on how to make a test for this! 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added? 
Working on it. Trying to understand the how tests can be written. 
- [ ] Have you run the acceptance tests on this branch? 
Working on it. Trying to understand the how tests can be written

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Virtualization Based Security and I/O MMU enabled by vbs_enabled and vvtd_enbled in resource "vsphere_virtual_machine"
```
### References
#1288
#677
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
