### PR TITLE
OVF deployment options support 

### DIFF
--- a/vsphere/data_source_vsphere_ovf_vm_template.go
+++ b/vsphere/data_source_vsphere_ovf_vm_template.go
@@ -103,7 +103,6 @@ func dataSourceVSphereOvfVMTemplate() *schema.Resource {
 		"datastore_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Computed:    true,
 			Description: "The ID of the virtual machine's datastore. The virtual machine configuration is placed here, along with any virtual disks that are created without datastores.",
 		},
 		"folder": {

--- a/vsphere/data_source_vsphere_ovf_vm_template.go
+++ b/vsphere/data_source_vsphere_ovf_vm_template.go
@@ -1,0 +1,173 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"
+
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow"
+)
+
+func dataSourceVSphereOvfVMTemplate() *schema.Resource {
+
+	vmConfigSpecSchema := map[string]*schema.Schema{
+		"num_cpus": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "The number of virtual processors to assign to this virtual machine.",
+		},
+		"num_cores_per_socket": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "The number of cores to distribute amongst the CPUs in this virtual machine. If specified, the value supplied to num_cpus must be evenly divisible by this value.",
+		},
+		"cpu_hot_add_enabled": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Allow CPUs to be added to this virtual machine while it is running.",
+		},
+		"cpu_hot_remove_enabled": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Allow CPUs to be added to this virtual machine while it is running.",
+		},
+		"nested_hv_enabled": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Enable nested hardware virtualization on this virtual machine, facilitating nested virtualization in the guest.",
+		},
+		"cpu_performance_counters_enabled": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Enable CPU performance counters on this virtual machine.",
+		},
+		"memory": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "The size of the virtual machine's memory, in MB.",
+		},
+		"memory_hot_add_enabled": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Allow memory to be added to this virtual machine while it is running.",
+		},
+		"swap_placement_policy": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The swap file placement policy for this virtual machine. Can be one of inherit, hostLocal, or vmDirectory.",
+		},
+		"annotation": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "User-provided description of the virtual machine.",
+		},
+		"guest_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The guest ID for the operating system.",
+		},
+		"alternate_guest_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The guest name for the operating system when guest_id is other or other-64.",
+		},
+		"firmware": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The firmware interface to use on the virtual machine. Can be one of bios or EFI.",
+		},
+	}
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Name of the virtual machine to create.",
+		},
+		"resource_pool_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ID of a resource pool to put the virtual machine in.",
+		},
+
+		"host_system_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ID of an optional host system to pin the virtual machine to.",
+		},
+		"datastore_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "The ID of the virtual machine's datastore. The virtual machine configuration is placed here, along with any virtual disks that are created without datastores.",
+		},
+		"folder": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The name of the folder to locate the virtual machine in.",
+			StateFunc:   folder.NormalizePath,
+		},
+	}
+	structure.MergeSchema(s, vmworkflow.VirtualMachineOvfDeploySchema())
+	structure.MergeSchema(s, vmConfigSpecSchema)
+
+	return &schema.Resource{
+		Read:   dataSourceVSphereOvfVMTemplateRead,
+		Schema: s,
+	}
+}
+
+func NewOvfHelperParamsFromVMDatasource(d *schema.ResourceData) *ovfdeploy.OvfHelperParams {
+	ovfParams := &ovfdeploy.OvfHelperParams{
+		AllowUnverifiedSSL: d.Get("allow_unverified_ssl_cert").(bool),
+		DatastoreId:        d.Get("datastore_id").(string),
+		DeploymentOption:   d.Get("deployment_option").(string),
+		DiskProvisioning:   d.Get("disk_provisioning").(string),
+		FilePath:           d.Get("local_ovf_path").(string),
+		Folder:             d.Get("folder").(string),
+		HostId:             d.Get("host_system_id").(string),
+		IpAllocationPolicy: d.Get("ip_allocation_policy").(string),
+		IpProtocol:         d.Get("ip_protocol").(string),
+		Name:               d.Get("name").(string),
+		NetworkMappings:    d.Get("ovf_network_map").(map[string]interface{}),
+		OvfUrl:             d.Get("remote_ovf_url").(string),
+		PoolId:             d.Get("resource_pool_id").(string),
+	}
+	return ovfParams
+}
+
+func dataSourceVSphereOvfVMTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	ovfParams := NewOvfHelperParamsFromVMDatasource(d)
+	ovfHelper, err := ovfdeploy.NewOvfHelper(client, ovfParams)
+	if err != nil {
+		return fmt.Errorf("while extracting OVF parameters: %s", err)
+	}
+
+	is, err := ovfHelper.GetImportSpec(client)
+	if err != nil {
+		return fmt.Errorf("while retrieving import spec: %s", err)
+	}
+
+	vmConfigSpec := is.ImportSpec.(*types.VirtualMachineImportSpec).ConfigSpec
+	_ = d.Set("num_cpus", vmConfigSpec.NumCPUs)
+	_ = d.Set("num_cores_per_socket", vmConfigSpec.NumCoresPerSocket)
+	_ = d.Set("cpu_hot_add_enabled", vmConfigSpec.CpuHotAddEnabled)
+	_ = d.Set("cpu_hot_remove_enabled", vmConfigSpec.CpuHotRemoveEnabled)
+	_ = d.Set("nested_hv_enabled", vmConfigSpec.NestedHVEnabled)
+	_ = d.Set("memory", vmConfigSpec.MemoryMB)
+	_ = d.Set("memory_hot_add_enabled", vmConfigSpec.MemoryHotAddEnabled)
+	_ = d.Set("swap_placement_policy", vmConfigSpec.SwapPlacement)
+	_ = d.Set("annotation", vmConfigSpec.Annotation)
+	_ = d.Set("guest_id", vmConfigSpec.GuestId)
+	_ = d.Set("alternate_guest_name", vmConfigSpec.AlternateGuestName)
+	_ = d.Set("firmware", vmConfigSpec.Firmware)
+	d.SetId(d.Get("name").(string))
+
+	return nil
+}

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -536,8 +536,16 @@ func (o *OvfHelper) GetImportSpec(client *govmomi.Client) (*types.OvfCreateImpor
 		importSpecParam.DeploymentOption = deploymentOption
 	}
 
-	return ovfManager.CreateImportSpec(context.Background(), ovfDescriptor,
+	is, err := ovfManager.CreateImportSpec(context.Background(), ovfDescriptor,
 		o.ResourcePool.Reference(), o.Datastore.Reference(), importSpecParam)
+	if len(is.Error) > 0 {
+		out := "while getting ovf import spec: \n"
+		for _, e := range is.Error {
+			out = fmt.Sprintf("%s\n- %s", out, e.LocalizedMessage)
+		}
+		return nil, fmt.Errorf(out)
+	}
+	return is, nil
 }
 
 func (o *OvfHelper) DeployOvf(spec *types.OvfCreateImportSpecResult) error {

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -68,18 +68,18 @@ func DeployOvfAndGetResult(ovfCreateImportSpecResult *types.OvfCreateImportSpecR
 	statusChannel := make(chan bool)
 	// Create a go routine to update progress regularly
 	go func() {
-		var progress int64 = 0
 		for {
 			select {
 			case <-statusChannel:
 				break
 			default:
-				log.Printf("Uploaded %v of %v Bytes", getTotalBytesRead(&currBytesRead), totalBytes)
 				if totalBytes == 0 {
-					break
+					_ = nfcLease.Progress(context.Background(), 100)
+					return
 				}
-				progress = (getTotalBytesRead(&currBytesRead) / totalBytes) * 100
-				nfcLease.Progress(context.Background(), int32(progress))
+				log.Printf("Uploaded %v of %v Bytes", getTotalBytesRead(&currBytesRead), totalBytes)
+				progress := (getTotalBytesRead(&currBytesRead) / totalBytes) * 100
+				_ = nfcLease.Progress(context.Background(), int32(progress))
 				time.Sleep(10 * time.Second)
 			}
 		}

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -479,11 +479,6 @@ func NetworkInterfacePostCloneOperation(d *schema.ResourceData, c *govmomi.Clien
 
 	// Any other device past the end of the network devices listed in config needs to be removed.
 	if len(curSet) < len(srcSet) {
-		ovfNetworks := map[string]int{}
-		for _, v := range d.Get("ovf_deploy.0.ovf_network_map").(map[string]interface{}) {
-			ovfNetworks[v.(string)] = 1
-		}
-
 		for i, si := range srcSet[len(curSet):] {
 			sm, ok := si.(map[string]interface{})
 			if !ok {
@@ -491,33 +486,12 @@ func NetworkInterfacePostCloneOperation(d *schema.ResourceData, c *govmomi.Clien
 				continue
 			}
 			r := NewNetworkInterfaceSubresource(c, d, sm, nil, i+len(curSet))
-
-			// If the VM was built via OVF then the network interfaces have not been imported yet.
-			// Since the remaining devices are so far unknown to us, this is a good opportunity to import then.
-			var pgId string
-			for k, _ := range ovfNetworks {
-				if r.Data()["network_id"].(string) == k {
-					pgId = k
-					break
-				}
+			dspec, err := r.Delete(l)
+			if err != nil {
+				return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
 			}
-			delete(ovfNetworks, pgId)
-
-			if pgId != "" {
-				cspec, err := r.Update(l)
-				if err != nil {
-					return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
-				}
-				l = applyDeviceChange(l, cspec)
-				spec = append(spec, cspec...)
-			} else {
-				dspec, err := r.Delete(l)
-				if err != nil {
-					return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
-				}
-				l = applyDeviceChange(l, dspec)
-				spec = append(spec, dspec...)
-			}
+			l = applyDeviceChange(l, dspec)
+			spec = append(spec, dspec...)
 		}
 	}
 
@@ -857,20 +831,12 @@ func (r *NetworkInterfaceSubresource) Update(l object.VirtualDeviceList) ([]type
 	}
 	version := viapi.ParseVersionFromClient(r.client)
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
-		var shareLevel string
-		bwShareLevel := r.Get("bandwidth_share_level")
-		switch bwShareLevel.(type) {
-		case string:
-			shareLevel = bwShareLevel.(string)
-		case types.SharesLevel:
-			shareLevel = string(bwShareLevel.(types.SharesLevel))
-		}
 		alloc := &types.VirtualEthernetCardResourceAllocation{
 			Limit:       structure.Int64Ptr(int64(r.Get("bandwidth_limit").(int))),
 			Reservation: structure.Int64Ptr(int64(r.Get("bandwidth_reservation").(int))),
 			Share: types.SharesInfo{
 				Shares: int32(r.Get("bandwidth_share_count").(int)),
-				Level:  types.SharesLevel(shareLevel),
+				Level:  types.SharesLevel(r.Get("bandwidth_share_level").(string)),
 			},
 		}
 		card.ResourceAllocation = alloc

--- a/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
@@ -52,7 +52,7 @@ func VirtualMachineOvfDeploySchema() map[string]*schema.Schema {
 		"allow_unverified_ssl_cert": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Default:     true,
+			DefaultFunc: schema.EnvDefaultFunc("VSPHERE_ALLOW_UNVERIFIED_SSL", false),
 			Description: "Allow unverified ssl certificates while deploying ovf/ova from url.",
 		},
 	}

--- a/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_ovfdeploy_subresource.go
@@ -36,6 +36,12 @@ func VirtualMachineOvfDeploySchema() map[string]*schema.Schema {
 			Description: "An optional disk provisioning. If set, all the disks in the deployed ovf will have the same specified disk type (e.g., thin provisioned).",
 			ForceNew:    true,
 		},
+		"deployment_option": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The Deployment option to be chosen. If empty, the default option is used.",
+			ForceNew:    true,
+		},
 		"ovf_network_map": {
 			Type:        schema.TypeMap,
 			Optional:    true,

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -156,6 +156,7 @@ func Provider() terraform.ResourceProvider {
 			"vsphere_host_pci_device":            dataSourceVSphereHostPciDevice(),
 			"vsphere_host_thumbprint":            dataSourceVSphereHostThumbprint(),
 			"vsphere_network":                    dataSourceVSphereNetwork(),
+			"vsphere_ovf_vm_template":            dataSourceVSphereOvfVMTemplate(),
 			"vsphere_resource_pool":              dataSourceVSphereResourcePool(),
 			"vsphere_storage_policy":             dataSourceVSphereStoragePolicy(),
 			"vsphere_tag":                        dataSourceVSphereTag(),

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1526,7 +1526,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	}
 	cfgSpec.DeviceChange = virtualdevice.AppendDeviceChangeSpec(cfgSpec.DeviceChange, delta...)
 	// Disks
-	devices, delta, err = virtualdevice.DiskPostCloneOperation(d, client, devices, false)
+	devices, delta, err = virtualdevice.DiskPostCloneOperation(d, client, devices, postOvf)
 	if err != nil {
 		return resourceVSphereVirtualMachineRollbackCreate(
 			d,

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/ovf"
 	"github.com/vmware/govmomi/vapi/vcenter"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -1319,13 +1318,20 @@ func resourceVSphereVirtualMachineCreateBareStandard(
 // Deploy vm from ovf/ova template
 func resourceVsphereMachineDeployOvfAndOva(d *schema.ResourceData, meta interface{}) (*object.VirtualMachine, error) {
 	client := meta.(*VSphereClient).vimClient
-	ovfParams, err := NewOvfParamsFromResourceData(client, d)
+
+	ovfParams := NewOvfHelperParamsFromVMResource(d)
+	ovfHelper, err := ovfdeploy.NewOvfHelper(client, ovfParams)
 	if err != nil {
 		return nil, fmt.Errorf("while extracting OVF parameters: %s", err)
 	}
 
+	ovfImportspec, err := ovfHelper.GetImportSpec(client)
+	if err != nil {
+		return nil, fmt.Errorf("while retrieving ovf import spec from the API: %s", err)
+	}
+
 	log.Print(" [DEBUG] start deploying from ovf/ova Template")
-	err = ovfParams.DeployOvfAndGetResult(client)
+	err = ovfHelper.DeployOvf(ovfImportspec)
 	if err != nil {
 		return nil, fmt.Errorf("error while importing ovf/ova template, %s", err)
 	}
@@ -1339,7 +1345,7 @@ func resourceVsphereMachineDeployOvfAndOva(d *schema.ResourceData, meta interfac
 		return nil, fmt.Errorf("error while getting datacenter with id %s %s", dataCenterId, err)
 	}
 
-	vm, err := virtualmachine.FromPath(client, ovfParams.Name, datacenterObj)
+	vm, err := virtualmachine.FromPath(client, ovfHelper.Name, datacenterObj)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching the created vm, %s", err)
 	}
@@ -1843,137 +1849,21 @@ func resourceVSphereVirtualMachineIDString(d structure.ResourceIDStringer) strin
 	return structure.ResourceIDString(d, "vsphere_virtual_machine")
 }
 
-type OvfParams struct {
-	AllowUnverifiedSSL bool
-	Datastore          *object.Datastore
-	DeploymentOption   string
-	DeployOva          bool
-	DiskProvisioning   string
-	FilePath           string
-	Folder             *object.Folder
-	IsLocal            bool
-	Name               string
-	HostSystem         *object.HostSystem
-	IpAllocationPolicy string
-	IpProtocol         string
-	NetworkMapping     []types.OvfNetworkMapping
-	OvfPath            string
-	OvfUrl             string
-	ResourcePool       *object.ResourcePool
-}
-
-func NewOvfParamsFromResourceData(client *govmomi.Client, d *schema.ResourceData) (*OvfParams, error) {
-	ovfParams := &OvfParams{
+func NewOvfHelperParamsFromVMResource(d *schema.ResourceData) *ovfdeploy.OvfHelperParams {
+	ovfParams := &ovfdeploy.OvfHelperParams{
 		AllowUnverifiedSSL: d.Get("ovf_deploy.0.allow_unverified_ssl_cert").(bool),
+		DatastoreId:        d.Get("datastore_id").(string),
 		DeploymentOption:   d.Get("ovf_deploy.0.deployment_option").(string),
 		DiskProvisioning:   d.Get("ovf_deploy.0.disk_provisioning").(string),
+		FilePath:           d.Get("ovf_deploy.0.local_ovf_path").(string),
+		Folder:             d.Get("folder").(string),
+		HostId:             d.Get("host_system_id").(string),
 		IpAllocationPolicy: d.Get("ovf_deploy.0.ip_allocation_policy").(string),
 		IpProtocol:         d.Get("ovf_deploy.0.ip_protocol").(string),
 		Name:               d.Get("name").(string),
+		NetworkMappings:    d.Get("ovf_deploy.0.ovf_network_map").(map[string]interface{}),
+		OvfUrl:             d.Get("ovf_deploy.0.remote_ovf_url").(string),
+		PoolId:             d.Get("resource_pool_id").(string),
 	}
-
-	ovfParams.DeployOva = false
-	ovfParams.IsLocal = true
-	ovfParams.FilePath = d.Get("ovf_deploy.0.local_ovf_path").(string)
-
-	ovfUrl := d.Get("ovf_deploy.0.remote_ovf_url").(string)
-	if ovfUrl != "" {
-		ovfParams.IsLocal = false
-		ovfParams.FilePath = ovfUrl
-	}
-
-	if strings.HasSuffix(ovfParams.FilePath, ".ova") {
-		ovfParams.DeployOva = true
-	}
-
-	//Resource pool
-	poolID := d.Get("resource_pool_id").(string)
-	poolObj, err := resourcepool.FromID(client, poolID)
-	if err != nil {
-		return nil, fmt.Errorf("could not find resource pool ID %q: %s", poolID, err)
-	}
-	ovfParams.ResourcePool = poolObj
-
-	// Folder
-	folderObj, err := folder.VirtualMachineFolderFromObject(client, poolObj, d.Get("folder").(string))
-	if err != nil {
-		return nil, err
-	}
-	ovfParams.Folder = folderObj
-
-	//Host
-	hostId := d.Get("host_system_id").(string)
-	if hostId == "" {
-		return nil, fmt.Errorf("host system ID is required for ovf deployment")
-	}
-	hostObj, err := hostsystem.FromID(client, hostId)
-	if err != nil {
-		return nil, fmt.Errorf("could not find host with ID %q: %s", hostId, err)
-	}
-	ovfParams.HostSystem = hostObj
-
-	//Datastore
-	dsId := d.Get("datastore_id").(string)
-	if dsId == "" {
-		return nil, fmt.Errorf("data store ID is required for ovf deployment")
-	}
-	dsObj, err := datastore.FromID(client, dsId)
-	if err != nil {
-		return nil, fmt.Errorf("could not find datastore with ID %q: %s", dsId, err)
-	}
-	ovfParams.Datastore = dsObj
-
-	//Network Mapping
-	networkMapping, err := ovfdeploy.GetNetworkMapping(client, d)
-	if err != nil {
-		return nil, fmt.Errorf("while getting OVF network mapping: %s", err)
-	}
-	ovfParams.NetworkMapping = networkMapping
-
-	return ovfParams, nil
-}
-
-func (o *OvfParams) GetImportSpec(client *govmomi.Client) (*types.OvfCreateImportSpecResult, error) {
-
-	hsRef := o.HostSystem.Reference()
-	importSpecParam := types.OvfCreateImportSpecParams{
-		EntityName:         o.Name,
-		HostSystem:         &hsRef,
-		NetworkMapping:     o.NetworkMapping,
-		IpAllocationPolicy: o.IpAllocationPolicy,
-		IpProtocol:         o.IpProtocol,
-		DiskProvisioning:   o.DiskProvisioning,
-	}
-
-	ovfDescriptor, err := ovfdeploy.GetOvfDescriptor(o.FilePath, o.DeployOva, o.IsLocal, o.AllowUnverifiedSSL)
-	if err != nil {
-		return nil, fmt.Errorf("error while reading the ovf file %s, %s ", o.FilePath, err)
-	}
-
-	if ovfDescriptor == "" {
-		return nil, fmt.Errorf("the given ovf file %s is empty", o.FilePath)
-	}
-
-	ovfManager := ovf.NewManager(client.Client)
-	deploymentOption := o.DeploymentOption
-	if deploymentOption != "" {
-		err := ovfdeploy.CheckDeploymentOption(client, deploymentOption, ovfDescriptor)
-		if err != nil {
-			return nil, fmt.Errorf("while checking deployment option: %s", err)
-		}
-		importSpecParam.DeploymentOption = deploymentOption
-	}
-
-	return ovfManager.CreateImportSpec(context.Background(), ovfDescriptor,
-		o.ResourcePool.Reference(), o.Datastore.Reference(), importSpecParam)
-}
-
-func (o *OvfParams) DeployOvfAndGetResult(client *govmomi.Client) error {
-	ovfCreateImportSpecResult, err := o.GetImportSpec(client)
-	if err != nil {
-		return err
-	}
-
-	return ovfdeploy.DeployOvfAndGetResult(ovfCreateImportSpecResult, o.ResourcePool, o.Folder, o.HostSystem,
-		o.FilePath, o.DeployOva, o.IsLocal, o.AllowUnverifiedSSL)
+	return ovfParams
 }

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -222,7 +222,6 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 		"network_interface": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			Computed:    true,
 			Description: "A specification for a virtual NIC on this virtual machine.",
 			MaxItems:    10,
 			Elem:        &schema.Resource{Schema: virtualdevice.NetworkInterfaceSubresourceSchema()},

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -3,8 +3,6 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"net"
 	"os"
 	"path"
@@ -14,6 +12,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -7171,33 +7172,51 @@ func testAccResourceVSphereVirtualMachineDeployOvfFromUrl(vmName string) string 
 	return fmt.Sprintf(`
 %s
 
-resource "vsphere_virtual_machine" "vm" {
-  name                       = "%s"
-  resource_pool_id           = vsphere_resource_pool.pool1.id
-  datastore_id               = vsphere_nas_datastore.ds1.id
-  datacenter_id              = data.vsphere_datacenter.rootdc1.id
-  host_system_id             = data.vsphere_host.roothost1.id
-  wait_for_guest_net_timeout = 0
-  wait_for_guest_ip_timeout  = 0
-  num_cpus                   = 2
-  ovf_deploy {
-    remote_ovf_url = "%s"
+variable "ovf_url" {
+	default = "%s"
+}
+
+data "vsphere_ovf_vm_template" "ovf" {
+  name              = "%s"
+  resource_pool_id  = vsphere_resource_pool.pool1.id
+  datastore_id      = vsphere_nas_datastore.ds1.id
+  host_system_id    = data.vsphere_host.roothost1.id
+  remote_ovf_url    = var.ovf_url
+
+  ovf_network_map   = {
+    "Network 1": data.vsphere_network.network1.id
   }
-	disk{
-		size           = 40
-		unit_number    = 0
-		label          = "disk0"
-		io_share_count = 1000
-	}
-  cdrom {
-    client_device = true
+}
+
+
+resource "vsphere_virtual_machine" "vm" {
+  datacenter_id    = data.vsphere_datacenter.rootdc1.id
+
+  annotation       = data.vsphere_ovf_vm_template.ovf.annotation
+  name             = data.vsphere_ovf_vm_template.ovf.name
+  num_cpus         = data.vsphere_ovf_vm_template.ovf.num_cpus
+  memory           = data.vsphere_ovf_vm_template.ovf.memory
+  guest_id         = data.vsphere_ovf_vm_template.ovf.guest_id
+  resource_pool_id = data.vsphere_ovf_vm_template.ovf.resource_pool_id
+  datastore_id     = data.vsphere_ovf_vm_template.ovf.datastore_id
+  host_system_id   = data.vsphere_ovf_vm_template.ovf.host_system_id
+
+  dynamic "network_interface" {
+    for_each = data.vsphere_ovf_vm_template.ovf.ovf_network_map
+    content {
+        network_id = network_interface.value
+    }
+  }
+
+  ovf_deploy {
+	  remote_ovf_url    = var.ovf_url
   }
 }
 
 `,
 		testAccResourceVSphereVirtualMachineConfigBase(),
+		os.Getenv("TF_VAR_VSPHERE_TEST_OVF"),
 		vmName,
-		os.Getenv("TF_VAR_REMOTE_OVF_URL"),
 	)
 }
 
@@ -7205,27 +7224,50 @@ func testAccResourceVSphereVirtualMachineDeployOvaFromUrl(vmName string) string 
 	return fmt.Sprintf(`
 %s // Mix and match config
 
+variable "ova_url" {
+	default = "%s"
+}
+
+data "vsphere_ovf_vm_template" "ovf" {
+  name              = "%s"
+  resource_pool_id  = vsphere_resource_pool.pool1.id
+  datastore_id      = vsphere_nas_datastore.ds1.id
+  host_system_id    = data.vsphere_host.roothost1.id
+  remote_ovf_url    = var.ova_url
+
+  ovf_network_map   = {
+    "Network 1": data.vsphere_network.network1.id
+  }
+}
+
+
 resource "vsphere_virtual_machine" "vm" {
-  name                       = "%s"
-  num_cpus                   = 2
-  resource_pool_id           = vsphere_resource_pool.pool1.id
-  datastore_id               = vsphere_nas_datastore.ds1.id
-  datacenter_id              = data.vsphere_datacenter.rootdc1.id
-  host_system_id             = data.vsphere_host.roothost1.id
-  wait_for_guest_net_timeout = 0
-  wait_for_guest_ip_timeout  = 0
-  ovf_deploy {
-    remote_ovf_url = "%s"
+  datacenter_id    = data.vsphere_datacenter.rootdc1.id
+
+  annotation       = data.vsphere_ovf_vm_template.ovf.annotation
+  name             = data.vsphere_ovf_vm_template.ovf.name
+  num_cpus         = data.vsphere_ovf_vm_template.ovf.num_cpus
+  memory           = data.vsphere_ovf_vm_template.ovf.memory
+  guest_id         = data.vsphere_ovf_vm_template.ovf.guest_id
+  resource_pool_id = data.vsphere_ovf_vm_template.ovf.resource_pool_id
+  datastore_id     = data.vsphere_ovf_vm_template.ovf.datastore_id
+  host_system_id   = data.vsphere_ovf_vm_template.ovf.host_system_id
+
+  dynamic "network_interface" {
+    for_each = data.vsphere_ovf_vm_template.ovf.ovf_network_map
+    content {
+        network_id = network_interface.value
+    }
   }
 
-  cdrom {
-    client_device = true
+  ovf_deploy {
+	  remote_ovf_url    = var.ova_url
   }
 }
 `,
 		testAccResourceVSphereVirtualMachineConfigBase(),
+		os.Getenv("TF_VAR_VSPHERE_TEST_OVA"),
 		vmName,
-		os.Getenv("TF_VAR_REMOTE_OVA_URL"),
 	)
 }
 

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -2569,14 +2569,6 @@ func TestAccResourceVSphereVirtualMachine_deployOvaFromUrl(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "name", vmName),
-					resource.TestCheckResourceAttrPair("data.vsphere_ovf_vm_template.ovf", "scsi_type",
-						"vsphere_virtual_machine.vm", "scsi_type"),
-					resource.TestCheckResourceAttrPair("data.vsphere_ovf_vm_template.ovf", "scsi_controller_count",
-						"vsphere_virtual_machine.vm", "scsi_controller_count"),
-					resource.TestCheckResourceAttrPair("data.vsphere_ovf_vm_template.ovf", "ide_controller_count",
-						"vsphere_virtual_machine.vm", "ide_controller_count"),
-					resource.TestCheckResourceAttrPair("data.vsphere_ovf_vm_template.ovf", "sata_controller_count",
-						"vsphere_virtual_machine.vm", "sata_controller_count"),
 				),
 			},
 			{
@@ -7192,7 +7184,7 @@ data "vsphere_ovf_vm_template" "ovf" {
   remote_ovf_url    = var.ovf_url
 
   ovf_network_map   = {
-    "Network 1": data.vsphere_network.network1.id
+    "Production_DVS - Mgmt": data.vsphere_network.network1.id
   }
 }
 
@@ -7217,7 +7209,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   ovf_deploy {
-	  remote_ovf_url    = var.ovf_url
+	  remote_ovf_url  = var.ovf_url
+	  ovf_network_map = data.vsphere_ovf_vm_template.ovf.ovf_network_map
   }
 }
 
@@ -7244,7 +7237,7 @@ data "vsphere_ovf_vm_template" "ovf" {
   remote_ovf_url    = var.ova_url
 
   ovf_network_map   = {
-    "Network 1": data.vsphere_network.network1.id,
+    "Production_DVS - Mgmt": data.vsphere_network.network1.id,
   }
 }
 
@@ -7260,10 +7253,6 @@ resource "vsphere_virtual_machine" "vm" {
   resource_pool_id      = vsphere_resource_pool.pool1.id
   datastore_id          = vsphere_nas_datastore.ds1.id
   host_system_id        = data.vsphere_ovf_vm_template.ovf.host_system_id
-  scsi_type             = data.vsphere_ovf_vm_template.ovf.scsi_type
-  scsi_controller_count = data.vsphere_ovf_vm_template.ovf.scsi_controller_count
-  sata_controller_count = data.vsphere_ovf_vm_template.ovf.sata_controller_count
-  ide_controller_count  = data.vsphere_ovf_vm_template.ovf.ide_controller_count
 
   dynamic "network_interface" {
     for_each = data.vsphere_ovf_vm_template.ovf.ovf_network_map

--- a/website/docs/d/ovf_vm_template.html.markdown
+++ b/website/docs/d/ovf_vm_template.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Virtual Machine"
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_ovf_vm_template"
+sidebar_current: "docs-vsphere-data-source-ovf-vm-template"
+description: |-
+A data source that can be used to extract the configuration of an OVF template 
+---
+
+# vsphere\_ovf\_vm\_template
+
+The `vsphere_ovf_vm_template` data source can be used to submit an OVF to vSphere and extract its hardware
+settings in a form that can be then used as inputs for a `vsphere_virtual_machine` resource.
+
+## Example Usage
+
+```hcl
+data "vsphere_ovf_vm_template" "ovf" {
+  name             = "testOVF"
+  resource_pool_id = vsphere_resource_pool.rp.id
+  datastore_id     = data.vsphere_datastore.ds.id
+  host_system_id   = data.vsphere_host.hs.id
+  remote_ovf_url   = "https://download3.vmware.com/software/vmw-tools/nested-esxi/Nested_ESXi7.0_Appliance_Template_v1.ova"
+
+  ovf_network_map = {
+    "Network 1": data.vsphere_network.net.id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `name` - Name of the virtual machine to create.
+* `resource_pool_id` - (Required) The ID of a resource pool to put the virtual machine in.
+* `host_system_id` - (Required) The ID of an optional host system to pin the virtual machine to.
+* `datastore_id` - (Required) The ID of the virtual machine's datastore. The virtual machine configuration is placed here, along with any virtual disks that are created without datastores.
+* `folder` - (Required) The name of the folder to locate the virtual machine in.
+* `local_ovf_path` - (Optional) The absolute path to the ovf/ova file in the local system. While deploying from ovf,
+  make sure the other necessary files like the .vmdk files are also in the same directory as the given ovf file.
+* `remote_ovf_url` - (Optional) URL to the remote ovf/ova file to be deployed.
+
+~> **NOTE:** Either `local_ovf_path` or `remote_ovf_url` is required, both can't be empty.
+
+* `ip_allocation_policy` - (Optional) The IP allocation policy.
+* `ip_protocol` - (Optional) The IP protocol.
+* `disk_provisioning` - (Optional) The disk provisioning. If set, all the disks in the deployed OVF will have
+  the same specified disk type (accepted values {thin, flat, thick, sameAsSource}).
+* `deployment_option` - (Optional) The key of the chosen deployment option. If empty, the default option is chosen.
+* `ovf_network_map` - (Optional) The mapping of name of network identifiers from the ovf descriptor to network UUID in the
+  VI infrastructure.
+* `allow_unverified_ssl_cert` - (Optional) Allow unverified ssl certificates while deploying ovf/ova from url.
+
+
+## Attribute Reference
+* `num_cpus` - The number of virtual processors to assign to this virtual machine.
+* `num_cores_per_socket` - The number of cores to distribute amongst the CPUs in this virtual machine.
+* `cpu_hot_add_enabled` - Allow CPUs to be added to this virtual machine while it is running.
+* `cpu_hot_remove_enabled` - Allow CPUs to be added to this virtual machine while it is running.
+* `nested_hv_enabled` - Enable nested hardware virtualization on this virtual machine, facilitating nested virtualization in the guest.
+* `memory` - The size of the virtual machine's memory, in MB.
+* `memory_hot_add_enabled` - Allow memory to be added to this virtual machine while it is running.
+* `swap_placement_policy` - The swap file placement policy for this virtual machine.
+* `annotation` - User-provided description of the virtual machine.
+* `guest_id` - The guest ID for the operating system
+* `alternate_guest_name` - The guest name for the operating system .
+* `firmware` - The firmware interface to use on the virtual machine.
+

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1369,6 +1369,7 @@ The options available in the `ovf_deploy` block are:
 * `ip_protocol` - (Optional) The IP protocol.
 * `disk_provisioning` - (Optional) The disk provisioning. If set, all the disks in the deployed OVF will have 
    the same specified disk type (accepted values {thin, flat, thick, sameAsSource}).
+* `deployment_option` - (Optional) The key of the chosen deployment option. If empty, the default option is chosen.   
 * `ovf_network_map` - (Optional) The mapping of name of network identifiers from the ovf descriptor to network UUID in the 
    VI infrastructure.
 * `allow_unverified_ssl_cert` - (Optional) Allow unverified ssl certificates while deploying ovf/ova from url.

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -245,11 +245,7 @@ resource "vsphere_virtual_machine" "vm" {
 Ovf and ova templates can be deployed both from local system and remote URL into the 
 vcenter using the `ovf_deploy` property. When deploying from local system, the 
 path to the ovf or ova template needs to be provided. While deploying ovf, all other 
-necessary files like vmdk files also should be present in the same directory as the ovf file. 
-While deploying, the VM properties like `name`, `datacenter_id`, `resource_pool_id`, `datastore_id`, 
-`host_system_id`, `folder`, `scsi_controller_count`, `sata_controller_count`, 
-`ide_controller_count`, and `vapp` can only be set. All other VM properties are taken from the ovf 
-template and setting them in the configuration file is redundant.
+necessary files like vmdk files also should be present in the same directory as the ovf file.
 
 ~> **NOTE:** Only the vApp properties which are pre-defined in the ovf template can be overwritten. 
 vApp properties from scratch cannot be created.
@@ -321,6 +317,88 @@ resource "vsphere_virtual_machine" "vmFromRemoteOvf" {
   }
 }
 ```
+
+Using the OVF/OVA to deploy virtual machines can result in situations where the resulting VM does
+match what's specified in the OVF specification because the provider will attempt to apply its own
+settings on top of that. For example if `memory` is not set in a `vsphere_virtual_machine` resource,
+then terraform will assume that it has to apply the default. There are also cases where the hardware
+specifications may not be applicable and changes need to be made. The way to work around these cases
+is to use the `vsphere_ovf_vm_template` data source that will parse the OVF template and export the
+settings as outputs, that are then passed as parameters to the `vsphere_virtual_machine` resource.
+Please note that the parameters to `ovf_deploy` are still required, in order for vSphere to do the
+actual deployment, as shown in the example below:
+
+```hcl
+provider "vsphere" {}
+
+data "vsphere_datacenter" "dc" {
+  name = "hashidc"
+}
+
+data "vsphere_host" "hs" {
+  name = "172.16.12.125"
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_compute_cluster" "compute_cluster" {
+  name          = "c1"
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+resource "vsphere_resource_pool" "rp" {
+  name = "rp1"
+  parent_resource_pool_id = data.vsphere_compute_cluster.compute_cluster.resource_pool_id
+}
+
+data "vsphere_network" "net" {
+  name = "VM Network"
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_datastore" "ds" {
+  name          = "nfs-vol1"
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_ovf_vm_template" "ovf" {
+  name             = "testOVF"
+  resource_pool_id = vsphere_resource_pool.rp.id
+  datastore_id     = data.vsphere_datastore.ds.id
+  host_system_id   = data.vsphere_host.hs.id
+  remote_ovf_url   = "https://download3.vmware.com/software/vmw-tools/nested-esxi/Nested_ESXi7.0_Appliance_Template_v1.ova"
+  
+  ovf_network_map = {
+    "Network 1": data.vsphere_network.net.id
+  }
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  datacenter_id = data.vsphere_datacenter.dc.id
+
+  name             = data.vsphere_ovf_vm_template.ovf.name
+  num_cpus         = data.vsphere_ovf_vm_template.ovf.num_cpus
+  memory           = data.vsphere_ovf_vm_template.ovf.memory
+  guest_id         = data.vsphere_ovf_vm_template.ovf.guest_id
+  resource_pool_id = data.vsphere_ovf_vm_template.ovf.resource_pool_id
+  datastore_id     = data.vsphere_ovf_vm_template.ovf.datastore_id
+  host_system_id   = data.vsphere_ovf_vm_template.ovf.host_system_id
+
+  dynamic "network_interface" {
+    for_each = data.vsphere_ovf_vm_template.ovf.ovf_network_map
+    content {
+      network_id = network_interface.value
+    }
+  }
+  
+  ovf_deploy {
+    ovf_network_map = data.vsphere_ovf_vm_template.ovf.ovf_network_map
+    remote_ovf_url  = data.vsphere_ovf_vm_template.ovf.remote_ovf_url
+  }
+}
+
+
+```
+
 
 ### Cloning from an OVF/OVA-created template with vApp properties
 

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -64,6 +64,9 @@
             <li<%= sidebar_current("docs-vsphere-data-source-vmfs-disks") %>>
               <a href="/docs/providers/vsphere/d/vmfs_disks.html">vsphere_vmfs_disks</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-ovf-vm-template") %>>
+              <a href="/docs/providers/vsphere/d/ovf_vm_template.html">vsphere_ovf_vm_template</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
    The provider expects to be the only entity altering the settings of a
    virtual machine, which is not the case when deploying via OVF.

    The easy way out of this would be to make all attributes `Computed`
    which would make terraform to blidnly accept all changes into the state.
    Unfortunately this would also mean a loss of drift detection.

    The middle ground is to create a new datasource that extracts all the
    settings from the OVF template and expose it as outputs, so we can then
    pass it as attribute values to the `vsphere_virtual_machine` resource.

    The ideal solution would be to create a whole new resource to deal
    exclusively with OVF-built virtual machines but it would be a breaking
    change since users are already using the ovf subresource in
    `vsphere_virtual_machine`. This could potentially go into a v2.0 version
    of the provider (cc: @redeux).

    This commit creates the `vsphere_ovf_vm_template` resource and re-arranges
    some of the OVF code so it can be used from both `vsphere_virtual_machine`
    resource and the datasource.

