### PR TITLE
Added VM shutdown feature #1394

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -282,6 +282,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Type: schema.TypeString,
 			Optional:    true,
 			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{"SHUTDOWN"}, false),
 			Description: "Provide the desired status for virtual machine resource. Supported state: 'SHUTDOWN'",
 		},
 		vSphereTagAttributeKey:    tagsSchema(),
@@ -592,6 +593,10 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 				if err := virtualmachine.GracefulPowerOff(client, vm, timeout, true); err != nil {
 					return fmt.Errorf("error shutting down virtual machine: %s", err)
 				}
+			}
+			if desiredStatus != "SHUTDOWN" {
+				return fmt.Errorf("Supported desired status value of the instance can only be 'SHUTDOWN'")
+				
 			}
 		}
 

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -283,7 +283,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Optional:    true,
 			Computed: true,
 			ValidateFunc: validation.StringInSlice([]string{"SHUTDOWN"}, false),
-			Description: "Provide the desired status for virtual machine resource. Supported state: 'SHUTDOWN'",
+			Description: "Provide the desired status for a deployed virtual machine instance. Supported state is: 'SHUTDOWN'",
 		},
 		vSphereTagAttributeKey:    tagsSchema(),
 		customattribute.ConfigKey: customattribute.ConfigSchema(),

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -677,6 +677,9 @@ requires vCenter 6.0 or higher.
 and require vCenter.
 
 * `storage_policy_id` - (Optional) The UUID of the storage policy to assign to VM home directory.
+* `desired_status` - (Optional) Desired status of the instance, supported state is "SHUTDOWN".
+
+~> **NOTE** A running virtual machine instance can be powered off/shutdown using this "desired_status" option.
 
 ### CPU and memory options
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -677,7 +677,7 @@ requires vCenter 6.0 or higher.
 and require vCenter.
 
 * `storage_policy_id` - (Optional) The UUID of the storage policy to assign to VM home directory.
-* `desired_status` - (Optional) Desired status of the instance, supported state is "SHUTDOWN".
+* `desired_status` - (Optional) Desired status of the deployed virtual machine instance, supported state is "SHUTDOWN".
 
 ~> **NOTE** A running virtual machine instance can be powered off/shutdown using this "desired_status" option.
 


### PR DESCRIPTION
### Description

This feature helps to shutdown/poweroff a running virtual machine in the environment. User can import the deployed virtual machines using terraform configuration file for the existing infra he/she can pass this parameter and poweroff the state.

### Release Note
NONE
...
```
### References
https://github.com/hashicorp/terraform-provider-vsphere/issues/1394

