### PR TITLE
Update default GOS to `otherGuest64` from `other-64`

### DIFF
--- a/vsphere/data_source_vsphere_ovf_vm_template.go
+++ b/vsphere/data_source_vsphere_ovf_vm_template.go
@@ -75,7 +75,7 @@ func dataSourceVSphereOvfVMTemplate() *schema.Resource {
 		"alternate_guest_name": {
 			Type:        schema.TypeString,
 			Computed:    true,
-			Description: "The guest name for the operating system when guest_id is other or other-64.",
+			Description: "The guest name for the operating system when guest_id is otherGuest or otherGuest64.",
 		},
 		"firmware": {
 			Type:        schema.TypeString,

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1216,7 +1216,7 @@ func resourceVSphereVirtualMachineCreateBare(d *schema.ResourceData, meta interf
 	// environment info in the resource pool, which we can then filter through
 	// our device CRUD lifecycles to get a full deviceChange attribute for our
 	// configspec.
-	guestID := "other-64"
+	guestID := "otherGuest64"
 	if guestInterface, ok := d.GetOk("guest_id"); ok {
 		guestID = guestInterface.(string)
 	}

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -143,41 +143,41 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"sync_time_with_host": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "Enable guest clock synchronization with the host. On vSphere 7 U1 and above, with only this setting the clock is synchronized on startup and resume so consider also setting `sync_time_with_host_periodically`. Requires VMware tools to be installed.",
+			Description: "Enable guest clock synchronization with the host. On vSphere 7.0 U1 and above, with only this setting the clock is synchronized on startup and resume. Requires VMware Tools to be installed.",
 		},
 		"sync_time_with_host_periodically": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "Enable periodic clock synchronization with the host. Supported only on vSphere 7 U1 and above. On older versions setting `sync_time_with_host` is enough for periodic synchronization. Requires VMware tools to be installed.",
+			Description: "Enable periodic clock synchronization with the host. Supported only on vSphere 7.0 U1 and above. On prior versions setting `sync_time_with_host` is enough for periodic synchronization. Requires VMware Tools to be installed.",
 		},
 		"run_tools_scripts_after_power_on": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
-			Description: "Enable the execution of post-power-on scripts when VMware tools is installed.",
+			Description: "Enable the run of scripts after virtual machine power-on when VMware Tools is installed.",
 		},
 		"run_tools_scripts_after_resume": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
-			Description: "Enable the execution of post-resume scripts when VMware tools is installed.",
+			Description: "Enable the run of scripts after virtual machine resume when when VMware Tools is installed.",
 		},
 		"run_tools_scripts_before_guest_reboot": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "Enable the execution of pre-reboot scripts when VMware tools is installed.",
+			Description: "Enable the run of scripts before guest operating system reboot when VMware Tools is installed.",
 		},
 		"run_tools_scripts_before_guest_shutdown": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
-			Description: "Enable the execution of pre-shutdown scripts when VMware tools is installed.",
+			Description: "Enable the run of scripts before guest operating system shutdown when VMware Tools is installed.",
 		},
 		"run_tools_scripts_before_guest_standby": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
-			Description: "Enable the execution of pre-standby scripts when VMware tools is installed.",
+			Description: "Enable the run of scripts before guest operating system standby when VMware Tools is installed.",
 		},
 
 		// LatencySensitivity
@@ -272,7 +272,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"alternate_guest_name": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The guest name for the operating system when guest_id is other or other-64.",
+			Description: "The guest name for the operating system when guest_id is otherGuest or otherGuest64.",
 		},
 		"firmware": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
### Description

- Updates the default GOS to `otherGuest64` from **invalid** `other-64`.
- Updates `guest_id` and `alternate_guest_name` to correctly mention `otherGuest` and `otherGuest64` - **not** `other` and `other-64`
- Also updates the descriptions in `virtual_machine_config_structure.go` with more inclusive/accurate terminology, cleaner structure, and correct component proper name.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):

```release-note
Updates the default GOS to `otherGuest64` from invalid `other-64`.
```

### References

Closes: #1263

vSphere Web Services API: [Enum - VirtualMachineGuestOsIdentifier](https://vdc-download.vmware.com/vmwb-repository/dcr-public/bf660c0a-f060-46e8-a94d-4b5e6ffc77ad/208bc706-e281-49b6-a0ce-b402ec19ef82/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)