### PR TITLE
Add `tools_upgrade_policy` argument to the `vsphere_virtual_machine` resource

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -38,6 +38,11 @@ var virtualMachineSwapPlacementAllowedValues = []string{
 	string(types.VirtualMachineConfigInfoSwapPlacementTypeHostLocal),
 }
 
+var virtualMachineUpgradePolicyAllowedValues = []string{
+	string(types.UpgradePolicyManual),
+	string(types.UpgradePolicyUpgradeAtPowerCycle),
+}
+
 var virtualMachineFirmwareAllowedValues = []string{
 	string(types.GuestOsDescriptorFirmwareTypeBios),
 	string(types.GuestOsDescriptorFirmwareTypeEfi),
@@ -50,7 +55,7 @@ var virtualMachineLatencySensitivityAllowedValues = []string{
 	string(types.LatencySensitivitySensitivityLevelHigh),
 }
 
-// getWithRestart fetches the resoruce data specified at key. If the value has
+// getWithRestart fetches the resource data specified at key. If the value has
 // changed, a reboot is flagged in the virtual machine by setting
 // reboot_required to true.
 func getWithRestart(d *schema.ResourceData, key string) interface{} {
@@ -144,6 +149,13 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Description: "Enable guest clock synchronization with the host. On vSphere 7.0 U1 and above, with only this setting the clock is synchronized on startup and resume. Requires VMware Tools to be installed.",
+		},
+		"tools_upgrade_policy": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      string(types.UpgradePolicyManual),
+			Description:  "Set the upgrade policy for VMware Tools. Can be one of manual or upgradeAtPowerCycle.",
+			ValidateFunc: validation.StringInSlice(virtualMachineUpgradePolicyAllowedValues, false),
 		},
 		"sync_time_with_host_periodically": {
 			Type:        schema.TypeBool,
@@ -413,6 +425,7 @@ func flattenVirtualMachineFlagInfo(d *schema.ResourceData, obj *types.VirtualMac
 func expandToolsConfigInfo(d *schema.ResourceData, client *govmomi.Client) *types.ToolsConfigInfo {
 	obj := &types.ToolsConfigInfo{
 		SyncTimeWithHost:    structure.GetBool(d, "sync_time_with_host"),
+		ToolsUpgradePolicy:  getWithRestart(d, "tools_upgrade_policy").(string),
 		AfterPowerOn:        getBoolWithRestart(d, "run_tools_scripts_after_power_on"),
 		AfterResume:         getBoolWithRestart(d, "run_tools_scripts_after_resume"),
 		BeforeGuestStandby:  getBoolWithRestart(d, "run_tools_scripts_before_guest_standby"),
@@ -432,6 +445,7 @@ func expandToolsConfigInfo(d *schema.ResourceData, client *govmomi.Client) *type
 // ToolsConfigInfo into the passed in ResourceData.
 func flattenToolsConfigInfo(d *schema.ResourceData, obj *types.ToolsConfigInfo, client *govmomi.Client) error {
 	_ = d.Set("sync_time_with_host", obj.SyncTimeWithHost)
+	_ = d.Set("tools_upgrade_policy", obj.ToolsUpgradePolicy)
 	_ = d.Set("run_tools_scripts_after_power_on", obj.AfterPowerOn)
 	_ = d.Set("run_tools_scripts_after_resume", obj.AfterResume)
 	_ = d.Set("run_tools_scripts_before_guest_standby", obj.BeforeGuestStandby)

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -154,7 +154,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Default:      string(types.UpgradePolicyManual),
-			Description:  "Set the upgrade policy for VMware Tools. Can be one of manual or upgradeAtPowerCycle.",
+			Description:  "Set the upgrade policy for VMware Tools. Can be one of `manual` or `upgradeAtPowerCycle`.",
 			ValidateFunc: validation.StringInSlice(virtualMachineUpgradePolicyAllowedValues, false),
 		},
 		"sync_time_with_host_periodically": {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -744,6 +744,11 @@ The following options control boot settings on a virtual machine:
 
 The following options control VMware Tools settings on the virtual machine:
 
+* `tools_upgrade_policy` - (Optional) Enable automatic upgrade of the VMware Tools
+version when the virtual machine is rebooted. If necessary, VMware Tools is upgraded
+to the latest version supported by the host on which the virtual machine is running.
+Requires VMware tools to be installed. One of `manual` or `upgradeAtPowerCycle`. Default: `manual`.
+
 * `sync_time_with_host` - (Optional) Enable the guest operating system to synchronization its clock with the host when the virtual machine is powered on or resumed. Requires vSphere 7.0 Update 1 and later. Requires VMware Tools to be installed. Default: `false`.
 
 * `sync_time_with_host_periodically` - (Optional) Enable the guest operating system to periodically synchronize its clock with the host. Requires vSphere 7.0 Update 1 and later. On previous versions, setting `sync_time_with_host` is will enable periodic synchronization. Requires VMware Tools to be installed. Default: `false`.


### PR DESCRIPTION
### Description

- Add `tools_upgrade_policy` argument to the `vsphere_virtual_machine` resource to set the upgrade policy for VMware Tools. One of `manual` or `upgradeAtPowerCycle`. Default: `manual`
- Updates the `vsphere_virtual_machine` resource docs to include the tools_upgrade_policy` argument.

### Testing
 Performed unit tests which included both positive and negative tests. All passed successfully.

Example:

```hcl
terraform {
  required_providers {
    vsphere = {
      source  = "hashicorp/vsphere"
      version = "x.y.z"
    }
  }
  required_version = ">= x.y.z"
}

provider "vsphere" {
  vsphere_server       = "m01-vc01.rainpole.io"
  user                 = "administrator@vsphere.local"
  password             = "VMware1!"
  allow_unverified_ssl = true
}

data "vsphere_datacenter" "datacenter" {
  name = "m01-dc01"
}

data "vsphere_network" "network" {
  name          = "M - 172.16.11.0"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_compute_cluster" "cluster" {
  name          = "m01-cl01"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_resource_pool" "pool" {
  name          = format("%s%s", data.vsphere_compute_cluster.cluster.name, "/Resources")
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_datastore" "datastore" {
  name          = "local-ssd-01"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_folder" "folder" {
  path = "/${data.vsphere_datacenter.datacenter.name}/vm/"
}

data "vsphere_virtual_machine" "template" {
  name          = "ubuntu-server-20-04-lts"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

resource "vsphere_virtual_machine" "vm" {
  name                    = "gh-1297"
  folder                  = trimprefix(data.vsphere_folder.folder.path, "/${data.vsphere_datacenter.datacenter.name}/vm") 
  datastore_id            = data.vsphere_datastore.datastore.id
  resource_pool_id        = data.vsphere_resource_pool.pool.id
  num_cpus                = 2
  memory                  = 4096
  firmware                = "efi"
  efi_secure_boot_enabled = true
  guest_id                = data.vsphere_virtual_machine.template.guest_id
  tools_upgrade_policy    = "upgradeAtPowerCycle" // <----- Set upgrade policy for VMware Tools.
  network_interface {
    network_id = data.vsphere_network.network.id
  }
  disk {
    label = "disk0"
    size  = 60
    thin_provisioned = true
  }
  clone {
    template_uuid = data.vsphere_virtual_machine.template.id
    customize {
      linux_options {
        host_name = "gh-1292"
        domain    = "rainpole.io"
      }
      network_interface {
        ipv4_address = "172.16.11.100"
        ipv4_netmask = "24"
      }

      ipv4_gateway    = "172.16.11.1"
      dns_suffix_list = ["rainpole.io"]
      dns_server_list = ["172.16.11.11", "172.16.11.12"]
    }
  }
}
```

### Release Note

 `resource/virtual_machine`: Adds the `tools_upgrade_policy` argument to to set the upgrade policy for VMware Tools. One of `manual` or `upgradeAtPowerCycle`. Default: `manual`. Will force a reboot. GH-1506


### References

Closes: #1297 
