### PR TITLE
Add `disabled` to `vsphere_ha_vm_override`

### DIFF
--- a/vsphere/resource_vsphere_ha_vm_override.go
+++ b/vsphere/resource_vsphere_ha_vm_override.go
@@ -34,6 +34,7 @@ var vmOverrideClusterDasConfigInfoServiceStateAllowedValues = []string{
 	string(types.ClusterDasVmSettingsRestartPriorityMedium),
 	string(types.ClusterDasVmSettingsRestartPriorityHigh),
 	string(types.ClusterDasVmSettingsRestartPriorityHighest),
+	string(types.ClusterDasVmSettingsRestartPriorityDisabled),
 }
 
 var vmOverrideClusterVMStorageProtectionForPDLAllowedValues = []string{

--- a/website/docs/r/ha_vm_override.html.markdown
+++ b/website/docs/r/ha_vm_override.html.markdown
@@ -17,7 +17,7 @@ while not affecting the rest of the cluster.
 
 For more information on vSphere HA, see [this page][ref-vsphere-ha-clusters].
 
-[ref-vsphere-ha-clusters]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html
+[ref-vsphere-ha-clusters]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html
 
 ~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
 connections.
@@ -32,8 +32,8 @@ virtual machine in the cluster looked up by the
 Considering a scenario where this virtual machine is of high value to the
 application or organization for which it does its work, it's been determined in
 the event of a host failure, that this should be one of the first virtual
-machines to be started by vSphere HA during recovery. Hence, its
-[`ha_vm_restart_priority`](#ha_vm_restart_priority) as been set to `highest`,
+machines to be started by vSphere HA during recovery. Hence, it
+[`ha_vm_restart_priority`](#ha_vm_restart_priority) has been set to `highest`,
 which, assuming that the default restart priority is `medium` and no other
 virtual machine has been assigned the `highest` priority, will mean that this
 VM will be started before any other virtual machine in the event of host
@@ -126,7 +126,7 @@ for an entire list of version restrictions.
 
 * `ha_vm_restart_priority` - (Optional) The restart priority for the virtual
   machine when vSphere detects a host failure. Can be one of
-  `clusterRestartPriority`, `lowest`, `low`, `medium`, `high`, or `highest`.
+  `clusterRestartPriority`, `lowest`, `low`, `medium`, `high`, `highest`, or `disabled`.
   Default: `clusterRestartPriority`.
 * `ha_vm_restart_timeout` - (Optional) The maximum time, in seconds, that
   vSphere HA will wait for this virtual machine to be ready. Use `-1` to


### PR DESCRIPTION
### Description

- Adds `disabled`option to `vsphere_ha_vm_overide` resource.
- Updates `vsphere_ha_vm_overide`resource docs to include `disabled`.
- Updates `vsphere_ha_vm_overide`resource docs to vSphere 7.0 reference.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

**Contributor Note:** Performed unit tests which included both positive and negative tests. All passed successfully.

**Example:**

**`variables.tf`**

```hcl
##################################################################################
# VARIABLES
##################################################################################

# Credentials

variable "vsphere_server" {
  type        = string
  description = "The fully qualified domain name or IP address of the vCenter Server instance."
}

variable "vsphere_username" {
  type        = string
  description = "The username to login to the vCenter Server instance."
}

variable "vsphere_password" {
  type        = string
  description = "The password for the login to the vCenter Server instance."
}

variable "vsphere_insecure" {
  type        = bool
  description = "Set to true for self-signed certificates."
  default     = false
}

# vSphere Objects

variable "vsphere_datacenter" {
  type        = string
  description = "The target vSphere datacenter object name (e.g. sfo-m01-dc01)"
}

variable "vsphere_cluster" {
  type        = string
  description = "The target vSphere cluster object name (e.g. sfo-m01-cl01)"
}

# vSphere HA - Virtual Machinee Startup Priority Overrides

variable "overrides" {
  type = map(object({
    vm    = string
    level = string
  }))
  description = "A mapping of objects and their priority level."
}
```

**`terraform.tfvars`**

```hcl
##################################################################################
# VARIABLES
##################################################################################

# Credentials

vsphere_server   = "sfo-m01-vc01.rainpole.io"
vsphere_username = "svc-terraform-vsphere@rainpole.io"
vsphere_password = "************"
vsphere_insecure = false

# vSphere Objects

vsphere_datacenter = "sfo-m01-dc01"
vsphere_cluster    = "sfo-m01-cl01"

# vSphere HA - Virtual Machine Startup Priority Overrides

overrides = {
  override0 = {
    vm = "ubuntu-0"
    level = "disabled"
  }
  override1 = {
    vm = "ubuntu-1"
    level = "disabled"
  }
}
```

**`main.tf`**

```hcl
terraform {
  required_providers {
    vsphere = {
      source  = "local/vmware/vsphere"
      version = "x.y.z"
    }
  }
  required_version = ">= 1.0.9"
}

##################################################################################
# PROVIDERS
##################################################################################

provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

##################################################################################
# DATA
##################################################################################

data "vsphere_datacenter" "dc" {
  name = var.vsphere_datacenter
}

data "vsphere_compute_cluster" "cluster" {
  name          = var.vsphere_cluster
  datacenter_id = data.vsphere_datacenter.dc.id
}

data "vsphere_virtual_machine" "vm" {
  for_each      = var.overrides
  name          = each.value["vm"]
  datacenter_id = data.vsphere_datacenter.dc.id
}

##################################################################################
# RESOURCES
##################################################################################

resource "vsphere_ha_vm_override" "ha_vm_override" {
  for_each           = var.overrides
  compute_cluster_id = data.vsphere_compute_cluster.cluster.id
  virtual_machine_id = data.vsphere_virtual_machine.vm[each.key].id
  ha_vm_restart_priority = each.value["level"]
}
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):

```release-note
Adds `disabled` option to `vsphere_ha_vm_override` resource.
```
### References

Resolves #1493