### PR TITLE
Update `content_library_item` data source docs 

### DIFF
--- a/website/docs/d/content_library_item.html.markdown
+++ b/website/docs/d/content_library_item.html.markdown
@@ -4,25 +4,37 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_content_library_item"
 sidebar_current: "docs-vsphere-data-source-content-library-item"
 description: |-
-  Provides a VMware Content Library item data source.
+  Provides a VMware vSphere content library item data source.
 ---
 
 # vsphere\_content\_library\_item
 
-The `vsphere_content_library_item` data source can be used to discover the ID of a Content Library item.
+The `vsphere_content_library_item` data source can be used to discover the ID of a content library item.
 
-~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
-connections.
+~> **NOTE:** This resource requires vCenter Server and is not available on direct ESXi host connections.
 
 ## Example Usage
 
 ```hcl
 data "vsphere_content_library" "library" {
-  name = "Content Library Test"
+  name = "Content Library"
 }
 
 data "vsphere_content_library_item" "item" {
-  name       = "Ubuntu Bionic 18.04"
+  name       = "ovf-ubuntu-server-lts"
+  type       = "ovf"
+  library_id = data.vsphere_content_library.library.id
+}
+
+data "vsphere_content_library_item" "item" {
+  name       = "tpl-ubuntu-server-lts"
+  type       = "vm-template"
+  library_id = data.vsphere_content_library.library.id
+}
+
+data "vsphere_content_library_item" "item" {
+  name       = "iso-ubuntu-server-lts"
+  type       = "iso"
   library_id = data.vsphere_content_library.library.id
 }
 ```
@@ -31,11 +43,10 @@ data "vsphere_content_library_item" "item" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Content Library.
-* `library_id` - (Required) The ID of the Content Library the item exists in.
-
+* `name` - (Required) The name of the content library item.
+* `library_id` - (Required) The ID of the content library in which the item exists.
+* `type` - (Required) The type for the content library item. One of `ovf`, `vm-template`, or `iso`
 
 ## Attribute Reference
 
-* `id` - The UUID of the Content Library item.
-* `type` - The Content Library type. Can be ovf, iso, or vm-template.
+* `id` - The UUID of the content library item.


### PR DESCRIPTION
Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

### Description

- Updates the `name` argument description for accuracy.
- Updates the documentation with the required `type` argument. 
- Updates the example usage to depict each `type`.
- Minor formatting and context updates for accuracy.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?
- [X] Not applicable.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):

```release-note
- Updates the `content_library_item` data source documentation with the required `type` argument. 
- Updates the `content_library_item` data source documentation example usage to depict each `type`.
```
### References

- Closes #1340 -  `name` argument description error.
- Closes #1245 - documentation gap. 