### PR TITLE
`vsan_disk_group` should be of type `TypeSet`

### DIFF
--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -478,7 +478,7 @@ func resourceVSphereComputeCluster() *schema.Resource {
 				Description: "Whether the VSAN service is enabled for the cluster.",
 			},
 			"vsan_disk_group": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,
 				Description: "A list of disk UUIDs to add to the vSAN cluster.",


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Change the type of `vsan_disk_group` from `typelist` to `typeset`. When it is a list, the order of it is random every time `terraform plan` is called and causes a change in the vSAN disk groups, resulting in disks being deleted and re-added into the disk group every time you run `terraform apply`. This issue has already been raised here: https://github.com/hashicorp/terraform-provider-vsphere/issues/1205.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/compute_cluster` - `vsan_disk_group` is now a set and the order will be preserved between `terraform` runs
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
* https://github.com/hashicorp/terraform-provider-vsphere/issues/1205.