### PR TITLE
Address PolicyIDByVirtualMachine and PolicyIDByVirtualDisk errors when deploying VM on ESXi.

### DIFF
--- a/vsphere/internal/helper/spbm/spbm_helper.go
+++ b/vsphere/internal/helper/spbm/spbm_helper.go
@@ -14,6 +14,13 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func IsSupported(client *govmomi.Client) bool {
+	if err := viapi.ValidateVirtualCenter(client); err != nil {
+		return false
+	}
+	return true
+}
+
 // pbmClientFromGovmomiClient creates a new pbm client from given govmomi client.
 // Can we have it in govmomi client as a field similar to tag client?
 // We should not create a new pbm client every time we need it.

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1300,18 +1300,20 @@ func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 		}
 	}
 
-	// Set storage policy if the VM exists.
-	vmUUID := r.rdd.Id()
-	if vmUUID != "" {
-		result, err := virtualmachine.MOIDForUUID(r.client, vmUUID)
-		if err != nil {
-			return err
+	if spbm.IsSupported(r.client) {
+		// Set storage policy if the VM exists.
+		vmUUID := r.rdd.Id()
+		if vmUUID != "" {
+			result, err := virtualmachine.MOIDForUUID(r.client, vmUUID)
+			if err != nil {
+				return err
+			}
+			polID, err := spbm.PolicyIDByVirtualDisk(r.client, result.MOID, r.Get("key").(int))
+			if err != nil {
+				return err
+			}
+			r.Set("storage_policy_id", polID)
 		}
-		polID, err := spbm.PolicyIDByVirtualDisk(r.client, result.MOID, r.Get("key").(int))
-		if err != nil {
-			return err
-		}
-		r.Set("storage_policy_id", polID)
 	}
 
 	log.Printf("[DEBUG] %s: Read finished (key and device address may have changed)", r)

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -493,12 +493,15 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error reading virtual machine configuration: %s", err)
 	}
 
-	// Read the VM Home storage policy if associated.
-	polID, err := spbm.PolicyIDByVirtualMachine(client, moid)
-	if err != nil {
-		return err
+	// Check if running for ESXi or vCenter.
+	if spbm.IsSupported(client) {
+		// Read the VM Home storage policy if associated.
+		polID, err := spbm.PolicyIDByVirtualMachine(client, moid)
+		if err != nil {
+			return err
+		}
+		d.Set("storage_policy_id", polID)
 	}
-	_ = d.Set("storage_policy_id", polID)
 
 	// Read the PCI passthrough devices.
 	var pciDevs []string


### PR DESCRIPTION
### Description

This PR will address #1033 issue for ESXi as storage policy related APIs are supported only for vCenter.
This will also address the following error for ESXi related to storage policy for virtual disks:
Error: disk.0: this operation is only supported on vCenter: RESOURCE (1625), ACTION (PolicyIDByVirtualDisk)

This is tested with Terraform 0.13.3 version.

$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

local_file.meta-data[0]: Refreshing state... [id=531754ffcbea5c01e45fcf0cc40be37aeaa34rte]
...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
~ update in-place

Terraform will perform the following actions:

vsphere_virtual_machine.example-vm[0] will be updated in-place
~ resource "vsphere_virtual_machine" "example-vm" {
boot_delay = 0
boot_retry_delay = 10000
boot_retry_enabled = false
change_version = "2021-05-15T07:40:57.251199Z"
cpu_hot_add_enabled = false
cpu_hot_remove_enabled = false
cpu_limit = -1
cpu_performance_counters_enabled = false
cpu_reservation = 0
cpu_share_count = 1000
cpu_share_level = "normal"
datastore_id = "5bd0b7d5-02d4a3bb-154a-ac162d77f63c"
efi_secure_boot_enabled = false
enable_disk_uuid = false
enable_logging = false
ept_rvi_mode = "automatic"
extra_config = {}
firmware = "bios"
force_power_off = true
guest_id = "centos8_64Guest"
guest_ip_addresses = []
hardware_version = 14
host_system_id = "ha-host"
hv_mode = "hvAuto"
id = "574d7840-19a1-45df-543b-4cd145eda7as"
ide_controller_count = 2
latency_sensitivity = "normal"
memory = 1024
memory_hot_add_enabled = false
memory_limit = -1
memory_reservation = 0
memory_share_count = 10240
memory_share_level = "normal"
migrate_wait_timeout = 30
moid = "1635"
name = "example-vm"
nested_hv_enabled = false
num_cores_per_socket = 1
num_cpus = 1
pci_device_id = []
poweron_timeout = 300
reboot_required = false
resource_pool_id = "ha-root-pool"
run_tools_scripts_after_power_on = true
run_tools_scripts_after_resume = true
run_tools_scripts_before_guest_reboot = false
run_tools_scripts_before_guest_shutdown = true
run_tools_scripts_before_guest_standby = true
sata_controller_count = 0
scsi_bus_sharing = "noSharing"
scsi_controller_count = 1
scsi_type = "pvscsi"
shutdown_wait_timeout = 3
swap_placement_policy = "inherit"
sync_time_with_host = false
uuid = "574d7840-19a1-45df-543b-4cd145eda7as"
vapp_transport = []
vmware_tools_status = "guestToolsNotRunning"
vmx_path = "example-vm/example-vm.vmx"
wait_for_guest_ip_timeout = 0
wait_for_guest_net_routable = true
wait_for_guest_net_timeout = 0
....

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->
```release-note
Fix for these two issues:
Error: this operation is only supported on vCenter: RESOURCE (52), ACTION (PolicyIDByVirtualMachine)
Error: disk.0: this operation is only supported on vCenter: RESOURCE (1625), ACTION (PolicyIDByVirtualDisk)
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
https://github.com/hashicorp/terraform-provider-vsphere/issues/1033
