### PR TITLE
Fix silent failure on vm datasource

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -132,6 +132,11 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 				},
 			},
 		},
+		"default_ip_address": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The default IP address.",
+		},
 		"guest_ip_addresses": {
 			Type:        schema.TypeList,
 			Description: "The current list of IP addresses on this virtual machine.",

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -117,6 +117,11 @@ The following attributes are exported:
  * `network_id` - The managed object reference ID of the network this interface is 
   connected to.
 * `firmware` - The firmware type for this virtual machine. Can be `bios` or `efi`.
+* `default_ip_address` - Whenever possible, this is the first IPv4 address that is reachable through
+  the default gateway configured on the machine, then the first reachable IPv6
+  address, and then the first general discovered address if neither exist. If
+  VMware tools is not running on the virtual machine, or if the VM is powered
+  off, this value will be blank.
 * `guest_ip_addresses` - A list of IP addresses as reported by VMWare tools.
 
 ~> **NOTE:** Keep in mind when using the results of `scsi_type` and


### PR DESCRIPTION
### Description
This field was failing to set silently, caught in acceptance tests.
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceVSphereVirtualMachine_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceVSphereVirtualMachine_ -timeout 240m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
=== RUN   TestAccDataSourceVSphereVirtualMachine_basic
--- PASS: TestAccDataSourceVSphereVirtualMachine_basic (30.22s)
=== RUN   TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath
--- PASS: TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath (29.57s)
PASS
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
