### PR TITLE
force reconfigure due to race condition

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1577,7 +1577,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] %s: Final device change cfgSpec: %s", resourceVSphereVirtualMachineIDString(d), virtualdevice.DeviceChangeString(cfgSpec.DeviceChange))
 
 	// Perform updates
-  err = virtualmachine.Reconfigure(vm, cfgSpec)
+	err = virtualmachine.Reconfigure(vm, cfgSpec)
 	if err != nil {
 		return resourceVSphereVirtualMachineRollbackCreate(
 			d,

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1577,11 +1577,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] %s: Final device change cfgSpec: %s", resourceVSphereVirtualMachineIDString(d), virtualdevice.DeviceChangeString(cfgSpec.DeviceChange))
 
 	// Perform updates
-	if _, ok := d.GetOk("datastore_cluster_id"); ok {
-		err = resourceVSphereVirtualMachineUpdateReconfigureWithSDRS(d, meta, vm, cfgSpec)
-	} else {
-		err = virtualmachine.Reconfigure(vm, cfgSpec)
-	}
+  err = virtualmachine.Reconfigure(vm, cfgSpec)
 	if err != nil {
 		return resourceVSphereVirtualMachineRollbackCreate(
 			d,


### PR DESCRIPTION
### Description

This change removes the conditional logic whereby if the datastore is known, that value is used. In some cases the previously obtained datastore value is incorrect due to an immediate vmotion event that occurs between the initial clone and the post update operations.

### Acceptance tests
This issue was observed in production and has been resistant to reproduction due to the numerous factors involved in inducing an immediate vmotion fast enough.

### Release Note

```release-note
Don't assume the datastore is the same between create and post updates
```