### PR TITLE
Update content_library.html.markdown

### DIFF
--- a/website/docs/r/content_library.html.markdown
+++ b/website/docs/r/content_library.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
   * `username` - (Optional) User name to log in with.
   * `password` - (Optional) Password to log in with.
   * `automatic_sync` - (Optional) Enable automatic synchronization with the external content library.
-  * `on_demand` - (Optional) Download all library content immediately.
+  * `on_demand` - (Optional) Boolean determining whether the content is immediately downloaded. When set to `true `, the library content will be downloaded when needed. When set to `false`, the library content will be downloaded immediately.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 


### PR DESCRIPTION
### Description

The current wording for the description of the `on_demand` attribute is confusing. When set to true, "on_demand" will not download all library content immediately (it's the opposite). 


