### PR TITLE
fix: Address `r/virtual_disk` type query failure

### DIFF
--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -301,7 +301,8 @@ func resourceVSphereVirtualDiskRead(d *schema.ResourceData, meta interface{}) er
 	}
 	diskType, err := virtualdisk.QueryDiskType(client, dp.String(), dc)
 	if err != nil {
-		return errors.New("Failed to query disk type")
+		log.Printf("[WARN] Failed to query disk type")
+		return nil
 	}
 
 	// adapter_type is deprecated, so just default.

--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -301,7 +301,7 @@ func resourceVSphereVirtualDiskRead(d *schema.ResourceData, meta interface{}) er
 	}
 	diskType, err := virtualdisk.QueryDiskType(client, dp.String(), dc)
 	if err != nil {
-		log.Printf("[WARN] Failed to query disk type")
+		log.Printf("[WARN] Unable to read diskType, skipping")
 		return nil
 	}
 


### PR DESCRIPTION
### Description

This pull request issues a warning rather than failure when queries for a disk's type return no attributes.

Applicable on vSphere 6.5 - 7.0.

### Manual testing

Patched provider and confirmed working on vSphere 6.7

### Release Note

`resource/virtual_disk`: Adds a warning when a virtual disk's type query fails.

### References

Resolves #1191