### PR TITLE
Update settings for GitHub Actions

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -1,4 +1,17 @@
 dependencies:
-  - vendor/**/*
+  - 'vendor/**/*'
 documentation:
-  - website/**/*
+  - '**/*.md'
+  - 'examples/**/*''
+  - 'website/**/*'
+provider:
+  - '.circleci/**/*'
+  - '.github/**/*'
+  - '.gitignore'
+  - '.go-version'
+  - '*.md'
+  - 'docs/**/*'
+  - 'GNUmakefile'
+  - 'main.go'
+  - 'vsphere/**/*'
+  - 'website/docs/index.html.markdown'

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
-          labels: |
-            stale
-            waiting-reply
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: stale
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: waiting-response

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: github/issue-labeler@v2
+    - uses: github/issue-labeler@v2.4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml
+        enable-versioned-regex: 0

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,22 +2,20 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '49 1 * * *'
+    - cron: '50 1 * * *'
 
 jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v3
         with:
           github-token: ${{ github.token }}
           issue-lock-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
-
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
           issue-lock-inactive-days: '30'
           pr-lock-comment: >
             I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
-
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
           pr-lock-inactive-days: '30'


### PR DESCRIPTION
### Description

This pull request addresses some issues and gaps with the projects use of GitHub Actions:

* `.github/workflows/lock.yml` : 
   Updates to `dessant/lock-threads@v3` as also used by `terraform-provider-aws`

* `.github/workflows/issue-comment-created.yml`: 
   Updates label from `waiting-reply` to `waiting-response` due to failing GitHub Actions.  `waiting-response` is the correct label used in the project issues.
   
   <img width="1792" alt="image" src="https://user-images.githubusercontent.com/7771363/142774754-c09799c2-51b7-447f-90bb-9dd7d009c0d9.png">

   <img width="979" alt="image" src="https://user-images.githubusercontent.com/7771363/142774745-33d5d974-baf8-4eb4-93cb-2cf9975c8ce0.png">

* `.github/workflows/issue-opened.yml`:
   Updates to `github/issue-labeler@v2.4` since the use of `github/issue-labeler@v2` is failing since it does not exist. (Also used by `terraform-provider-aws` project.)

   <img width="1357" alt="image" src="https://user-images.githubusercontent.com/7771363/142774783-6c477ebe-2ea0-4222-a7c2-d16dc3fd3d84.png">

* `.github/labeler-pull-request-triage.yml`
   Updates the settings for the pull request labeler to apply the appropriate labels to a pull request based on the files changed.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user-facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

