### PR TITLE
Fix compare for VM Config spec change

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -916,15 +916,17 @@ func expandVirtualMachineConfigSpecChanged(d *schema.ResourceData, client *govmo
 	log.Printf("[DEBUG] %s: Expanding of old config complete", resourceVSphereVirtualMachineIDString(d))
 
 	newSpec, err := expandVirtualMachineConfigSpec(d, client)
-	// Don't include the hardware version in the UpdateSpec. It is only needed
-	// when created new VMs.
-	newSpec.Version = ""
 	if err != nil {
 		return types.VirtualMachineConfigSpec{}, false, err
 	}
 
+	isVMConfigSpecChanged := !reflect.DeepEqual(oldSpec, newSpec)
+	// Don't include the hardware version in the UpdateSpec. It is only needed
+	// when creating new VMs.
+	newSpec.Version = ""
+
 	// Return the new spec and compare
-	return newSpec, !reflect.DeepEqual(oldSpec, newSpec), nil
+	return newSpec, isVMConfigSpecChanged, nil
 }
 
 // getMemoryReservationLockedToMax determines if the memory_reservation is not


### PR DESCRIPTION
This PR fixes an issue reported in https://github.com/hashicorp/terraform-provider-vsphere/issues/1266. 

When a Virtual Machine is imported, and then a plan/apply is run without any changes to the template, the VM is started after apply. This started happening in **v1.17.4** and is still present in the latest provider.  This appears to be a side effect from a different fix https://github.com/hashicorp/terraform-provider-vsphere/pull/1055