### PR TITLE
Update GHA for issues/pull-request locking

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -11,11 +11,11 @@ jobs:
       - uses: dessant/lock-threads@v3
         with:
           github-token: ${{ github.token }}
-          issue-lock-comment: >
+          issue-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          issue-lock-inactive-days: '30'
-          pr-lock-comment: >
+          issue-inactive-days: '30'
+          pr-comment: >
             I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          pr-lock-inactive-days: '30'
+          pr-inactive-days: '30'


### PR DESCRIPTION
### Description

Updates the GHA `dessant/lock-threads@v3` to use the v3.0.0 options for comments and inactive days, thus avoiding GHA warnings and missed locking of threads.

- issue-comment
- issue-inactive-days
- pr-comment
- pr-inactive-days

### References

Reference: https://github.com/marketplace/actions/lock-threads for v3.0.0.

Issue observed in https://github.com/tenthirtyam/terraform-provider-vsphere/actions/runs/1585598160

<img width="1736" alt="image" src="https://user-images.githubusercontent.com/7771363/146424130-39c158ac-1911-4710-a8a5-a4db6ab97c9a.png">

cc @iBrandyJackson @appilon 
