### PR TITLE
Add check for `vsphere_virtual_machine` power state

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -278,7 +278,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Computed:    true,
 			Description: "The machine object ID from VMware vSphere.",
 		},
-       		"power_state": {
+		"power_state": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "The power state of the virtual machine.",
@@ -1022,23 +1022,6 @@ func resourceVSphereVirtualMachineCustomizeDiff(_ context.Context, d *schema.Res
 	// ValidateVirtualMachineClone.
 	if err = virtualdevice.VerifyVAppTransport(d); err != nil {
 		return err
-	}
-
-        // Check the power state diff for virtual machine
-	power_state := d.Get("power_state").(string)
-	switch power_state {
-	case "poweredOn":
-		if power_state == "on" {
-			d.SetNew("power_state", "on")
-		}
-	case "poweredOff":
-		if power_state == "off" {
-			d.SetNew("power_state", "off")
-		}
-	case "suspended":
-		if power_state == "suspended" {
-			d.SetNew("power_state", "suspended")
-		}
 	}
 
 	log.Printf("[DEBUG] %s: Diff customization and validation complete", resourceVSphereVirtualMachineIDString(d))

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1489,6 +1489,8 @@ The following attributes are exported on the base level of this resource:
 
 * `vapp_transport` - Computed value which is only valid for cloned virtual machines. A list of vApp transport methods supported by the source virtual machine or template.
 
+* `power_state` - A computed value for the current power state of the virtual machine. One of `on`, `off`, or `suspended`.
+
 [docs-about-morefs]: https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Importing 


### PR DESCRIPTION
### Description

Added a computed parameter (power_state) for checking the power state of VM and to show the difference in case VM is not in running state.
Related to https://github.com/hashicorp/terraform-provider-vsphere/issues/916

When VM is not running and we run terraform plan, it will show the following diff:
This is tested with Terraform 0.13.3 version.

```console
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

local_file.meta-data[0]: Refreshing state... [id=221754ffcbea5c01e45fcf0cc40be37aeaa33fda]

vsphere_virtual_machine.example-vm[0]: Refreshing state... [id=564d7840-81a1-72c1-463b-0cc137eed6ea]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

vsphere_virtual_machine.example-vm[0] will be updated in-place
  ~ resource "vsphere_virtual_machine" "example-vm" {
        boot_delay                              = 0
        boot_retry_delay                        = 10000
        boot_retry_enabled                      = false
        change_version                          = "2020-12-28T06:39:57.251199Z"
        cpu_hot_add_enabled                     = false
        cpu_hot_remove_enabled                  = false
        cpu_limit                               = -1
        cpu_performance_counters_enabled        = false
        cpu_reservation                         = 0
        cpu_share_count                         = 1000
        cpu_share_level                         = "normal"
        datastore_id                            = "5bd0b7d5-02d4a3bb-154a-ac162d77f63c"
        efi_secure_boot_enabled                 = false
        enable_disk_uuid                        = false
        enable_logging                          = false
        ept_rvi_mode                            = "automatic"
        extra_config                            = {}
        firmware                                = "bios"
        force_power_off                         = true
        guest_id                                = "centos8_64Guest"
        guest_ip_addresses                      = []
        hardware_version                        = 14
        host_system_id                          = "ha-host"
        hv_mode                                 = "hvAuto"
        id                                      = "564d7840-81a1-72c1-463b-0cc137eed6ea"
        ide_controller_count                    = 2
        latency_sensitivity                     = "normal"
        memory                                  = 1024
        memory_hot_add_enabled                  = false
        memory_limit                            = -1
        memory_reservation                      = 0
        memory_share_count                      = 10240
        memory_share_level                      = "normal"
        migrate_wait_timeout                    = 30
        moid                                    = "1635"
        name                                    = "example-vm"
        nested_hv_enabled                       = false
        num_cores_per_socket                    = 1
        num_cpus                                = 1
        pci_device_id                           = []
      ~ power_state                             = "shutdown" -> "running"
        poweron_timeout                         = 300
        reboot_required                         = false
        resource_pool_id                        = "ha-root-pool"
        run_tools_scripts_after_power_on        = true
        run_tools_scripts_after_resume          = true
        run_tools_scripts_before_guest_reboot   = false
        run_tools_scripts_before_guest_shutdown = true
        run_tools_scripts_before_guest_standby  = true
        sata_controller_count                   = 0
        scsi_bus_sharing                        = "noSharing"
        scsi_controller_count                   = 1
        scsi_type                               = "pvscsi"
        shutdown_wait_timeout                   = 3
        swap_placement_policy                   = "inherit"
        sync_time_with_host                     = false
        uuid                                    = "564d7840-81a1-72c1-463b-0cc137eed6ea"
        vapp_transport                          = []
        vmware_tools_status                     = "guestToolsNotRunning"
        vmx_path                                = "example-vm/example-vm.vmx"
        wait_for_guest_ip_timeout               = 0
        wait_for_guest_net_routable             = true
        wait_for_guest_net_timeout              = 0
```

### Release Note

`resource/virtual_machine` : Adds support to check the power state of the resource. [GH-1407]

### References

Closes https://github.com/hashicorp/terraform-provider-vsphere/issues/916