### PR TITLE
Adding deployment option while deploying ovf/ova

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
@@ -36,6 +36,12 @@ func VirtualMachineOvfDeploySchema() map[string]*schema.Schema {
 			Description: "An optional disk provisioning. If set, all the disks in the deployed ovf will have the same specified disk type (e.g., thin provisioned).",
 			ForceNew:    true,
 		},
+		"deployment_option": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The Deployment option to be chosen. If empty, the default option is used.",
+			ForceNew:    true,
+		},
 		"ovf_network_map": {
 			Type:        schema.TypeMap,
 			Optional:    true,

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1369,6 +1369,7 @@ The options available in the `ovf_deploy` block are:
 * `ip_protocol` - (Optional) The IP protocol.
 * `disk_provisioning` - (Optional) The disk provisioning. If set, all the disks in the deployed OVF will have 
    the same specified disk type (accepted values {thin, flat, thick, sameAsSource}).
+* `deployment_option` - (Optional) The key of the chosen deployment option. If empty, the default option is chosen.   
 * `ovf_network_map` - (Optional) The mapping of name of network identifiers from the ovf descriptor to network UUID in the 
    VI infrastructure.
 * `allow_unverified_ssl_cert` - (Optional) Allow unverified ssl certificates while deploying ovf/ova from url.


### PR DESCRIPTION
### Description

This allows users to specify any deployment option while deploying an OVA/OVF.
### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added? Yes
- [ ] Have you run the acceptance tests on this branch? No

I have tested the code with NSX-T manager OVA.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/virtual_machine: Adding deployment option for OVA/OVF deployment (#1209)

```
### References
https://github.com/hashicorp/terraform-provider-vsphere/issues/1209

