### PR TITLE
Change vnic netstack property default value to 'defaultTcpipStack' as the 'default' value does not exist

### DIFF
--- a/vsphere/resource_vsphere_vnic.go
+++ b/vsphere/resource_vsphere_vnic.go
@@ -3,15 +3,16 @@ package vsphere
 import (
 	"context"
 	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"log"
-	"strconv"
-	"strings"
 )
 
 func resourceVsphereNic() *schema.Resource {
@@ -262,8 +263,8 @@ func BaseVMKernelSchema() map[string]*schema.Schema {
 		"netstack": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "TCP/IP stack setting for this interface. Possible values are 'default', 'vmotion', 'provisioning'",
-			Default:     "default",
+			Description: "TCP/IP stack setting for this interface. Possible values are 'defaultTcpipStack', 'vmotion', 'provisioning'",
+			Default:     "defaultTcpipStack",
 			ForceNew:    true,
 		},
 	}


### PR DESCRIPTION
### Description

Change default value to 'defaultTcpipStack' as the 'default' value does not exist

The test uses the correct value to test, which is why this probably went unnoticed.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added? 

The current test already is valid, however it overwrites the default value and as such this has gone unnoticed.

- [ ] Have you run the acceptance tests on this branch?

No, tests need a test vsphere cluster which I currently do not have available. However, this makes the code work as specified in the documentation: 

https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/vnic

netstack - (Optional) TCP/IP stack setting for this interface. Possible values are 'defaultTcpipStack', 'vmotion', 'vSphereProvisioning'. Changing this will force the creation of a new interface since it's not possible to change the stack once it gets created. (Default: defaultTcpipStack)

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
