### PR TITLE
Sorting permissions object on username/group name before storing.

### DIFF
--- a/vsphere/resource_vsphere_entity_permissions.go
+++ b/vsphere/resource_vsphere_entity_permissions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -119,6 +120,11 @@ func resourceEntityPermissionsRead(d *schema.ResourceData, meta interface{}) err
 		permissionObj["role_id"] = strconv.Itoa(int(permission.RoleId))
 		permissionObjs = append(permissionObjs, permissionObj)
 	}
+
+	sort.Slice(permissionObjs[:], func(i, j int) bool {
+		return strings.ToLower(permissionObjs[i]["user_or_group"].(string)) <
+			strings.ToLower(permissionObjs[j]["user_or_group"].(string))
+	})
 	d.Set("permissions", permissionObjs)
 	return nil
 }

--- a/vsphere/resource_vsphere_entity_permissions.go
+++ b/vsphere/resource_vsphere_entity_permissions.go
@@ -123,7 +123,7 @@ func resourceEntityPermissionsRead(d *schema.ResourceData, meta interface{}) err
 		permissionObjs = append(permissionObjs, permissionObj)
 	}
 
-	sort.Slice(permissionObjs[:], func(i, j int) bool {
+	sort.Slice(permissionObjs, func(i, j int) bool {
 		return strings.ToLower(permissionObjs[i]["user_or_group"].(string)) <
 			strings.ToLower(permissionObjs[j]["user_or_group"].(string))
 	})
@@ -245,11 +245,11 @@ func permissionsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) boo
 		newPermission.(map[string]interface{})["user_or_group"] =
 			strings.ToLower(newPermission.(map[string]interface{})["user_or_group"].(string))
 	}
-	sort.Slice(oldPermissionsArr[:], func(i, j int) bool {
+	sort.Slice(oldPermissionsArr, func(i, j int) bool {
 		return oldPermissionsArr[i].(map[string]interface{})["user_or_group"].(string) <
 			oldPermissionsArr[j].(map[string]interface{})["user_or_group"].(string)
 	})
-	sort.Slice(newPermissionsArr[:], func(i, j int) bool {
+	sort.Slice(newPermissionsArr, func(i, j int) bool {
 		return newPermissionsArr[i].(map[string]interface{})["user_or_group"].(string) <
 			newPermissionsArr[j].(map[string]interface{})["user_or_group"].(string)
 	})

--- a/website/docs/r/vsphere_entity_permissions.html.markdown
+++ b/website/docs/r/vsphere_entity_permissions.html.markdown
@@ -19,7 +19,7 @@ This example creates entity permissions on the virtual machine VM1 for the user 
 consumer and for user group ExternalIDPUsers with role my_terraform_role. The `entity_id` can be the managed object id
 (or uuid for some resources). The `entity_type` is one of the vmware managed object types which can be found from the 
 managed object types section in [vmware_api_7](https://code.vmware.com/apis/968/vsphere). Keep the permissions sorted
-alphabetically on `user_or_group` for a better user experience.
+alphabetically, ignoring case on `user_or_group` for a better user experience.
 
 
 ```hcl


### PR DESCRIPTION
### Description
The permissions objects received from server are not necessarily sorted on username/groupname. We are asking the users to keep it sorted in the TF file and this PR sorts the received objects alphabetically so that terraform doesn't show a diff while refreshing. 
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

- resource/vsphere_entity_permissions: Sorting permission objects on username/groupname before storing. (#1311)

```
### References
Closes #1293 