### PR TITLE
vsphere_virtual_machine: added keepers param to force VM re-creation

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -253,6 +253,12 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			MaxItems:    1,
 			Elem:        &schema.Resource{Schema: vmworkflow.VirtualMachineOvfDeploySchema()},
 		},
+		"keepers": {
+			Description: "Arbitrary map of values that, when changed, will trigger recreation of the virtual machine.",
+			Type:        schema.TypeMap,
+			Optional:    true,
+			ForceNew:    true,
+		},
 		"reboot_required": {
 			Type:        schema.TypeBool,
 			Computed:    true,

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -674,6 +674,8 @@ and require vCenter.
 
 * `storage_policy_id` - (Optional) The UUID of the storage policy to assign to VM home directory.
 
+* `keepers` - (Optional) Arbitrary map of values that, when changed, will trigger recreation of the virtual machine.
+
 ### CPU and memory options
 
 The following options control CPU and memory settings on the virtual machine:


### PR DESCRIPTION
### Description

Added keepers param to force VM re-creation when needed.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added? No (Not needed)
- [ ] Have you run the acceptance tests on this branch? No


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
vsphere_virtual_machine: Added `keepers` param to force VM re-creation when needed.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
