### PR TITLE
Fix calculation of diskCapacityInGiB by rounding up

### DIFF
--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -302,19 +302,15 @@ func ByteToGB(n interface{}) interface{} {
 	panic(fmt.Errorf("non-integer type %T for value", n))
 }
 
-// ByteToGiB returns n/1024^3. The input must be an integer that can be
-// appropriately divisible.
+// ByteToGiB returns n/1024^3, *rounded up*.
 //
-// Remember that int32 overflows at approximately 2GiB, so any values higher
-// than that will produce an inaccurate result.
-func ByteToGiB(n interface{}) interface{} {
-	switch v := n.(type) {
-	case int:
-		return v / int(math.Pow(1024, 3))
-	case int32:
-		return v / int32(math.Pow(1024, 3))
-	case int64:
-		return v / int64(math.Pow(1024, 3))
+// Standard integer division results in fractional GiB being discarded,
+// resulting in errors errors cloning virtual machines having disk size
+// in non-integer GiB. The result is rounded up to avoid this edge case.
+func ByteToGiB(n interface{}) int {
+	switch n.(type) {
+	case int, int32, int64:
+		return int(math.Ceil(float64(n.(int64)) / math.Pow(1024, 3)))
 	}
 	panic(fmt.Errorf("non-integer type %T for value", n))
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -2251,11 +2251,11 @@ func diskUUIDMatch(device types.BaseVirtualDevice, uuid string) bool {
 // data gets cleared, which seems to happen on upgrades.
 func diskCapacityInGiB(disk *types.VirtualDisk) int {
 	if disk.CapacityInBytes > 0 {
-		return int(structure.ByteToGiB(disk.CapacityInBytes).(int64))
+		return structure.ByteToGiB(disk.CapacityInBytes)
 	}
 	log.Printf(
 		"[DEBUG] diskCapacityInGiB: capacityInBytes missing for for %s, falling back to capacityInKB",
 		object.VirtualDeviceList{}.Name(disk),
 	)
-	return int(structure.ByteToGiB(disk.CapacityInKB * 1024).(int64))
+	return structure.ByteToGiB(disk.CapacityInKB * 1024)
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource_test.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource_test.go
@@ -13,7 +13,7 @@ func TestDiskCapacityInGiB(t *testing.T) {
 		expected int
 	}{
 		{
-			name: "capacityInBytes",
+			name: "capacityInBytes - integer GiB",
 			subject: &types.VirtualDisk{
 				CapacityInBytes: 4294967296,
 				CapacityInKB:    4194304,
@@ -21,11 +21,26 @@ func TestDiskCapacityInGiB(t *testing.T) {
 			expected: 4,
 		},
 		{
-			name: "capacityInKB",
+			name: "capacityInKB - integer GiB",
 			subject: &types.VirtualDisk{
 				CapacityInKB: 4194304,
 			},
 			expected: 4,
+		},
+		{
+			name: "capacityInBytes - non-integer GiB",
+			subject: &types.VirtualDisk{
+				CapacityInBytes: 4294968320,
+				CapacityInKB:    4194305,
+			},
+			expected: 5,
+		},
+		{
+			name: "capacityInKB - non-integer GiB",
+			subject: &types.VirtualDisk{
+				CapacityInKB: 4194305,
+			},
+			expected: 5,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
* Fix the error `Invalid operation for device '0'` when cloning a virtual
  machine template with a disk whose size is not an multiple of 1024^3
  bytes, by ensuring that the calculated disk capacity is rounded up
  rather than down.

### Description

<!--- Please leave a helpful description of the pull request here. --->
The vsphere_virtual_machine data source calculates and stores disk size in integer GiB. Unfortunately, without this patch, the calculation always rounds the size down. As a result, if the vsphere_virtual_machine resource is used to clone a template with a non-integer GiB disk, it tries to shrink the disk to the calculated, rounded-down size, resulting in the opaque error `Invalid operation for device '0'`.

This PR resolves the issue by ensuring that the calculated size is always rounded up rather than down, so that, for example, a Packer-generated template with disk size 42000MiB will be cloned without error to a virtual machine with disk size 42GiB rather than 41GiB.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestDiskCapacityInGiB'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestDiskCapacityInGiB -timeout 240m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere 0.357s [no tests to run]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   0.240s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     0.588s [no tests to run]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
=== RUN   TestDiskCapacityInGiB
=== RUN   TestDiskCapacityInGiB/capacityInBytes_-_integer_GiB
=== RUN   TestDiskCapacityInGiB/capacityInKB_-_integer_GiB
2021/04/24 12:04:28 [DEBUG] diskCapacityInGiB: capacityInBytes missing for for disk-0-0, falling back to capacityInKB
=== RUN   TestDiskCapacityInGiB/capacityInBytes_-_non-integer_GiB
=== RUN   TestDiskCapacityInGiB/capacityInKB_-_non-integer_GiB
2021/04/24 12:04:28 [DEBUG] diskCapacityInGiB: capacityInBytes missing for for disk-0-0, falling back to capacityInKB
--- PASS: TestDiskCapacityInGiB (0.00s)
    --- PASS: TestDiskCapacityInGiB/capacityInBytes_-_integer_GiB (0.00s)
    --- PASS: TestDiskCapacityInGiB/capacityInKB_-_integer_GiB (0.00s)
    --- PASS: TestDiskCapacityInGiB/capacityInBytes_-_non-integer_GiB (0.00s)
    --- PASS: TestDiskCapacityInGiB/capacityInKB_-_non-integer_GiB (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  0.296s
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix `Invalid operation for device '0'` error when cloning template with non-integer GiB disk size.
```
### References

- Fixes at least some of the issues reported in #1016
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
