### PR TITLE
Update max hardware version

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -307,7 +307,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"hardware_version": {
 			Type:         schema.TypeInt,
 			Optional:     true,
-			ValidateFunc: validation.IntBetween(4, 17),
+			ValidateFunc: validation.IntBetween(4, 19),
 			Description:  "The hardware version for the virtual machine.",
 			Computed:     true,
 		},


### PR DESCRIPTION
Hardware version goes up to 19 since vsphere 7.0.2
(https://kb.vmware.com/s/article/1003746)

Closes #1389.
