### PR TITLE
Acceptance test simplification and related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ website/node_modules
 *~
 .*.swp
 .idea
+.vscode
 *.iml
 *.test
 *.iml

--- a/scripts/packet/devrc.tpl
+++ b/scripts/packet/devrc.tpl
@@ -1,0 +1,65 @@
+export TF_VAR_VCSA_DEPLOY_PATH="/tmp/vcsa/vcsa-cli-installer/mac/vcsa-deploy"
+export TF_VAR_PRIV_KEY='<your ssh key>'
+export TF_VAR_VSPHERE_REST_SESSION_PATH=$HOME/.govmomi/rest_sessions
+export TF_VAR_VSPHERE_VIM_SESSION_PATH=$HOME/.govmomi/sessions
+export TF_VAR_VSPHERE_LICENSE=00000-00000-00000-00000-00000 
+export TF_VAR_PACKET_PROJECT=00000000-0000-0000-0000-000000000000
+export TF_VAR_PACKET_AUTH=00000000000000000000000000000000
+#export TF_VAR_ESXI_VERSION="vmware_esxi_7_0"
+export TF_VAR_ESXI_VERSION="vmware_esxi_6_7"
+
+export TF_VAR_VSPHERE_NAS_HOST=${nas_host}
+export TF_VAR_VSPHERE_ESXI1=${esxi_host_1}
+export TF_VAR_VSPHERE_ESXI2=${esxi_host_2}
+export VSPHERE_SERVER=${vsphere_host}
+
+export TF_VAR_VSPHERE_VMFS_REGEXP='naa.6000c29[2b]'
+export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0="naa.6000c29b4b217432a854822b1bc40502"
+export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK1="naa.6000c29f3dbf773c6c25cb830dfc201b"
+
+export VSPHERE_USER="administrator@vcenter.vspheretest.internal"
+export VSPHERE_PASSWORD="Password123!"
+export VSPHERE_ALLOW_UNVERIFIED_SSL=true
+
+export TF_VAR_VSPHERE_SERVER=$VSPHERE_SERVER
+export TF_VAR_VSPHERE_USER=$VSPHERE_USER
+export TF_VAR_VSPHERE_PASSWORD=$VSPHERE_PASSWORD
+export TF_VAR_VSPHERE_ALLOW_UNVERIFIED_SSL=$VSPHERE_ALLOW_UNVERIFIED_SSL
+export TF_VAR_VSPHERE_ESXI_TRUNK_NIC=vmnic1
+export TF_VAR_VSPHERE_DATACENTER=hashidc
+export TF_VAR_VSPHERE_CLUSTER=c1
+export TF_VAR_VSPHERE_NFS_DS_NAME=nfs
+export TF_VAR_VSPHERE_NFS_DS_NAME1=nfs-vol1
+export TF_VAR_VSPHERE_NFS_DS_NAME2=nfs-vol2
+export TF_VAR_VSPHERE_DVS_NAME=terraform-test-dvs
+export TF_VAR_VSPHERE_PG_NAME='vmnet'
+export TF_VAR_VSPHERE_RESOURCE_POOL=hashi-resource-pool
+export TF_VAR_VSPHERE_NFS_PATH=/nfs
+export TF_VAR_VSPHERE_NFS_PATH1=/nfs/ds1
+export TF_VAR_VSPHERE_NFS_PATH2=/nfs/ds2
+export TF_VAR_VSPHERE_ISO_DATASTORE=nfs
+export TF_VAR_VSPHERE_ISO_FILE=fake.iso
+export TF_VAR_REMOTE_OVA_URL="https://storage.googleapis.com/acctest-images/tfvsphere_template.ova"
+export TF_VAR_VSPHERE_TEMPLATE=tfvsphere_template
+export TF_VAR_VSPHERE_INIT_TYPE=thin
+export TF_VAR_VSPHERE_ADAPTER_TYPE=lsiLogic
+export TF_VAR_VSPHERE_DC_FOLDER=dc-folder
+export TF_VAR_VSPHERE_DS_FOLDER=ds
+export TF_VAR_VSPHERE_USE_LINKED_CLONE=true
+export TF_VAR_VSPHERE_PERSIST_SESSION=true
+export TF_VAR_VSPHERE_CLONED_VM_DISK_SIZE=20
+export TF_VAR_VSPHERE_TEST_OVA="https://storage.googleapis.com/acctest-images/yVM.ova"
+export TF_VAR_VSPHERE_TEST_OVF="https://storage.googleapis.com/acctest-images/yVM.ovf"
+export TF_VAR_VSPHERE_CONTENT_LIBRARY_FILES="https://storage.googleapis.com/acctest-images/yVM.ovf"
+export TF_VAR_REMOTE_OVF_URL=https://acctest-images.storage.googleapis.com/tfvsphere_template.ovf
+
+export TF_VAR_VSPHERE_HOST_NIC0=vmnic0
+export TF_VAR_VSPHERE_HOST_NIC1=vmnic1
+
+
+export TF_VAR_VSPHERE_VSWITCH_UPPER_VERSION="7.0.0"
+export TF_VAR_VSPHERE_VSWITCH_LOWER_VERSION="6.5.0"
+export TF_VAR_VSPHERE_DS_VMFS_NAME='ds-001'
+export TF_VAR_VSPHERE_VM_V1_PATH='pxe-server'
+export TF_VAR_VSPHERE_FOLDER_V0_PATH='Discovered virtual machine'
+export TF_VAR_VSPHERE_ENTITY_PERMISSION_USER_GROUP="root"

--- a/scripts/packet/main.tf.phase1
+++ b/scripts/packet/main.tf.phase1
@@ -30,6 +30,28 @@ variable "PACKET_PROJECT" {}
 
 variable "PRIV_KEY" {}
 
+variable "VCSA_DEPLOY_PATH" {}
+
+variable "ESXI_VERSION" {
+  default = "vmware_esxi_6_7"
+}
+
+variable "PACKET_FACILITY" {
+  default = "sjc1"
+}
+
+variable ESXI_PLAN {
+  default = "c3.medium.x86"
+}
+
+variable STORAGE_PLAN {
+  default = "c1.small.x86"
+}
+
+variable LAB_PREFIX {
+  default = ""
+}
+
 provider "packet" {
   auth_token = var.PACKET_AUTH
 }
@@ -46,10 +68,10 @@ provider "vsphere" {
 }
 
 resource "packet_device" "esxi1" {
-  hostname         = "esxi1.vspheretest.internal"
-  plan             = "c3.medium.x86"
-  facilities         = ["sjc1"]
-  operating_system = "vmware_esxi_6_7"
+  hostname         = "${var.LAB_PREFIX}esxi1.vspheretest.internal"
+  plan             = var.ESXI_PLAN
+  facilities       = [var.PACKET_FACILITY]
+  operating_system = var.ESXI_VERSION
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -60,10 +82,10 @@ resource "packet_device_network_type" "esxi1" {
 }
 
 resource "packet_device" "esxi2" {
-  hostname         = "esxi2.vspheretest.internal"
-  plan             = "c3.medium.x86"
-  facilities         = ["sjc1"]
-  operating_system = "vmware_esxi_6_7"
+  hostname         = "${var.LAB_PREFIX}esxi2.vspheretest.internal"
+  plan             = var.ESXI_PLAN
+  facilities       = [var.PACKET_FACILITY]
+  operating_system = var.ESXI_VERSION
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -74,36 +96,56 @@ resource "packet_device_network_type" "esxi2" {
 }
 
 resource "packet_device" "storage1" {
-  hostname         = "storage1.vspheretest.internal"
-  plan             = "c1.small.x86"
-  facilities         = ["sjc1"]
+  hostname         = "${var.LAB_PREFIX}storage1.vspheretest.internal"
+  plan             = var.STORAGE_PLAN
+  facilities       = [var.PACKET_FACILITY]
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
   provisioner "remote-exec" {
     inline = [
-      "mkdir /nfs",
+      "mkdir -p /nfs/ds1 /nfs/ds2 /nfs/ds2 /nfs/ds3",
       "apt-get update",
       "apt-get install nfs-common nfs-kernel-server -y",
       "echo \"/nfs *(rw,no_root_squash)\" > /etc/exports",
+      "echo \"/nfs/ds1 *(rw,no_root_squash)\" >> /etc/exports",
+      "echo \"/nfs/ds2 *(rw,no_root_squash)\" >> /etc/exports",
+      "echo \"/nfs/ds3 *(rw,no_root_squash)\" >> /etc/exports",
       "exportfs -a",
     ]
     connection {
       host = packet_device.storage1.network.0.address
-      private_key = var.PRIV_KEY
+      private_key = file(var.PRIV_KEY)
     }
   }
 }
 
+resource "packet_vlan" "vmvlan" {
+  facility   = var.PACKET_FACILITY
+  project_id = local.project_id
+}
+
+resource "packet_port_vlan_attachment" "vmvlan_esxi1" {
+  device_id = packet_device.esxi1.id
+  port_name = "eth1"
+  vlan_vnid = packet_vlan.vmvlan.vxlan
+}
+
+resource "packet_port_vlan_attachment" "vmvlan_esxi2" {
+  device_id = packet_device.esxi2.id
+  port_name = "eth1"
+  vlan_vnid = packet_vlan.vmvlan.vxlan
+}
+
 data "packet_precreated_ip_block" "private" {
-  facility         = "sjc1"
+  facility         = var.PACKET_FACILITY
   project_id       = local.project_id
   address_family   = 4
   public           = false
 }
 
 data "packet_precreated_ip_block" "public" {
-  facility         = "sjc1"
+  facility         = var.PACKET_FACILITY
   project_id       = local.project_id
   address_family   = 4
   public           = true
@@ -137,10 +179,21 @@ resource "local_file" "vcsa_template" {
   })
   filename = "./tmp/vcsa.json"
   provisioner "local-exec" {
-    command = "sleep 290; echo five more; sleep 290; TERM=xterm-256color ./tmp/mnt/vcsa-cli-installer/lin64/vcsa-deploy install --accept-eula --acknowledge-ceip --no-ssl-certificate-verification --verbose --skip-ovftool-verification ./tmp/vcsa.json"
+    command = "sleep 290; echo five more; sleep 290; TERM=xterm-256color ${var.VCSA_DEPLOY_PATH} install --accept-eula --acknowledge-ceip --no-ssl-certificate-verification --verbose --skip-ovftool-verification $(pwd)/tmp/vcsa.json"
   }
 }
 
 output "ip" {
   value = cidrhost("${packet_device.esxi1.network.0.address}/${packet_device.esxi1.network.0.cidr}",3)
+}
+
+resource "local_file" "devrc" {
+  sensitive_content = templatefile("${path.cwd}/devrc.tpl", {
+    nas_host    = packet_device.storage1.network.0.address
+    esxi_host_1 = packet_device.esxi1.network.0.address
+    esxi_host_2 = packet_device.esxi2.network.0.address
+    vsphere_host = cidrhost("${packet_device.esxi1.network.0.address}/${packet_device.esxi1.network.0.cidr}",3)
+
+  })
+  filename = "./devrc"
 }

--- a/scripts/packet/main.tf.phase2
+++ b/scripts/packet/main.tf.phase2
@@ -30,6 +30,21 @@ variable "PACKET_PROJECT" {}
 
 variable "PRIV_KEY" {}
 
+variable "ESXI_VERSION" {
+  default = "vmware_esxi_6_7"
+}
+variable "PACKET_FACILITY" {
+  default = "sjc1"
+}
+
+variable ESXI_PLAN {
+  default = "c3.medium.x86"
+}
+
+variable STORAGE_PLAN {
+  default = "c1.small.x86"
+}
+
 provider "packet" {
   auth_token = var.PACKET_AUTH
 }
@@ -53,9 +68,9 @@ data "packet_device" "esxi1" {
 
 resource "packet_device" "esxi1" {
   hostname         = "esxi1.vspheretest.internal"
-  plan             = "c3.medium.x86"
-  facilities         = ["sjc1"]
-  operating_system = "vmware_esxi_6_7"
+  plan             = var.ESXI_PLAN
+  facilities       = [var.PACKET_FACILITY]
+  operating_system = var.ESXI_VERSION
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -67,9 +82,9 @@ resource "packet_device_network_type" "esxi1" {
 
 resource "packet_device" "esxi2" {
   hostname         = "esxi2.vspheretest.internal"
-  plan             = "c3.medium.x86"
-  facilities         = ["sjc1"]
-  operating_system = "vmware_esxi_6_7"
+  plan             = var.ESXI_PLAN
+  facilities       = [var.PACKET_FACILITY]
+  operating_system = var.ESXI_VERSION
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -81,35 +96,55 @@ resource "packet_device_network_type" "esxi2" {
 
 resource "packet_device" "storage1" {
   hostname         = "storage1.vspheretest.internal"
-  plan             = "c1.small.x86"
-  facilities         = ["sjc1"]
+  plan             = var.STORAGE_PLAN
+  facilities       = [var.PACKET_FACILITY]
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
   provisioner "remote-exec" {
     inline = [
-      "mkdir /nfs",
+      "mkdir -p /nfs/ds1 /nfs/ds2 /nfs/ds2 /nfs/ds3",
       "apt-get update",
       "apt-get install nfs-common nfs-kernel-server -y",
       "echo \"/nfs *(rw,no_root_squash)\" > /etc/exports",
+      "echo \"/nfs/ds1 *(rw,no_root_squash)\" >> /etc/exports",
+      "echo \"/nfs/ds2 *(rw,no_root_squash)\" >> /etc/exports",
+      "echo \"/nfs/ds3 *(rw,no_root_squash)\" >> /etc/exports",
       "exportfs -a",
     ]
     connection {
       host = packet_device.storage1.network.0.address
-      private_key = var.PRIV_KEY
+      private_key = file(var.PRIV_KEY)
     }
   }
 }
 
+resource "packet_vlan" "vmvlan" {
+  facility   = var.PACKET_FACILITY
+  project_id = local.project_id
+}
+
+resource "packet_port_vlan_attachment" "vmvlan_esxi1" {
+  device_id = packet_device.esxi1.id
+  port_name = "eth1"
+  vlan_vnid = packet_vlan.vmvlan.vxlan
+}
+
+resource "packet_port_vlan_attachment" "vmvlan_esxi2" {
+  device_id = packet_device.esxi2.id
+  port_name = "eth1"
+  vlan_vnid = packet_vlan.vmvlan.vxlan
+}
+
 data "packet_precreated_ip_block" "private" {
-  facility         = "sjc1"
+  facility         = var.PACKET_FACILITY
   project_id       = local.project_id
   address_family   = 4
   public           = false
 }
 
 data "packet_precreated_ip_block" "public" {
-  facility         = "sjc1"
+  facility         = var.PACKET_FACILITY
   project_id       = local.project_id
   address_family   = 4
   public           = true
@@ -200,4 +235,28 @@ resource "vsphere_host" "host2" {
   force      = true
   cluster    = vsphere_compute_cluster.compute_cluster.id
   thumbprint = data.vsphere_host_thumbprint.esxi2.id
+}
+
+resource "local_file" "devrc" {
+  sensitive_content = templatefile("${path.cwd}/devrc.tpl", {
+    nas_host    = packet_device.storage1.network.0.address
+    esxi_host_1 = packet_device.esxi1.network.0.address
+    esxi_host_2 = packet_device.esxi2.network.0.address
+    vsphere_host = cidrhost("${packet_device.esxi1.network.0.address}/${packet_device.esxi1.network.0.cidr}",3)
+
+  })
+  filename = "./devrc"
+}
+
+resource "vsphere_content_library" "nested-library" {
+  name            = "nested esxi content library"
+  storage_backing = [vsphere_nas_datastore.ds.id]
+  description     = "https://www.virtuallyghetto.com/2015/04/subscribe-to-vghetto-nested-esxi-template-content-library-in-vsphere-6-0.html"
+}
+
+resource "vsphere_content_library_item" "n-esxi" {
+  name        = "nested esxi vm"
+  description = "nested esxi template"
+  library_id  = vsphere_content_library.nested-library.id
+  file_url = "https://s3-us-west-1.amazonaws.com/vghetto-content-library/Nested-ESXi-VM-Template/Nested-ESXi-VM-Template.ovf"
 }

--- a/scripts/packet/main.tf.phase3
+++ b/scripts/packet/main.tf.phase3
@@ -30,6 +30,26 @@ variable "PACKET_PROJECT" {}
 
 variable "PRIV_KEY" {}
 
+variable "ESXI_VERSION" {
+  default = "vmware_esxi_6_7"
+}
+
+variable "PACKET_FACILITY" {
+  default = "sjc1"
+}
+
+variable ESXI_PLAN {
+  default = "c3.medium.x86"
+}
+
+variable STORAGE_PLAN {
+  default = "c1.small.x86"
+}
+
+variable LAB_PREFIX {
+  default = ""
+}
+
 provider "packet" {
   auth_token = var.PACKET_AUTH
 }
@@ -41,21 +61,25 @@ provider "vsphere" {
   allow_unverified_ssl = true
 }
 
+output "hostname" {
+    value = cidrhost("${data.packet_device.esxi1.network.0.address}/${data.packet_device.esxi1.network.0.cidr}",3)
+}
+
 locals {
   project_id = var.PACKET_PROJECT
 }
 
 data "packet_device" "esxi1" {
   project_id = local.project_id
-  hostname       = "esxi1.vspheretest.internal"
+  hostname       = "${var.LAB_PREFIX}esxi1.vspheretest.internal"
 }
 
 
 resource "packet_device" "esxi1" {
-  hostname         = "esxi1.vspheretest.internal"
-  plan             = "c3.medium.x86"
-  facilities         = ["sjc1"]
-  operating_system = "vmware_esxi_6_7"
+  hostname         = "${var.LAB_PREFIX}esxi1.vspheretest.internal"
+  plan             = var.ESXI_PLAN
+  facilities       = [var.PACKET_FACILITY]
+  operating_system = var.ESXI_VERSION
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -66,10 +90,10 @@ resource "packet_device_network_type" "esxi1" {
 }
 
 resource "packet_device" "esxi2" {
-  hostname         = "esxi2.vspheretest.internal"
-  plan             = "c3.medium.x86"
-  facilities         = ["sjc1"]
-  operating_system = "vmware_esxi_6_7"
+  hostname         = "${var.LAB_PREFIX}esxi2.vspheretest.internal"
+  plan             = var.ESXI_PLAN
+  facilities       = [var.PACKET_FACILITY]
+  operating_system = var.ESXI_VERSION
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -80,36 +104,56 @@ resource "packet_device_network_type" "esxi2" {
 }
 
 resource "packet_device" "storage1" {
-  hostname         = "storage1.vspheretest.internal"
-  plan             = "c1.small.x86"
-  facilities         = ["sjc1"]
+  hostname         = "${var.LAB_PREFIX}storage1.vspheretest.internal"
+  plan             = var.STORAGE_PLAN
+  facilities       = [var.PACKET_FACILITY]
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
   provisioner "remote-exec" {
     inline = [
-      "mkdir /nfs",
+      "mkdir -p /nfs/ds1 /nfs/ds2 /nfs/ds2 /nfs/ds3",
       "apt-get update",
       "apt-get install nfs-common nfs-kernel-server -y",
       "echo \"/nfs *(rw,no_root_squash)\" > /etc/exports",
+      "echo \"/nfs/ds1 *(rw,no_root_squash)\" >> /etc/exports",
+      "echo \"/nfs/ds2 *(rw,no_root_squash)\" >> /etc/exports",
+      "echo \"/nfs/ds3 *(rw,no_root_squash)\" >> /etc/exports",
       "exportfs -a",
     ]
     connection {
       host = packet_device.storage1.network.0.address
-      private_key = var.PRIV_KEY
+      private_key = file(var.PRIV_KEY)
     }
   }
 }
 
+resource "packet_vlan" "vmvlan" {
+  facility   = var.PACKET_FACILITY
+  project_id = local.project_id
+}
+
+resource "packet_port_vlan_attachment" "vmvlan_esxi1" {
+  device_id = packet_device.esxi1.id
+  port_name = "eth1"
+  vlan_vnid = packet_vlan.vmvlan.vxlan
+}
+
+resource "packet_port_vlan_attachment" "vmvlan_esxi2" {
+  device_id = packet_device.esxi2.id
+  port_name = "eth1"
+  vlan_vnid = packet_vlan.vmvlan.vxlan
+}
+
 data "packet_precreated_ip_block" "private" {
-  facility         = "sjc1"
+  facility         = var.PACKET_FACILITY
   project_id       = local.project_id
   address_family   = 4
   public           = false
 }
 
 data "packet_precreated_ip_block" "public" {
-  facility         = "sjc1"
+  facility         = var.PACKET_FACILITY
   project_id       = local.project_id
   address_family   = 4
   public           = true
@@ -249,7 +293,7 @@ resource "vsphere_virtual_machine" "pxe" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "ubuntu64Guest"
+  guest_id = "other3xLinux64Guest"
 
   network_interface {
     network_id = data.vsphere_network.vmnet.id
@@ -271,3 +315,26 @@ resource "vsphere_virtual_machine" "pxe" {
   }
 }
 
+resource "local_file" "devrc" {
+  sensitive_content = templatefile("${path.cwd}/devrc.tpl", {
+    nas_host    = packet_device.storage1.network.0.address
+    esxi_host_1 = packet_device.esxi1.network.0.address
+    esxi_host_2 = packet_device.esxi2.network.0.address
+    vsphere_host = cidrhost("${packet_device.esxi1.network.0.address}/${packet_device.esxi1.network.0.cidr}",3)
+
+  })
+  filename = "./devrc"
+}
+
+resource "vsphere_content_library" "nested-library" {
+  name            = "nested esxi content library"
+  storage_backing = [vsphere_nas_datastore.ds.id]
+  description     = "https://www.virtuallyghetto.com/2015/04/subscribe-to-vghetto-nested-esxi-template-content-library-in-vsphere-6-0.html"
+}
+
+resource "vsphere_content_library_item" "n-esxi" {
+  name        = "nested esxi vm"
+  description = "nested esxi template"
+  library_id  = vsphere_content_library.nested-library.id
+  file_url = "https://s3-us-west-1.amazonaws.com/vghetto-content-library/Nested-ESXi-VM-Template/Nested-ESXi-VM-Template.ovf"
+}

--- a/scripts/packet/vcsa_deploy.json
+++ b/scripts/packet/vcsa_deploy.json
@@ -15,11 +15,7 @@
             ],
             "thin_disk_mode": true,
             "deployment_option": "tiny",
-            "name": "vcsa",
-            "image": "https://storage.googleapis.com/acctest-images/VMware-vCenter-Server-Appliance-6.7.0.43000-15976714_OVF10.ova",
-             "image_url_ssl_certificate_verification": {
-               "verification_mode": "NONE"              
-             }
+            "name": "vcsa"
         },
         "network": {
             "ip_family": "ipv4",

--- a/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
@@ -2,8 +2,10 @@ package vsphere
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
@@ -27,12 +29,12 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.0",
-						"tfup1",
+						os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 					),
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.1",
-						"tfup2",
+						os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 					),
 					resource.TestCheckResourceAttrPair(
 						"data.vsphere_distributed_virtual_switch.dvs-data", "id",
@@ -63,12 +65,12 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSp
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.0",
-						"tfup1",
+						os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 					),
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.1",
-						"tfup2",
+						os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 					),
 					resource.TestCheckResourceAttrPair(
 						"data.vsphere_distributed_virtual_switch.dvs-data", "id",
@@ -104,12 +106,12 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup(t *testing
 					resource.TestCheckResourceAttr(
 						"vsphere_distributed_port_group.pg",
 						"active_uplinks.0",
-						"tfup1",
+						os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 					),
 					resource.TestCheckResourceAttr(
 						"vsphere_distributed_port_group.pg",
 						"standby_uplinks.0",
-						"tfup2",
+						os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 					),
 				),
 			},
@@ -124,7 +126,7 @@ func testAccDataSourceVSphereDistributedVirtualSwitchConfig() string {
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-  uplinks       = ["tfup1", "tfup2"]
+  uplinks       = ["%s", "%s"]
 }
 
 data "vsphere_distributed_virtual_switch" "dvs-data" {
@@ -133,6 +135,8 @@ data "vsphere_distributed_virtual_switch" "dvs-data" {
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 	)
 }
 
@@ -143,7 +147,7 @@ func testAccDataSourceVSphereDistributedVirtualSwitchConfigWithPortgroup() strin
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-  uplinks       = ["tfup1", "tfup2"]
+  uplinks       = ["%s", "%s"]
 }
 
 data "vsphere_distributed_virtual_switch" "dvs-data" {
@@ -160,6 +164,8 @@ resource "vsphere_distributed_port_group" "pg" {
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 	)
 }
 
@@ -170,7 +176,7 @@ func testAccDataSourceVSphereDistributedVirtualSwitchConfigAbsolute() string {
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-  uplinks       = ["tfup1", "tfup2"]
+  uplinks       = ["%s", "%s"]
 }
 
 data "vsphere_distributed_virtual_switch" "dvs-data" {
@@ -178,5 +184,7 @@ data "vsphere_distributed_virtual_switch" "dvs-data" {
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 	)
 }

--- a/vsphere/data_source_vsphere_host_test.go
+++ b/vsphere/data_source_vsphere_host_test.go
@@ -2,10 +2,11 @@ package vsphere
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
@@ -44,7 +45,7 @@ func TestAccDataSourceVSphereHost_defaultHost(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceVSphereHostConfigDefault,
+				Config: testAccDataSourceVSphereHostConfigDefault(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"data.vsphere_host.host",
@@ -84,10 +85,11 @@ data "vsphere_host" "host" {
 `, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }
 
-const testAccDataSourceVSphereHostConfigDefault = `
-data "vsphere_datacenter" "dc" {}
+func testAccDataSourceVSphereHostConfigDefault() string {
+	return fmt.Sprintf(`
+%s
 
 data "vsphere_host" "host" {
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
+}`, testhelper.ConfigDataRootDC1())
 }
-`

--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -760,7 +760,7 @@ func schemaDVSCreateSpec() map[string]*schema.Schema {
 		"version": {
 			Type:         schema.TypeString,
 			Computed:     true,
-			Description:  "The version of this virtual switch. Allowed versions are 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
+			Description:  "The version of this virtual switch. Allowed versions are 7.0.0, 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice(dvsVersions, false),
 		},

--- a/vsphere/host_nas_volume_structure.go
+++ b/vsphere/host_nas_volume_structure.go
@@ -1,6 +1,8 @@
 package vsphere
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure"
@@ -91,18 +93,25 @@ func schemaHostNasVolumeSpec() map[string]*schema.Schema {
 
 // expandHostNasVolumeSpec reads certain ResourceData keys and returns a
 // HostNasVolumeSpec.
-func expandHostNasVolumeSpec(d *schema.ResourceData) *types.HostNasVolumeSpec {
+func expandHostNasVolumeSpec(d *schema.ResourceData) (*types.HostNasVolumeSpec, error) {
+	remoteHosts := d.Get("remote_hosts").([]interface{})
+	var remoteHost string
+	if len(remoteHosts) == 0 || (len(remoteHosts) > 0 && remoteHosts[0] == nil) {
+		return nil, fmt.Errorf("remote hosts cannot be empty")
+	} else {
+		remoteHost = remoteHosts[0].(string)
+	}
 	obj := &types.HostNasVolumeSpec{
 		AccessMode:      d.Get("access_mode").(string),
 		LocalPath:       d.Get("name").(string),
-		RemoteHost:      structure.SliceInterfacesToStrings(d.Get("remote_hosts").([]interface{}))[0],
+		RemoteHost:      remoteHost,
 		RemoteHostNames: structure.SliceInterfacesToStrings(d.Get("remote_hosts").([]interface{})),
 		RemotePath:      d.Get("remote_path").(string),
 		SecurityType:    d.Get("security_type").(string),
 		Type:            d.Get("type").(string),
 	}
 
-	return obj
+	return obj, nil
 }
 
 // flattenHostNasVolume reads various fields from a HostNasVolume into the

--- a/vsphere/internal/helper/testhelper/testing.go
+++ b/vsphere/internal/helper/testhelper/testing.go
@@ -136,16 +136,34 @@ data "vsphere_host" "roothost2" {
 `, os.Getenv("TF_VAR_VSPHERE_ESXI2"))
 }
 
+func ConfigDataRootHost3() string {
+	return fmt.Sprintf(`
+data "vsphere_host" "roothost3" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_ESXI3"))
+}
+
+func ConfigDataRootHost4() string {
+	return fmt.Sprintf(`
+data "vsphere_host" "roothost4" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_ESXI4"))
+}
+
 func ConfigResDS1() string {
 	return fmt.Sprintf(`
 resource "vsphere_nas_datastore" "ds1" {
-  name            = "testacc-nfsds1"
+  name            = "%s"
   host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
   type            = "NFS"
   remote_hosts    = ["%s"]
   remote_path     = "%s"
 }
-`, os.Getenv("TF_VAR_VSPHERE_NAS_HOST"), os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"))
+`, os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"), os.Getenv("TF_VAR_VSPHERE_NAS_HOST"), os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"))
 }
 
 func ConfigDataRootComputeCluster1() string {
@@ -198,8 +216,8 @@ resource "vsphere_virtual_machine" "nested-esxi1" {
   enable_disk_uuid  = true
 
   num_cpus = 2
-  memory   = 6144
-  guest_id = "other3xLinux64Guest"
+  memory   = 8192
+  guest_id = "vmkernel65Guest"
 
   wait_for_guest_ip_timeout  = 5
   wait_for_guest_net_timeout = -1
@@ -209,24 +227,10 @@ resource "vsphere_virtual_machine" "nested-esxi1" {
   }
 
   ovf_deploy {
-    remote_ovf_url = "https://download3.vmware.com/software/vmw-tools/Nested_ESXi6.7u3_Appliance_Template_v1.0/Nested_ESXi6.7u3_Appliance_Template_v1.ovf"
+    remote_ovf_url = "%s"
     ovf_network_map = {
       "VM Network" = data.vsphere_network.vmnet.id
     }
-  }
-  disk {
-    label = "disk0"
-    size  = 2
-  }
-
-  disk {
-    label = "disk1"
-    size  = 4
-  }
-
-  disk {
-    label = "disk2"
-    size  = 8
   }
 
   cdrom {
@@ -236,6 +240,7 @@ resource "vsphere_virtual_machine" "nested-esxi1" {
 
 data "vsphere_host_thumbprint" "thumb" {
   address = vsphere_virtual_machine.nested-esxi1.default_ip_address
+  insecure = true
 }
 
 resource "vsphere_host" "nested-esxi1" {
@@ -247,5 +252,5 @@ resource "vsphere_host" "nested-esxi1" {
   thumbprint                 = data.vsphere_host_thumbprint.thumb.id
   datacenter                 = data.vsphere_datacenter.rootdc1.id
 }
-`, os.Getenv("TF_VAR_VSPHERE_LICENSE"))
+`, os.Getenv("TF_VAR_VSPHERE_ESXI_OVF_URL"), os.Getenv("TF_VAR_VSPHERE_LICENSE"))
 }

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 	"github.com/vmware/govmomi/vim25/types"
@@ -45,7 +44,7 @@ func TestAccResourceVSphereComputeCluster_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					cluster, err := testGetComputeCluster(s, "compute_cluster")
+					cluster, err := testGetComputeCluster(s, "compute_cluster", resourceVSphereComputeClusterName)
 					if err != nil {
 						return "", err
 					}
@@ -121,7 +120,7 @@ func TestAccResourceVSphereComputeCluster_explicitFailoverHost(t *testing.T) {
 					testAccResourceVSphereComputeClusterCheckDRSEnabled(true),
 					testAccResourceVSphereComputeClusterCheckHAEnabled(true),
 					testAccResourceVSphereComputeClusterCheckAdmissionControlMode(clusterAdmissionControlTypeFailoverHosts),
-					testAccResourceVSphereComputeClusterCheckAdmissionControlFailoverHost(os.Getenv("TF_VAR_VSPHERE_ESXI_HOST1")),
+					testAccResourceVSphereComputeClusterCheckAdmissionControlFailoverHost(os.Getenv("TF_VAR_VSPHERE_ESXI3")),
 				),
 			},
 		},
@@ -349,11 +348,11 @@ func testAccResourceVSphereComputeClusterPreCheck(t *testing.T) {
 	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
 		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_compute_cluster acceptance tests")
 	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_compute_cluster acceptance tests")
+	if os.Getenv("TF_VAR_VSPHERE_ESXI3") == "" {
+		t.Skip("set TF_VAR_VSPHERE_ESXI3 to run vsphere_compute_cluster acceptance tests")
 	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI2") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI2 to run vsphere_compute_cluster acceptance tests")
+	if os.Getenv("TF_VAR_VSPHERE_ESXI4") == "" {
+		t.Skip("set TF_VAR_VSPHERE_ESXI4 to run vsphere_compute_cluster acceptance tests")
 	}
 	if os.Getenv("TF_VAR_VSPHERE_PG_NAME") == "" {
 		t.Skip("set TF_VAR_VSPHERE_PG_NAME to run vsphere_virtual_machine acceptance tests")
@@ -365,7 +364,7 @@ func testAccResourceVSphereComputeClusterPreCheck(t *testing.T) {
 
 func testAccResourceVSphereComputeClusterCheckExists(expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, err := testGetComputeCluster(s, "compute_cluster")
+		_, err := testGetComputeCluster(s, "compute_cluster", resourceVSphereComputeClusterName)
 		if err != nil {
 			if viapi.IsManagedObjectNotFoundError(err) && expected == false {
 				// Expected missing
@@ -465,7 +464,7 @@ func testAccResourceVSphereComputeClusterCheckAdmissionControlFailoverHost(expec
 			return fmt.Errorf("expected failover host name to be %s, got %s", expected, actual)
 		}
 
-		if failoverHostsPolicy.ResourceReductionToToleratePercent != structure.Int32Ptr(0) {
+		if *failoverHostsPolicy.ResourceReductionToToleratePercent != 0 {
 			return fmt.Errorf("expected ha_admission_control_performance_tolerance be 0, got %d", failoverHostsPolicy.ResourceReductionToToleratePercent)
 		}
 
@@ -475,7 +474,7 @@ func testAccResourceVSphereComputeClusterCheckAdmissionControlFailoverHost(expec
 
 func testAccResourceVSphereComputeClusterCheckName(expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		cluster, err := testGetComputeCluster(s, "compute_cluster")
+		cluster, err := testGetComputeCluster(s, "compute_cluster", resourceVSphereComputeClusterName)
 		if err != nil {
 			return err
 		}
@@ -489,7 +488,7 @@ func testAccResourceVSphereComputeClusterCheckName(expected string) resource.Tes
 
 func testAccResourceVSphereComputeClusterMatchInventoryPath(expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		cluster, err := testGetComputeCluster(s, "compute_cluster")
+		cluster, err := testGetComputeCluster(s, "compute_cluster", resourceVSphereComputeClusterName)
 		if err != nil {
 			return err
 		}
@@ -522,7 +521,7 @@ func testAccResourceVSphereComputeClusterCheckDRSDefaultAutomationLevel(expected
 
 func testAccResourceVSphereComputeClusterCheckTags(tagResName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		cluster, err := testGetComputeCluster(s, "compute_cluster")
+		cluster, err := testGetComputeCluster(s, "compute_cluster", resourceVSphereComputeClusterName)
 		if err != nil {
 			return err
 		}
@@ -561,30 +560,25 @@ func testAccResourceVSphereComputeClusterConfigHAAdmissionControlPolicyDisabled(
 	return fmt.Sprintf(`
 %s
 
-variable "hosts" {
-  default = [
-    "%s",
-  ]
-}
-
-data "vsphere_host" "hosts" {
-  count         = "${length(var.hosts)}"
-  name          = "${var.hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_compute_cluster" "compute_cluster" {
   name                        = "testacc-compute-cluster"
   datacenter_id               = "${data.vsphere_datacenter.rootdc1.id}"
-  host_system_ids             = "${data.vsphere_host.hosts.*.id}"
+  host_system_ids             = [data.vsphere_host.roothost3.id]
   ha_enabled                  = true
   ha_admission_control_policy = "disabled"
 
   force_evacuate_on_destroy = true
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1(), testhelper.ConfigResNestedEsxi()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_NESTED1"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigDataRootDS1(),
+			testhelper.ConfigDataRootVMNet(),
+		),
 	)
 }
 
@@ -592,44 +586,26 @@ func testAccResourceVSphereComputeClusterConfigBasic() string {
 	return fmt.Sprintf(`
 %s
 
-data "vsphere_host" "hosts" {
-  count         = 1
-  name          = vsphere_host.nested-esxi1.hostname
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
-
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
   datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
-  host_system_ids = [ vsphere_host.nested-esxi1.name ]
+  host_system_ids = [ data.vsphere_host.roothost3.id ]
 
   force_evacuate_on_destroy = true
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1(), testhelper.ConfigResNestedEsxi(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigDataRootVMNet()),
-	)
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3()))
 }
 
 func testAccResourceVSphereComputeClusterConfigDRSHABasic() string {
 	return fmt.Sprintf(`
 %s
 
-variable "hosts" {
-  default = [
-    "%s",
-  ]
-}
-
-data "vsphere_host" "hosts" {
-  count         = "${length(var.hosts)}"
-  name          = "${var.hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
   datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
-  host_system_ids = "${data.vsphere_host.hosts.*.id}"
+  host_system_ids = [data.vsphere_host.roothost3.id]
 
   drs_enabled          = true
   drs_automation_level = "fullyAutomated"
@@ -639,8 +615,15 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 	force_evacuate_on_destroy = true
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1(), testhelper.ConfigResNestedEsxi()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_NESTED1"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigDataRootDS1(),
+			testhelper.ConfigDataRootVMNet(),
+		),
 	)
 }
 
@@ -648,36 +631,31 @@ func testAccResourceVSphereComputeClusterConfigDRSHABasicExplicitFailoverHost() 
 	return fmt.Sprintf(`
 %s
 
-variable "hosts" {
-  default = [
-    "%s",
-  ]
-}
-
-data "vsphere_host" "hosts" {
-  count         = "${length(var.hosts)}"
-  name          = "${var.hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
   datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
-  host_system_ids = "${data.vsphere_host.hosts.*.id}"
+  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
   drs_enabled          = true
   drs_automation_level = "fullyAutomated"
 
   ha_enabled                                    = true
   ha_admission_control_policy                   = "failoverHosts"
-  ha_admission_control_failover_host_system_ids = "${data.vsphere_host.hosts.*.id}"
+  ha_admission_control_failover_host_system_ids = [data.vsphere_host.roothost3.id]
   ha_admission_control_performance_tolerance    = 0
 
   force_evacuate_on_destroy = true
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1(), testhelper.ConfigResNestedEsxi()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_NESTED1"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigDataRootDS1(),
+			testhelper.ConfigDataRootVMNet(),
+		),
 	)
 }
 

--- a/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -46,7 +47,7 @@ func TestAccResourceVSphereComputeClusterVMAffinityRule_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					cluster, err := testGetComputeClusterFromDataSource(s, "cluster")
+					cluster, err := testGetComputeClusterFromDataSource(s, "rootcompute_cluster1")
 					if err != nil {
 						return "", err
 					}
@@ -341,7 +342,14 @@ resource "vsphere_compute_cluster_vm_affinity_rule" "cluster_vm_affinity_rule" {
 	enabled             = %t
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigResDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigResResourcePool1(),
+			testhelper.ConfigDataRootPortGroup1()),
 		count,
 		enabled,
 	)

--- a/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -46,7 +47,7 @@ func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic(t *testing.T) 
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					cluster, err := testGetComputeClusterFromDataSource(s, "cluster")
+					cluster, err := testGetComputeClusterFromDataSource(s, "rootcompute_cluster1")
 					if err != nil {
 						return "", err
 					}
@@ -341,7 +342,14 @@ resource "vsphere_compute_cluster_vm_anti_affinity_rule" "cluster_vm_anti_affini
 	enabled             = %t
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigResDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigResResourcePool1(),
+			testhelper.ConfigDataRootPortGroup1()),
 		count,
 		enabled,
 	)

--- a/vsphere/resource_vsphere_compute_cluster_vm_group_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_group_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -41,7 +42,7 @@ func TestAccResourceVSphereComputeClusterVMGroup_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					cluster, err := testGetComputeClusterFromDataSource(s, "cluster")
+					cluster, err := testGetComputeClusterFromDataSource(s, "rootcompute_cluster1")
 					if err != nil {
 						return "", err
 					}
@@ -253,7 +254,14 @@ resource "vsphere_compute_cluster_vm_group" "cluster_vm_group" {
   virtual_machine_ids = "${vsphere_virtual_machine.vm.*.id}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigResDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigResResourcePool1(),
+			testhelper.ConfigDataRootPortGroup1()),
 		count,
 	)
 }

--- a/vsphere/resource_vsphere_datacenter_test.go
+++ b/vsphere/resource_vsphere_datacenter_test.go
@@ -21,13 +21,13 @@ resource "vsphere_datacenter" "testDC" {
 
 const testAccCheckVSphereDatacenterConfigSubfolder = `
 resource "vsphere_folder" "folder" {
-  name = "%s"
+  path = "%s"
   type = "datacenter"
 }
 
 resource "vsphere_datacenter" "testDC" {
   name   = "testDC"
-  folder = vsphere_folder.folder.name
+  folder = vsphere_folder.folder.path
 }
 `
 

--- a/vsphere/resource_vsphere_distributed_port_group.go
+++ b/vsphere/resource_vsphere_distributed_port_group.go
@@ -227,7 +227,7 @@ func resourceVSphereDistributedPortGroupImport(d *schema.ResourceData, meta inte
 		return nil, err
 	}
 	moId := d.Id()
-	pg, err := dvportgroup.FromMOID(client, moId)
+	pg, err := dvportgroup.FromPath(client, moId, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error locating portgroup: %s", err)
 	}

--- a/vsphere/resource_vsphere_distributed_port_group_test.go
+++ b/vsphere/resource_vsphere_distributed_port_group_test.go
@@ -2,8 +2,9 @@ package vsphere
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -280,7 +281,7 @@ resource "vsphere_distributed_port_group" "pg" {
   distributed_virtual_switch_uuid = "${vsphere_distributed_virtual_switch.dvs.id}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1()),
 	)
 }
 

--- a/vsphere/resource_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_test.go
@@ -3,11 +3,12 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"path"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -113,9 +114,9 @@ func TestAccResourceVSphereDistributedVirtualSwitch_standbyWithExplicitFailoverO
 				Config: testAccResourceVSphereDistributedVirtualSwitchConfigStandbyLink(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereDistributedVirtualSwitchExists(true),
-					testAccResourceVSphereDistributedVirtualSwitchHasUplinks([]string{"tfup1", "tfup2"}),
-					testAccResourceVSphereDistributedVirtualSwitchHasActiveUplinks([]string{"tfup1"}),
-					testAccResourceVSphereDistributedVirtualSwitchHasStandbyUplinks([]string{"tfup2"}),
+					testAccResourceVSphereDistributedVirtualSwitchHasUplinks([]string{os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"), os.Getenv("TF_VAR_VSPHERE_HOST_NIC1")}),
+					testAccResourceVSphereDistributedVirtualSwitchHasActiveUplinks([]string{os.Getenv("TF_VAR_VSPHERE_HOST_NIC0")}),
+					testAccResourceVSphereDistributedVirtualSwitchHasStandbyUplinks([]string{os.Getenv("TF_VAR_VSPHERE_HOST_NIC1")}),
 				),
 			},
 		},
@@ -142,9 +143,9 @@ func TestAccResourceVSphereDistributedVirtualSwitch_basicToStandbyWithFailover(t
 				Config: testAccResourceVSphereDistributedVirtualSwitchConfigStandbyLink(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereDistributedVirtualSwitchExists(true),
-					testAccResourceVSphereDistributedVirtualSwitchHasUplinks([]string{"tfup1", "tfup2"}),
-					testAccResourceVSphereDistributedVirtualSwitchHasActiveUplinks([]string{"tfup1"}),
-					testAccResourceVSphereDistributedVirtualSwitchHasStandbyUplinks([]string{"tfup2"}),
+					testAccResourceVSphereDistributedVirtualSwitchHasUplinks([]string{os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"), os.Getenv("TF_VAR_VSPHERE_HOST_NIC1")}),
+					testAccResourceVSphereDistributedVirtualSwitchHasActiveUplinks([]string{os.Getenv("TF_VAR_VSPHERE_HOST_NIC0")}),
+					testAccResourceVSphereDistributedVirtualSwitchHasStandbyUplinks([]string{os.Getenv("TF_VAR_VSPHERE_HOST_NIC1")}),
 				),
 			},
 		},
@@ -162,17 +163,17 @@ func TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion(t *testing.T)
 		CheckDestroy: testAccResourceVSphereDistributedVirtualSwitchExists(false),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceVSphereDistributedVirtualSwitchConfigStaticVersion("6.0.0"),
+				Config: testAccResourceVSphereDistributedVirtualSwitchConfigStaticVersion(os.Getenv("TF_VAR_VSPHERE_VSWITCH_LOWER_VERSION")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereDistributedVirtualSwitchExists(true),
-					testAccResourceVSphereDistributedVirtualSwitchHasVersion("6.0.0"),
+					testAccResourceVSphereDistributedVirtualSwitchHasVersion(os.Getenv("TF_VAR_VSPHERE_VSWITCH_LOWER_VERSION")),
 				),
 			},
 			{
-				Config: testAccResourceVSphereDistributedVirtualSwitchConfigStaticVersion("6.5.0"),
+				Config: testAccResourceVSphereDistributedVirtualSwitchConfigStaticVersion(os.Getenv("TF_VAR_VSPHERE_VSWITCH_UPPER_VERSION")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereDistributedVirtualSwitchExists(true),
-					testAccResourceVSphereDistributedVirtualSwitchHasVersion("6.5.0"),
+					testAccResourceVSphereDistributedVirtualSwitchHasVersion(os.Getenv("TF_VAR_VSPHERE_VSWITCH_UPPER_VERSION")),
 				),
 			},
 		},
@@ -217,7 +218,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_explicitUplinks(t *testing.T
 				Config: testAccResourceVSphereDistributedVirtualSwitchConfigUplinks(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereDistributedVirtualSwitchExists(true),
-					testAccResourceVSphereDistributedVirtualSwitchHasUplinks([]string{"tfup1", "tfup2"}),
+					testAccResourceVSphereDistributedVirtualSwitchHasUplinks([]string{os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"), os.Getenv("TF_VAR_VSPHERE_HOST_NIC1")}),
 				),
 			},
 		},
@@ -254,8 +255,8 @@ func TestAccResourceVSphereDistributedVirtualSwitch_modifyUplinks(t *testing.T) 
 					testAccResourceVSphereDistributedVirtualSwitchExists(true),
 					testAccResourceVSphereDistributedVirtualSwitchHasUplinks(
 						[]string{
-							"tfup1",
-							"tfup2",
+							os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+							os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 						},
 					),
 				),
@@ -435,12 +436,6 @@ func testAccResourceVSphereDistributedVirtualSwitchPreCheck(t *testing.T) {
 	}
 	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
 		t.Skip("set TF_VAR_VSPHERE_ESXI_HOST to run vsphere_host_virtual_switch acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI_HOST2") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI_HOST2 to run vsphere_host_virtual_switch acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI_HOST3") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI_HOST3 to run vsphere_host_virtual_switch acceptance tests")
 	}
 }
 
@@ -649,43 +644,24 @@ func testAccResourceVSphereDistributedVirtualSwitchConfig() string {
 	return fmt.Sprintf(`
 %s
 
-variable "network_interfaces" {
-  default = [
-    "%s",
-  ]
-}
-
-data "vsphere_host" "host" {
-  count         = 1
-  name          = vsphere_host.nested-esxi1.hostname
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
-
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   host {
-    host_system_id = "${data.vsphere_host.host.0.id}"
-    devices = "vmnic1"
+    host_system_id = data.vsphere_host.roothost2.id
+    devices = ["%s"]
   }
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost2()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 	)
 }
 
 func testAccResourceVSphereDistributedVirtualSwitchConfigStaticVersion(version string) string {
 	return fmt.Sprintf(`
 %s
-
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
 
 variable "network_interfaces" {
   default = [
@@ -697,37 +673,22 @@ variable "dvs_version" {
   default = "%s"
 }
 
-data "vsphere_host" "host" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
   version       = "${var.dvs_version}"
 
   host {
-    host_system_id = "${data.vsphere_host.host.0.id}"
-    devices = "${var.network_interfaces}"
-  }
-
-  host {
-    host_system_id = "${data.vsphere_host.host.1.id}"
-    devices = "${var.network_interfaces}"
-  }
-
-  host {
-    host_system_id = "${data.vsphere_host.host.2.id}"
+    host_system_id = "${data.vsphere_host.roothost1.id}"
     devices = "${var.network_interfaces}"
   }
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 		version,
 	)
 }
@@ -736,49 +697,34 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigSingleNIC() string {
 	return fmt.Sprintf(`
 %s
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
-
 variable "network_interfaces" {
   default = [
     "%s",
   ]
 }
 
-data "vsphere_host" "host" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   host {
-    host_system_id = "${data.vsphere_host.host.0.id}"
+    host_system_id = "${data.vsphere_host.roothost1.id}"
     devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = "${data.vsphere_host.host.1.id}"
-    devices = "${var.network_interfaces}"
-  }
-
-  host {
-    host_system_id = "${data.vsphere_host.host.2.id}"
+    host_system_id = "${data.vsphere_host.roothost2.id}"
     devices = "${var.network_interfaces}"
   }
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+		),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 	)
 }
 
@@ -786,12 +732,6 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigNetworkResourceControl(
 	return fmt.Sprintf(`
 %s
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
 
 variable "network_interfaces" {
   default = [
@@ -799,39 +739,30 @@ variable "network_interfaces" {
   ]
 }
 
-data "vsphere_host" "host" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   network_resource_control_enabled = true
   network_resource_control_version = "version3"
 
   host {
-    host_system_id = "${data.vsphere_host.host.0.id}"
+    host_system_id = "${data.vsphere_host.roothost1.id}"
     devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = "${data.vsphere_host.host.1.id}"
-    devices = "${var.network_interfaces}"
-  }
-
-  host {
-    host_system_id = "${data.vsphere_host.host.2.id}"
+    host_system_id = "${data.vsphere_host.roothost2.id}"
     devices = "${var.network_interfaces}"
   }
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 	)
 }
 
@@ -839,51 +770,37 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigUplinks() string {
 	return fmt.Sprintf(`
 %s
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
-
 variable "network_interfaces" {
   default = [
     "%s",
+    "%s"
   ]
 }
 
-data "vsphere_host" "host" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  uplinks = ["tfup1", "tfup2"]
+  uplinks = var.network_interfaces
 
   host {
-    host_system_id = "${data.vsphere_host.host.0.id}"
+    host_system_id = "${data.vsphere_host.roothost1.id}"
     devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = "${data.vsphere_host.host.1.id}"
-    devices = "${var.network_interfaces}"
-  }
-
-  host {
-    host_system_id = "${data.vsphere_host.host.2.id}"
+    host_system_id = "${data.vsphere_host.roothost2.id}"
     devices = "${var.network_interfaces}"
   }
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 	)
 }
 
@@ -891,53 +808,38 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigStandbyLink() string {
 	return fmt.Sprintf(`
 %s
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
-
 variable "network_interfaces" {
   default = [
     "%s",
+	"%s"
   ]
 }
 
-data "vsphere_host" "host" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  uplinks         = ["tfup1", "tfup2"]
-  active_uplinks  = ["tfup1"]
-  standby_uplinks = ["tfup2"]
+  uplinks         = var.network_interfaces
+  active_uplinks  = [var.network_interfaces.0]
+  standby_uplinks = [var.network_interfaces.1]
 
   host {
-    host_system_id = "${data.vsphere_host.host.0.id}"
+    host_system_id = "${data.vsphere_host.roothost1.id}"
     devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = "${data.vsphere_host.host.1.id}"
-    devices = "${var.network_interfaces}"
-  }
-
-  host {
-    host_system_id = "${data.vsphere_host.host.2.id}"
+    host_system_id = "${data.vsphere_host.roothost2.id}"
     devices = "${var.network_interfaces}"
   }
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2()),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 	)
 }
 
@@ -946,7 +848,7 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigNoHosts() string {
 %s
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 `,
@@ -965,7 +867,7 @@ resource "vsphere_folder" "folder" {
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
   folder        = "${vsphere_folder.folder.path}"
 }
@@ -993,7 +895,7 @@ resource "vsphere_tag" "testacc-tag" {
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
   tags          = ["${vsphere_tag.testacc-tag.id}"]
 }
@@ -1034,7 +936,7 @@ resource "vsphere_tag" "testacc-tags-alt" {
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
   tags          = "${vsphere_tag.testacc-tags-alt.*.id}"
 }
@@ -1048,7 +950,7 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigNetflow() string {
 %s
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   ipv4_address                  = "10.0.0.100"
@@ -1071,7 +973,7 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigMultiVlanRange() string
 %s
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   vlan_range {
@@ -1105,7 +1007,7 @@ locals {
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   custom_attributes = "${local.vs_attrs}"
@@ -1145,7 +1047,7 @@ locals {
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = "testacc-dvs"
+  name          = "testacc-dvs1"
   datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   custom_attributes = "${local.vs_attrs}"

--- a/vsphere/resource_vsphere_drs_vm_override_test.go
+++ b/vsphere/resource_vsphere_drs_vm_override_test.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -40,7 +41,7 @@ func TestAccResourceVSphereDRSVMOverride_drs(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					cluster, err := testGetComputeClusterFromDataSource(s, "cluster")
+					cluster, err := testGetComputeClusterFromDataSource(s, "rootcompute_cluster1")
 					if err != nil {
 						return "", err
 					}
@@ -223,7 +224,13 @@ resource "vsphere_drs_vm_override" "drs_vm_override" {
   drs_enabled        = false
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigResDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigResResourcePool1(),
+			testhelper.ConfigDataRootPortGroup1()),
 	)
 }
 

--- a/vsphere/resource_vsphere_file_test.go
+++ b/vsphere/resource_vsphere_file_test.go
@@ -15,7 +15,12 @@ import (
 
 // Basic file creation (upload to vSphere)
 func TestAccResourceVSphereFile_basic(t *testing.T) {
-	testVmdkFileData := []byte("# Disk DescriptorFile\n")
+	testVmdkFileData := []byte(`# Disk DescriptorFile
+version=1
+CID=fffffffe
+parentCID=ffffffff
+createType="twoGbMaxExtentSparse"
+`)
 	testVmdkFile := "/tmp/tf_test.vmdk"
 	err := ioutil.WriteFile(testVmdkFile, testVmdkFileData, 0644)
 	if err != nil {

--- a/vsphere/resource_vsphere_ha_vm_override_test.go
+++ b/vsphere/resource_vsphere_ha_vm_override_test.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -58,7 +59,7 @@ func TestAccResourceVSphereHAVMOverride_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					cluster, err := testGetComputeClusterFromDataSource(s, "cluster")
+					cluster, err := testGetComputeClusterFromDataSource(s, "rootcompute_cluster1")
 					if err != nil {
 						return "", err
 					}
@@ -414,7 +415,14 @@ resource "vsphere_ha_vm_override" "ha_vm_override" {
   virtual_machine_id = "${vsphere_virtual_machine.vm.id}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigResDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigResResourcePool1(),
+			testhelper.ConfigDataRootPortGroup1()),
 	)
 }
 

--- a/vsphere/resource_vsphere_host_port_group_test.go
+++ b/vsphere/resource_vsphere_host_port_group_test.go
@@ -2,10 +2,11 @@ package vsphere
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -186,7 +187,7 @@ variable "host_nic0" {
 
 data "vsphere_host" "esxi_host" {
   name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
@@ -203,7 +204,7 @@ resource "vsphere_host_port_group" "pg" {
   host_system_id      = "${data.vsphere_host.esxi_host.id}"
   virtual_switch_name = "${vsphere_host_virtual_switch.switch.name}"
 }
-`, os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+`, os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }
@@ -214,20 +215,24 @@ variable "host_nic0" {
   default = "%s"
 }
 
+variable "host_nic1" {
+  default = "%s"
+}
+
 %s
 
 data "vsphere_host" "esxi_host" {
   name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
   name           = "vSwitchTerraformTest"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
-  network_adapters  = ["${var.host_nic0}"]
+  network_adapters  = ["${var.host_nic0}", "${var.host_nic1}"]
   active_nics       = ["${var.host_nic0}"]
-  standby_nics      = []
+  standby_nics      = ["${var.host_nic1}"]
   allow_promiscuous = false
 }
 
@@ -241,7 +246,8 @@ resource "vsphere_host_port_group" "pg" {
   standby_nics      = ["${var.host_nic1}"]
   allow_promiscuous = true
 }
-`, os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+`, os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }

--- a/vsphere/resource_vsphere_host_test.go
+++ b/vsphere/resource_vsphere_host_test.go
@@ -3,11 +3,12 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"regexp"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/vmware/govmomi/vim25/types"
 
@@ -393,17 +394,20 @@ func testAccVSphereHostConfig() string {
 
 	resource "vsphere_host" "h1" {
 	  # Useful only for connection
-	  hostname = vsphere_host.nested-esxi1.hostname
-	  username = vsphere_host.nested-esxi1.username
-	  thumbprint = vsphere_host.nested-esxi1.password
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
 
 	  # Makes sense to update
 	  license = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
 	}
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
 		os.Getenv("TF_VAR_VSPHERE_LICENSE"))
 }
 
@@ -413,16 +417,18 @@ func testAccVSphereHostConfig_rootFolder() string {
 
 	resource "vsphere_host" "h1" {
 	  # Useful only for connection
-	  hostname = vsphere_host.nested-esxi1.hostname
-	  username = vsphere_host.nested-esxi1.username
-	  password = vsphere_host.nested-esxi1.password
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
 
 	  # Makes sense to update
 	  license = "%s"
 	  datacenter = data.vsphere_datacenter.rootdc1.id
 	}
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+	`, testhelper.ConfigDataRootDC1(), os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
 		os.Getenv("TF_VAR_VSPHERE_LICENSE"))
 }
 
@@ -431,15 +437,19 @@ func testAccVSphereHostConfig_emptyLicense() string {
 	%s 
 	resource "vsphere_host" "h1" {
 	  # Useful only for connection
-	  hostname = vsphere_host.nested-esxi1.hostname
-	  username = vsphere_host.nested-esxi1.username
-	  thumbprint = vsphere_host.nested-esxi1.password
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
 
 	  # Makes sense to update
 	  datacenter = data.vsphere_datacenter.rootdc1.id
 	}
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()))
+	`, testhelper.ConfigDataRootDC1(),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+	)
 }
 
 func testAccVSphereHostConfig_import() string {
@@ -453,17 +463,20 @@ func testAccVSphereHostConfig_import() string {
 		
 	resource "vsphere_host" "h1" {
 	  # Useful only for connection
-	  hostname = vsphere_host.nested-esxi1.hostname
-	  username = vsphere_host.nested-esxi1.username
-	  thumbprint = vsphere_host.nested-esxi1.password
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
 	
 	  # Makes sense to update
 	  license = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
 	}	  
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
 		os.Getenv("TF_VAR_VSPHERE_LICENSE"))
 }
 
@@ -477,17 +490,20 @@ func testAccVSphereHostConfig_connection(connection bool) string {
 	}
 		
 	resource "vsphere_host" "h1" {
-	  hostname = vsphere_host.nested-esxi1.hostname
-	  username = vsphere_host.nested-esxi1.username
-	  thumbprint = vsphere_host.nested-esxi1.password
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
 	
 	  license = "%s"
 	  connected = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
 	}	  
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
 		os.Getenv("TF_VAR_VSPHERE_LICENSE"),
 		strconv.FormatBool(connection))
 }
@@ -502,9 +518,9 @@ func testAccVSphereHostConfig_maintenance(maintenance bool) string {
 	}
 		
 	resource "vsphere_host" "h1" {
-	  hostname = vsphere_host.nested-esxi1.hostname
-	  username = vsphere_host.nested-esxi1.username
-	  thumbprint = vsphere_host.nested-esxi1.password
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
 	
 	  license = "%s"
@@ -512,8 +528,11 @@ func testAccVSphereHostConfig_maintenance(maintenance bool) string {
 	  maintenance = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
 	}	  
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
 		os.Getenv("TF_VAR_VSPHERE_LICENSE"),
 		strconv.FormatBool(maintenance))
 }
@@ -528,9 +547,9 @@ func testAccVSphereHostConfig_lockdown(lockdown string) string {
 	}
 		
 	resource "vsphere_host" "h1" {
-	  hostname = vsphere_host.nested-esxi1.hostname
-	  username = vsphere_host.nested-esxi1.username
-	  thumbprint = vsphere_host.nested-esxi1.password
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
 	
 	  license = "%s"
@@ -539,8 +558,11 @@ func testAccVSphereHostConfig_lockdown(lockdown string) string {
 	  lockdown = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
 	}	  
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
 		os.Getenv("TF_VAR_VSPHERE_LICENSE"),
 		lockdown)
 }

--- a/vsphere/resource_vsphere_host_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_host_virtual_switch_test.go
@@ -3,10 +3,11 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -107,7 +108,7 @@ func TestAccResourceVSphereHostVirtualSwitch_badActiveNICList(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceVSphereHostVirtualSwitchConfigBadActive(),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("active NIC entry %q not present in network_adapters list", os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"))),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("active NIC entry %q not present in network_adapters list", os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"))),
 				PlanOnly:    true,
 			},
 			{
@@ -130,7 +131,7 @@ func TestAccResourceVSphereHostVirtualSwitch_badStandbyNICList(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceVSphereHostVirtualSwitchConfigBadStandby(),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("standby NIC entry %q not present in network_adapters list", os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"))),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("standby NIC entry %q not present in network_adapters list", os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"))),
 				PlanOnly:    true,
 			},
 			{
@@ -248,23 +249,28 @@ variable "host_nic0" {
   default = "%s"
 }
 
+variable "host_nic1" {
+  default = "%s"
+}
+
 %s
 
 data "vsphere_host" "esxi_host" {
   name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
   name           = "vSwitchTerraformTest"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
-  network_adapters = ["${var.host_nic0}", "${var.host_nic1}"]
+  network_adapters = [var.host_nic0, var.host_nic1]
 
-  active_nics  = ["${var.host_nic0}"]
-  standby_nics = []
+  active_nics  = [var.host_nic0]
+  standby_nics = [var.host_nic1]
 }
-`, os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+`, os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
+		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }
@@ -279,7 +285,7 @@ variable "host_nic0" {
 
 data "vsphere_host" "esxi_host" {
   name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
@@ -291,7 +297,7 @@ resource "vsphere_host_virtual_switch" "switch" {
   active_nics  = ["${var.host_nic0}"]
   standby_nics = []
 }
-`, os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+`, os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }
@@ -306,7 +312,7 @@ variable "host_nic0" {
 
 data "vsphere_host" "esxi_host" {
   name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
@@ -333,7 +339,7 @@ variable "host_nic0" {
 
 data "vsphere_host" "esxi_host" {
   name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
@@ -345,7 +351,7 @@ resource "vsphere_host_virtual_switch" "switch" {
   active_nics  = ["${var.host_nic0}"]
   standby_nics = []
 }
-`, os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+`, os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }
@@ -360,7 +366,7 @@ variable "host_nic0" {
 
 data "vsphere_host" "esxi_host" {
   name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
@@ -372,7 +378,7 @@ resource "vsphere_host_virtual_switch" "switch" {
   active_nics  = []
   standby_nics = ["${var.host_nic0}"]
 }
-`, os.Getenv("TF_VAR_VSPHERE_ESXI_TRUNK_NIC"),
+`, os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }

--- a/vsphere/resource_vsphere_license_test.go
+++ b/vsphere/resource_vsphere_license_test.go
@@ -133,10 +133,6 @@ func testAccVSphereLicenseBasicConfig() string {
 	return fmt.Sprintf(`
 resource "vsphere_license" "foo" {
  license_key = "%s"
-  labels {
-    VpxClientLicenseLabel = "Hello World"
-	TestTitle             = "fooBar"
-  }
 }
 `, os.Getenv("TF_VAR_VSPHERE_LICENSE"))
 }

--- a/vsphere/resource_vsphere_resource_pool_test.go
+++ b/vsphere/resource_vsphere_resource_pool_test.go
@@ -475,7 +475,7 @@ resource "vsphere_resource_pool" "resource_pool" {
   parent_resource_pool_id = "${vsphere_resource_pool.alt_parent_resource_pool.id}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 	)
 }
 
@@ -503,7 +503,7 @@ resource "vsphere_resource_pool" "resource_pool" {
   memory_limit            = 20
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 	)
 }
 
@@ -525,7 +525,7 @@ resource "vsphere_resource_pool" "resource_pool" {
   parent_resource_pool_id = "${data.vsphere_host.host.resource_pool_id}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
 	)
 }
@@ -554,7 +554,7 @@ resource "vsphere_resource_pool" "resource_pool" {
   tags                    = ["${vsphere_tag.testacc-tag.id}"]
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 	)
 }
 
@@ -572,7 +572,7 @@ resource "vsphere_resource_pool" "resource_pool" {
   parent_resource_pool_id = "${vsphere_resource_pool.parent_resource_pool.id}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 	)
 }
 
@@ -590,6 +590,6 @@ resource "vsphere_resource_pool" "resource_pool" {
   parent_resource_pool_id = "${vsphere_resource_pool.parent_resource_pool.id}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 	)
 }

--- a/vsphere/resource_vsphere_vapp_entity_test.go
+++ b/vsphere/resource_vsphere_vapp_entity_test.go
@@ -3,9 +3,10 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -314,11 +315,6 @@ func testAccResourceVSphereVAppEntityConfigBasic() string {
 	return fmt.Sprintf(`
 %s
 
-data "vsphere_datastore" "datastore" {
-	name = "${var.datastore}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
-
 resource "vsphere_resource_pool" "parent_resource_pool" {
   name                    = "terraform-resource-pool-test-parent"
   parent_resource_pool_id = "${data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id}"
@@ -333,11 +329,11 @@ resource "vsphere_folder" "parent_folder" {
 resource "vsphere_vapp_container" "vapp_container" {
   name                    = "terraform-resource-pool-test"
   parent_resource_pool_id = "${vsphere_resource_pool.parent_resource_pool.id}"
-	parent_folder_id = "${vsphere_folder.parent_folder.id}"
+  parent_folder_id        = "${vsphere_folder.parent_folder.id}"
 }
 
 resource "vsphere_vapp_entity" "vapp_entity" {
-	target_id = "${vsphere_virtual_machine.vm.moid}"
+	target_id    = "${vsphere_virtual_machine.vm.moid}"
 	container_id = "${vsphere_vapp_container.vapp_container.id}"
 }
 
@@ -362,7 +358,14 @@ resource "vsphere_virtual_machine" "vm" {
 	}
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigResDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigResResourcePool1(),
+			testhelper.ConfigDataRootPortGroup1()),
 	)
 }
 

--- a/vsphere/resource_vsphere_virtual_machine_migrate_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_migrate_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter"
+
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice"
@@ -87,7 +89,11 @@ func TestAccResourceVSphereVirtualMachine_migrateStateV3_fromV2(t *testing.T) {
 
 	client := meta.(*VSphereClient).vimClient
 	pth := os.Getenv("TF_VAR_VSPHERE_VM_V1_PATH")
-	vm, err := virtualmachine.FromPath(client, pth, nil)
+	dc, err := datacenter.FromPath(client, os.Getenv("TF_VAR_VSPHERE_DATACENTER"))
+	if err != nil {
+		t.Fatalf("error while fetching datacenter: %s", err)
+	}
+	vm, err := virtualmachine.FromPath(client, pth, dc)
 	if err != nil {
 		t.Fatalf("error fetching virtual machine: %s", err)
 	}
@@ -127,7 +133,11 @@ func TestAccResourceVSphereVirtualMachine_migrateStateV3FromV1(t *testing.T) {
 	client := meta.(*VSphereClient).vimClient
 	pth := os.Getenv("TF_VAR_VSPHERE_VM_V1_PATH")
 	name := path.Base(pth)
-	vm, err := virtualmachine.FromPath(client, pth, nil)
+	dc, err := datacenter.FromPath(client, os.Getenv("TF_VAR_VSPHERE_DATACENTER"))
+	if err != nil {
+		t.Fatalf("error while fetching datacenter: %s", err)
+	}
+	vm, err := virtualmachine.FromPath(client, pth, dc)
 	if err != nil {
 		t.Fatalf("error fetching virtual machine: %s", err)
 	}
@@ -181,7 +191,11 @@ func TestAccResourceVSphereVirtualMachine_migrateStateV2(t *testing.T) {
 	client := meta.(*VSphereClient).vimClient
 	pth := os.Getenv("TF_VAR_VSPHERE_VM_V1_PATH")
 	name := path.Base(pth)
-	vm, err := virtualmachine.FromPath(client, pth, nil)
+	dc, err := datacenter.FromPath(client, os.Getenv("TF_VAR_VSPHERE_DATACENTER"))
+	if err != nil {
+		t.Fatalf("error while fetching datacenter: %s", err)
+	}
+	vm, err := virtualmachine.FromPath(client, pth, dc)
 	if err != nil {
 		t.Fatalf("error fetching virtual machine: %s", err)
 	}

--- a/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
@@ -3,9 +3,10 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -49,9 +50,6 @@ func testAccResourceVSphereVirtualMachineSnapshotPreCheck(t *testing.T) {
 	}
 	if os.Getenv("TF_VAR_VSPHERE_RESOURCE_POOL") == "" {
 		t.Skip("set TF_VAR_VSPHERE_RESOURCE_POOL to run vsphere_virtual_machine_snapshot acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_NETWORK_LABEL") == "" {
-		t.Skip("set TF_VAR_VSPHERE_NETWORK_LABEL to run vsphere_virtual_machine_snapshot acceptance tests")
 	}
 	if os.Getenv("TF_VAR_VSPHERE_IPV4_ADDRESS") == "" {
 		t.Skip("set TF_VAR_VSPHERE_IPV4_ADDRESS to run vsphere_virtual_machine_snapshot acceptance tests")

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -1969,8 +1969,7 @@ func TestAccResourceVSphereVirtualMachine_resourcePoolVMotion(t *testing.T) {
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccResourceVSphereVirtualMachineConfigResourcePoolVMotion(os.Getenv("TF_VAR_VSPHERE_RESOURCE_POOL")),
-				ExpectNonEmptyPlan: true,
+				Config: testAccResourceVSphereVirtualMachineConfigResourcePoolVMotion(os.Getenv("TF_VAR_VSPHERE_RESOURCE_POOL")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckResourcePool(os.Getenv("TF_VAR_VSPHERE_RESOURCE_POOL")),
@@ -2072,7 +2071,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionPinDatastore(t *testing.
 				Config: testAccResourceVSphereVirtualMachineConfigBase(),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore("vsphere_nas_datastore.ds1.id"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
@@ -2081,7 +2080,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionPinDatastore(t *testing.
 				),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore("data.vsphere_datastore.rootds1.id"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
@@ -2115,19 +2114,19 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionRenamedVirtualMachine(t 
 				),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionRename("testacc-foobar-test", os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
-				Check: resource.ComposeTestCheckFunc(
-					testAccResourceVSphereVirtualMachineCheckExists(true),
-					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
-					testAccResourceVSphereVirtualMachineCheckVmdkDatastore(0, os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
-				),
-			},
-			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionRename("foobar-test", os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionRename("testacc-foobar-test", os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
 					testAccResourceVSphereVirtualMachineCheckVmdkDatastore(0, os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
+				),
+			},
+			{
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionRename("foobar-test", os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
+					testAccResourceVSphereVirtualMachineCheckVmdkDatastore(0, os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
 				),
 			},
 		},
@@ -2150,7 +2149,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionLinkedClones(t *testing.
 				Config: testAccResourceVSphereVirtualMachineConfigBase(),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone("data.vsphere_datastore.rootds1.id"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME")),
@@ -2158,7 +2157,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionLinkedClones(t *testing.
 				),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone(os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2")),
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone("vsphere_nas_datastore.ds1.id"),
 				Check: resource.ComposeTestCheckFunc(
 					copyStatePtr(&state),
 					testAccResourceVSphereVirtualMachineCheckExists(true),
@@ -6089,15 +6088,12 @@ resource "vsphere_virtual_machine" "vm" {
   cdrom {
     client_device = true
   }
-
-  depends_on = ["vsphere_host.nested-esxi1"]
 }
 `,
 
 		testhelper.CombineConfigs(
 			testAccResourceVSphereVirtualMachineConfigBase(),
-			testhelper.ConfigDataRootVMNet(),
-			testhelper.ConfigResNestedEsxi()),
+			testhelper.ConfigDataRootVMNet()),
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
 		pool,
 		os.Getenv("TF_VAR_VSPHERE_USE_LINKED_CLONE"),
@@ -6231,7 +6227,7 @@ resource "vsphere_virtual_machine" "vm" {
 	)
 }
 
-func testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore(datastore string) string {
+func testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore(datastoreAddress string) string {
 	return fmt.Sprintf(`
 
 
@@ -6242,19 +6238,14 @@ data "vsphere_virtual_machine" "template" {
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
 
-variable "disk_datastore" {
+variable "ds_id" {
   default = "%s"
-}
-
-data "vsphere_datastore" "disk_datastore" {
-  name          = "${var.disk_datastore}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = "${vsphere_resource_pool.pool1.id}"
-  datastore_id     = data.vsphere_datastore.disk_datastore.id
+  datastore_id     = var.ds_id
 
   num_cpus = 2
   memory   = 2048
@@ -6271,11 +6262,12 @@ resource "vsphere_virtual_machine" "vm" {
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+    datastore_id     = var.ds_id
   }
 
   disk {
     label        = "disk1"
-    datastore_id = "${data.vsphere_datastore.disk_datastore.id}"
+    datastore_id = %s
     size         = 1
     unit_number  = 1
   }
@@ -6293,7 +6285,7 @@ resource "vsphere_virtual_machine" "vm" {
 
 		testAccResourceVSphereVirtualMachineConfigBase(),
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
-		datastore,
+		datastoreAddress, datastoreAddress,
 	)
 }
 
@@ -6338,6 +6330,7 @@ resource "vsphere_virtual_machine" "vm" {
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+	datastore_id     = data.vsphere_datastore.ds.id
   }
 
   clone {
@@ -6358,16 +6351,11 @@ resource "vsphere_virtual_machine" "vm" {
 	)
 }
 
-func testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone(datastore string) string {
+func testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone(datastoreAddress string) string {
 	return fmt.Sprintf(`
 
 
 %s  // Mix and match config
-
-data "vsphere_datastore" "ds" {
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  name          = "%s"
-}
 
 data "vsphere_virtual_machine" "template" {
   name          = "%s"
@@ -6378,10 +6366,14 @@ variable "linked_clone" {
   default = "%s"
 }
 
+variable "ds" {
+  default = %s
+}
+
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = "${vsphere_resource_pool.pool1.id}"
-  datastore_id     = data.vsphere_datastore.ds.id
+  datastore_id     = var.ds
 
   num_cpus = 2
   memory   = 2048
@@ -6397,6 +6389,7 @@ resource "vsphere_virtual_machine" "vm" {
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+    datastore_id     = var.ds
   }
 
   clone {
@@ -6410,9 +6403,9 @@ resource "vsphere_virtual_machine" "vm" {
 }
 `,
 		testAccResourceVSphereVirtualMachineConfigBase(),
-		datastore,
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
 		os.Getenv("TF_VAR_VSPHERE_USE_LINKED_CLONE"),
+		datastoreAddress,
 	)
 }
 
@@ -7067,14 +7060,10 @@ func testAccResourceVSphereVirtualMachineTestPathInterpolation() string {
 %s  // Mix and match config
 
 
-resource "null_resource" "n" {
-  count = 2
-}
-
 resource "vsphere_virtual_disk" "d" {
   count      = 2
   size       = 1
-  vmdk_path  = "${null_resource.n[count.index].id}.vmdk"
+  vmdk_path  = "disk-${count.index}.vmdk"
   datastore  = vsphere_nas_datastore.ds1.name
   datacenter = data.vsphere_datacenter.rootdc1.name
 }
@@ -7114,11 +7103,6 @@ func testAccResourceVSphereVirtualMachineConfigContentLibrary_basic() string {
 %s
 
 
-variable "file_list" {
-  type    = list(string)
-  default = %s 
-}
-
 resource "vsphere_content_library" "library" {
   name            = "ContentLibrary_test"
   storage_backing = [ data.vsphere_datastore.rootds1.id ]
@@ -7129,19 +7113,20 @@ resource "vsphere_content_library_item" "item" {
   name = "ubuntu"
   description = "Ubuntu Description"
   library_id = vsphere_content_library.library.id
-  file_url = var.file_list
+  file_url = "%s"
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
   datastore_id     = data.vsphere_datastore.rootds1.id
+  annotation       = "Name: yVM (a very small virtual machine)\nRelease date: 11th November 2015\nFor more information, please visit: cloudarchitectblog.wordpress.com"
 
   num_cpus = 1
   memory   = 2048
 
   wait_for_guest_net_timeout = -1
-  guest_id                   = "ubuntu64Guest"
+  guest_id                   = "otherLinuxGuest"
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -8284,7 +8269,7 @@ resource "vsphere_virtual_machine" "vm" {
 // Must be able to manage datastore cluster membership outside of datastore
 func testAccResourceVSphereVirtualMachineConfigCloneDatastoreCluster() string {
 	return fmt.Sprintf(`
-
+%s
 
 variable "nfs_host" {
   default = "%s"
@@ -8294,23 +8279,11 @@ variable "nfs_path" {
   default = "%s"
 }
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
-
 data "vsphere_virtual_machine" "template" {
   name          = "%s"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
 
-data "vsphere_host" "esxi_hosts" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
-}
 
 resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "testacc-datastore-cluster"
@@ -8320,7 +8293,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name                 = "testacc-nas"
-  host_system_ids      = "${data.vsphere_host.esxi_hosts.*.id}"
+  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -8360,12 +8333,9 @@ resource "vsphere_virtual_machine" "vm" {
   depends_on = ["vsphere_nas_datastore.datastore"]
 }
 `,
-
+		testAccResourceVSphereVirtualMachineConfigBase(),
 		os.Getenv("TF_VAR_VSPHERE_NAS_HOST"),
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
 	)
 }
@@ -8394,6 +8364,7 @@ func skipTestAccResourceVSphereVirtualMachine_datastoreClusterClone(t *testing.T
 func testAccResourceVSphereVirtualMachineConfigStorageVMotionDatastoreCluster(clusterName string) string {
 	return fmt.Sprintf(`
 
+%s
 
 variable "nfs_host" {
   default = "%s"
@@ -8407,22 +8378,9 @@ variable "nfs_path2" {
   default = "%s"
 }
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
-
 data "vsphere_virtual_machine" "template" {
   name          = "%s"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
-
-data "vsphere_host" "esxi_hosts" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_datastore_cluster" "%s" {
@@ -8449,7 +8407,7 @@ resource "vsphere_datastore_cluster" "%s" {
 
 resource "vsphere_nas_datastore" "datastore2" {
   name                 = "testacc-nas2"
-  host_system_ids      = "${data.vsphere_host.esxi_hosts.*.id}"
+  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.%s.id}"
 
   type         = "NFS"
@@ -8492,13 +8450,10 @@ resource "vsphere_virtual_machine" "vm" {
 	]
 }
 `,
-
+		testAccResourceVSphereVirtualMachineConfigBase(),
 		os.Getenv("TF_VAR_VSPHERE_NAS_HOST"),
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH"),
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
 		testAccResourceVSphereVirtualMachineDatastoreCluster,
 		testAccResourceVSphereVirtualMachineDatastoreCluster,
@@ -8742,7 +8697,7 @@ func skipTestAccResourceVSphereVirtualMachine_hostVMotionDatastoreCluster(t *tes
 
 func testAccResourceVSphereVirtualMachineConfigStorageVMotionDatastoreClusterSingleDiskStep0() string {
 	return fmt.Sprintf(`
-
+%s
 
 variable "nfs_host" {
   default = "%s"
@@ -8752,22 +8707,10 @@ variable "nfs_path" {
   default = "%s"
 }
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
 
 data "vsphere_virtual_machine" "template" {
   name          = "%s"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
-
-data "vsphere_host" "esxi_hosts" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_datastore_cluster" "datastore_cluster" {
@@ -8778,7 +8721,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name                 = "testacc-nas"
-  host_system_ids      = "${data.vsphere_host.esxi_hosts.*.id}"
+  host_system_ids      = "[data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -8826,12 +8769,9 @@ resource "vsphere_virtual_machine" "vm" {
   ]
 }
 `,
-
+		testAccResourceVSphereVirtualMachineConfigBase(),
 		os.Getenv("TF_VAR_VSPHERE_NAS_HOST"),
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
 	)
 }
@@ -8848,12 +8788,6 @@ variable "nfs_path" {
   default = "%s"
 }
 
-variable "esxi_hosts" {
-  default = [
-    "%s",
-    "%s",
-  ]
-}
 
 %s  // Mix and match config
 
@@ -8864,12 +8798,6 @@ data "vsphere_virtual_machine" "template" {
 
 variable "disk_datastore" {
   default = "%s"
-}
-
-data "vsphere_host" "esxi_hosts" {
-  count         = "${length(var.esxi_hosts)}"
-  name          = "${var.esxi_hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 data "vsphere_datastore" "disk_datastore" {
@@ -8885,7 +8813,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name                 = "testacc-nas"
-  host_system_ids      = "${data.vsphere_host.esxi_hosts.*.id}"
+  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -8937,9 +8865,6 @@ resource "vsphere_virtual_machine" "vm" {
 
 		os.Getenv("TF_VAR_VSPHERE_NAS_HOST"),
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
-		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
-
 		testAccResourceVSphereVirtualMachineConfigBase(),
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
 		datastore,

--- a/vsphere/resource_vsphere_vmfs_datastore_test.go
+++ b/vsphere/resource_vsphere_vmfs_datastore_test.go
@@ -2,11 +2,12 @@ package vsphere
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 	"os"
 	"path"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -136,7 +137,7 @@ func TestAccResourceVSphereVmfsDatastore_renameDatastore(t *testing.T) {
 				Config: testAccResourceVSphereVmfsDatastoreConfigStaticSingleAltName(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVmfsDatastoreExists(true),
-					testAccResourceVSphereVmfsDatastoreHasName("terraform-test-renamed"),
+					testAccResourceVSphereVmfsDatastoreHasName(fmt.Sprintf("%s-renamed", os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))),
 				),
 			},
 		},
@@ -392,7 +393,7 @@ func TestAccResourceVSphereVmfsDatastore_multiCustomAttribute(t *testing.T) {
 }
 
 func testAccResourceVSphereVmfsDatastorePreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
+	if os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME") == "" {
 		t.Skip("set TF_VAR_VSPHERE_ESXI_HOST to run vsphere_vmfs_disks acceptance tests")
 	}
 	if os.Getenv("TF_VAR_VSPHERE_VMFS_REGEXP") == "" {
@@ -479,20 +480,20 @@ variable "disk0" {
 
 %s
 
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
   ]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()), os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigStaticSingleAltName() string {
@@ -504,20 +505,20 @@ variable "disk0" {
 
 %s
 
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
-
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "terraform-test-renamed"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s-renamed"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
   ]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigStaticMulti() string {
@@ -532,29 +533,24 @@ variable "disk1" {
   default = "%s"
 }
 
-variable "disk2" {
-  type    = "string"
-  default = "%s"
-}
-
 %s
 
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
-
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
     "${var.disk1}",
-    "${var.disk2}",
   ]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK1"), os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK2"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK1"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigDiscoverDatasource() string {
@@ -566,24 +562,24 @@ variable "regexp" {
 
 %s
 
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
-
 data "vsphere_vmfs_disks" "available" {
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
   rescan         = true
   filter         = "${var.regexp}"
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = "${data.vsphere_vmfs_disks.available.disks}"
 }
-`, os.Getenv("TF_VAR_VSPHERE_VMFS_REGEXP"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_VMFS_REGEXP"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigStaticSingleFolder() string {
@@ -600,21 +596,28 @@ variable "folder" {
 
 %s
 
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+resource "vsphere_folder" "folder" {
+  path = var.folder
+  type = "datastore"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
-  folder         = "${var.folder}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
+  folder         = vsphere_folder.folder.path
 
   disks = [
     "${var.disk0}",
   ]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_FOLDER"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		os.Getenv("TF_VAR_VSPHERE_DS_FOLDER"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigTags() string {
@@ -625,11 +628,6 @@ variable "disk0" {
 }
 
 %s
-
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
 
 resource "vsphere_tag_category" "testacc-category" {
   name        = "testacc-tag-category"
@@ -646,8 +644,8 @@ resource "vsphere_tag" "testacc-tag" {
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
@@ -655,7 +653,12 @@ resource "vsphere_vmfs_datastore" "datastore" {
 
   tags = ["${vsphere_tag.testacc-tag.id}"]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigMultiTags() string {
@@ -673,11 +676,6 @@ variable "extra_tags" {
 }
 
 %s
-
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
 
 resource "vsphere_tag_category" "testacc-category" {
   name        = "testacc-tag-category"
@@ -700,8 +698,8 @@ resource "vsphere_tag" "testacc-tags-alt" {
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
@@ -709,7 +707,12 @@ resource "vsphere_vmfs_datastore" "datastore" {
 
   tags = "${vsphere_tag.testacc-tags-alt.*.id}"
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigBadDisk() string {
@@ -726,14 +729,9 @@ variable "disk1" {
 
 %s
 
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
-
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
@@ -741,7 +739,12 @@ resource "vsphere_vmfs_datastore" "datastore" {
     "",
   ]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK1"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK1"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigDuplicateDisk() string {
@@ -758,14 +761,9 @@ variable "disk1" {
 
 %s
 
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
-
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
@@ -773,7 +771,12 @@ resource "vsphere_vmfs_datastore" "datastore" {
     "${var.disk1}",
   ]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK1"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK1"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigCustomAttributes() string {
@@ -784,11 +787,6 @@ variable "disk0" {
 }
 
 %s
-
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
 
 resource "vsphere_custom_attribute" "testacc-attribute" {
   name                = "testacc-attribute"
@@ -802,8 +800,8 @@ locals {
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
@@ -811,7 +809,12 @@ resource "vsphere_vmfs_datastore" "datastore" {
 
   custom_attributes = "${local.vmfs_attrs}"
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigMultiCustomAttributes() string {
@@ -822,11 +825,6 @@ variable "disk0" {
 }
 
 %s
-
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
 
 resource "vsphere_custom_attribute" "testacc-attribute" {
   name                = "testacc-attribute"
@@ -846,8 +844,8 @@ locals {
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name           = "testacc-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  name           = "%s"
+  host_system_id = "${data.vsphere_host.roothost1.id}"
 
   disks = [
     "${var.disk0}",
@@ -855,7 +853,12 @@ resource "vsphere_vmfs_datastore" "datastore" {
 
   custom_attributes = "${local.vmfs_attrs}"
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }
 
 func testAccResourceVSphereVmfsDatastoreConfigDatastoreCluster() string {
@@ -871,25 +874,24 @@ variable "folder" {
 }
 
 %s
-
-data "vsphere_host" "esxi_host" {
-  name          = "%s"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
-}
-
 resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "testacc-datastore-cluster"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
-  name                 = "testacc-test"
-  host_system_id       = "${data.vsphere_host.esxi_host.id}"
+  name                 = "%s"
+  host_system_id       = "${data.vsphere_host.roothost1.id}"
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   disks = [
     "${var.disk0}",
   ]
 }
-`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_FOLDER"), testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME"))
+`, os.Getenv("TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0"), os.Getenv("TF_VAR_VSPHERE_DS_FOLDER"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
+		os.Getenv("TF_VAR_VSPHERE_DS_VMFS_NAME"))
 }

--- a/vsphere/resource_vsphere_vnic_test.go
+++ b/vsphere/resource_vsphere_vnic_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
-	"github.com/vmware/govmomi"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
+	"github.com/vmware/govmomi"
 )
 
 type genTfConfig func(string) string
@@ -289,7 +290,7 @@ func testAccVSphereVNicConfig_hvs(netConfig string) string {
 	  %s
 	}
 	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI_HOST3"),
+		os.Getenv("TF_VAR_VSPHERE_ESXI3"),
 		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 		os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
@@ -301,17 +302,11 @@ func testAccVSphereVNicConfig_dvs(netConfig string) string {
 	return fmt.Sprintf(`
 %s
 
-	data "vsphere_host" "h1" {
-	  name          = "%s"
-	  datacenter_id = data.vsphere_datacenter.rootdc1.id
-	}
-	
-	
 	resource "vsphere_distributed_virtual_switch" "d1" {
 	  name          = "hashi-dc_DVPG0"
 	  datacenter_id = data.vsphere_datacenter.rootdc1.id
 	  host {
-		host_system_id = data.vsphere_host.h1.id
+		host_system_id = data.vsphere_host.roothost1.id
 		devices        = ["%s"]
 	  }
 	}
@@ -323,13 +318,15 @@ func testAccVSphereVNicConfig_dvs(netConfig string) string {
 	}
 	
 	resource "vsphere_vnic" "v1" {
-	  host                    = data.vsphere_host.h1.id
+	  host                    = data.vsphere_host.roothost1.id
 	  distributed_switch_port = vsphere_distributed_virtual_switch.d1.id
 	  distributed_port_group  = vsphere_distributed_port_group.p1.id
 	  %s
 	}
-	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+	`, testhelper.CombineConfigs(
+		testhelper.ConfigDataRootDC1(),
+		testhelper.ConfigDataRootHost1(),
+	),
 		os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"),
 		netConfig)
 }


### PR DESCRIPTION
This started as an effort to run tests against vsphere 7.0, but ended up fixing a few outstanding bugs and making the acceptance tests a bit simpler by reusing some resources instead of building new ones each time.

There are some outstanding issues with the tests, but these will addressed in separate PRs.