### PR TITLE
Add support for dvs versions `6.6.0` and `7.0.3`

### DIFF
--- a/vsphere/distributed_virtual_switch_helper.go
+++ b/vsphere/distributed_virtual_switch_helper.go
@@ -19,8 +19,10 @@ var dvsVersions = []string{
 	"5.5.0",
 	"6.0.0",
 	"6.5.0",
+	"6.6.0",
 	"7.0.0",
 	"7.0.2",
+	"7.0.3",
 }
 
 // dvsFromUUID gets a DVS object from its UUID.

--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -749,7 +749,7 @@ func schemaDVSCreateSpec() map[string]*schema.Schema {
 		"version": {
 			Type:         schema.TypeString,
 			Computed:     true,
-			Description:  "The version of this virtual switch. Allowed versions are 7.0.0, 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
+			Description:  "The version of this virtual switch. Allowed versions are 7.0.3, 7.0.0, 6.6.0, 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice(dvsVersions, false),
 		},


### PR DESCRIPTION
### Description

Adds support for:
- vSphere 6.7 (`6.6.0`)
- vSphere 7.0 Update 3 (`7.0.3`)

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Have run unit tests for added `6.6.0` and `7.0.3`, regression tests for existing versions, and negative tests for non-compliant dvs versions.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):

```release-note
Adds support for dvs versions `6.6.0` and `7.0.3`.
```
### References

Resolves #1291 
