### PR TITLE
EFI firmware should be lowercase

### DIFF
--- a/vsphere/data_source_vsphere_ovf_vm_template.go
+++ b/vsphere/data_source_vsphere_ovf_vm_template.go
@@ -80,7 +80,7 @@ func dataSourceVSphereOvfVMTemplate() *schema.Resource {
 		"firmware": {
 			Type:        schema.TypeString,
 			Computed:    true,
-			Description: "The firmware interface to use on the virtual machine. Can be one of bios or EFI.",
+			Description: "The firmware interface to use on the virtual machine. Can be one of bios or efi.",
 		},
 		"sata_controller_count": {
 			Type:        schema.TypeInt,

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -278,7 +278,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Default:      string(types.GuestOsDescriptorFirmwareTypeBios),
-			Description:  "The firmware interface to use on the virtual machine. Can be one of bios or EFI.",
+			Description:  "The firmware interface to use on the virtual machine. Can be one of bios or efi.",
 			ValidateFunc: validation.StringInSlice(virtualMachineFirmwareAllowedValues, false),
 		},
 		"extra_config": {

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -69,7 +69,7 @@ The following attributes are exported:
   virtual machine.
 * `num_cores_per_socket` - The number of cores per socket for this virtual machine.
 * `firmware` - The firmware interface that is used by this virtual machine. Can be
-  either `bios` or `EFI`.
+  either `bios` or `efi`.
 * `hardware_version` - The hardware version number on this virtual machine.
 * `scsi_type` - The common type of all SCSI controllers on this virtual machine.
   Will be one of `lsilogic` (LSI Logic Parallel), `lsilogic-sas` (LSI Logic

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -638,7 +638,7 @@ connections.
 * `annotation` - (Optional) A user-provided description of the virtual machine.
   The default is no annotation.
 * `firmware` - (Optional) The firmware interface to use on the virtual machine.
-  Can be one of `bios` or `EFI`. Default: `bios`.
+  Can be one of `bios` or `efi`. Default: `bios`.
 * `extra_config` - (Optional) Extra configuration data for this virtual
   machine. Can be used to supply advanced parameters not normally in
   configuration, such as instance metadata. 


### PR DESCRIPTION
### Description

EFI firmware should be lowercase.
See `vendor/github.com/vmware/govmomi/vim25/types/enum.go`
```
const (
	GuestOsDescriptorFirmwareTypeBios = GuestOsDescriptorFirmwareType("bios")
	GuestOsDescriptorFirmwareTypeEfi  = GuestOsDescriptorFirmwareType("efi")
)
```

### Acceptance tests
N/A

Output from acceptance testing:

N/A

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
