### PR TITLE
Update examples for affinity/anti-affinity rule resources

### DIFF
--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -25,7 +25,6 @@ that would keep that from happening, depending on the value of the
 [`mandatory`](#mandatory) flag.
 
 host within a cluster. When configured, vSphere DRS will make a best effort
-to ensure that the virtual machines run on the same host, or prevent any
 -> An affinity rule can only be used to place virtual machines on the same
 _non-specific_ hosts. It cannot be used to pin virtual machines to a host. 
 To enable this capability, use the

--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -4,41 +4,48 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_vm_affinity_rule"
 sidebar_current: "docs-vsphere-resource-compute-cluster-vm-affinity-rule"
 description: |-
-  Provides a VMware vSphere cluster virtual machine affinity rule. This can be used to manage rules to tell virtual machines to run on the same host.
+  Provides the VMware vSphere Distributed Resource Scheduler affinity rule resource.
 ---
 
 # vsphere\_compute\_cluster\_vm\_affinity\_rule
 
-The `vsphere_compute_cluster_vm_affinity_rule` resource can be used to manage
-VM affinity rules in a cluster, either created by the
+The `vsphere_compute_cluster_vm_affinity_rule` resource can be used to
+manage virtual machine affinity rules in a cluster, either created by the
 [`vsphere_compute_cluster`][tf-vsphere-cluster-resource] resource or looked up
 by the [`vsphere_compute_cluster`][tf-vsphere-cluster-data-source] data source.
+
 
 [tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
 [tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html
 
-This rule can be used to tell a set to virtual machines to run together on a
-single host within a cluster. When configured, DRS will make a best effort to
+This rule can be used to tell a set to virtual machines to run together on the
+same host within a cluster. When configured, DRS will make a best effort to
 ensure that the virtual machines run on the same host, or prevent any operation
 that would keep that from happening, depending on the value of the
 [`mandatory`](#mandatory) flag.
 
--> Keep in mind that this rule can only be used to tell VMs to run together on
-a _non-specific_ host - it can't be used to pin VMs to a host. For that, see
-the
+An affinity rule places a group of virtual machines on the same 
+host within a cluster. When configured, vSphere DRS will make a best effort
+to ensure that the virtual machines run on the same host, or prevent any
+operation that would keep that from happening, depending on the value of the
+[`mandatory`](#mandatory) flag.
+
+-> An affinity rule can only be used to place virtual machines on the same
+_non-specific_ hosts. It cannot be used to pin virtual machines to a host. 
+To enable this capability, use the
 [`vsphere_compute_cluster_vm_host_rule`][tf-vsphere-cluster-vm-host-rule-resource]
 resource.
 
 [tf-vsphere-cluster-vm-host-rule-resource]: /docs/providers/vsphere/r/compute_cluster_vm_host_rule.html
 
-~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
-connections.
+~> **NOTE:** This resource requires vCenter Server and is not available on
+direct ESXi host connections.
 
 ~> **NOTE:** vSphere DRS requires a vSphere Enterprise Plus license.
 
 ## Example Usage
 
-The example below creates two virtual machines in a cluster using the
+The following example creates two virtual machines in a cluster using the
 [`vsphere_virtual_machine`][tf-vsphere-vm-resource] resource, creating the
 virtual machines in the cluster looked up by the
 [`vsphere_compute_cluster`][tf-vsphere-cluster-data-source] data source. It
@@ -48,37 +55,37 @@ will run on the same host whenever possible.
 [tf-vsphere-vm-resource]: /docs/providers/vsphere/r/virtual_machine.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore" "datastore" {
-  name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "datastore-01"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
 }
 
 data "vsphere_network" "network" {
-  name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "VM Network"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
 }
 
 resource "vsphere_virtual_machine" "vm" {
   count            = 2
-  name             = "terraform-test-${count.index}"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  name             = "foo-${count.index}"
+  resource_pool_id = "data.vsphere_compute_cluster.cluster.resource_pool_id"
+  datastore_id     = "data.vsphere_datastore.datastore.id"
 
-  num_cpus = 2
-  memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  num_cpus = 1
+  memory   = 1024
+  guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = "data.vsphere_network.network.id"
   }
 
   disk {
@@ -87,10 +94,47 @@ resource "vsphere_virtual_machine" "vm" {
   }
 }
 
-resource "vsphere_compute_cluster_vm_affinity_rule" "cluster_vm_affinity_rule" {
-  name                = "terraform-test-cluster-vm-affinity-rule"
-  compute_cluster_id  = "${data.vsphere_compute_cluster.cluster.id}"
-  virtual_machine_ids = ["${vsphere_virtual_machine.vm.*.id}"]
+resource "vsphere_compute_cluster_vm_affinity_rule" "vm_affinity_rule" {
+  name                = "vm-affinity-rule"
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
+  virtual_machine_ids = [for k, v in vsphere_virtual_machine.vm : v.id]
+}
+```
+
+The following example creates an affinity rule for a set of virtual machines
+in the cluster by looking up the virtual machine UUIDs from the
+[`vsphere_virtual_machine`][tf-vsphere-vm-data-source] data source. 
+
+[tf-vsphere-vm-data-source]: /docs/providers/vsphere/d/virtual_machine.html
+
+```hcl
+locals {
+  vms = [
+    "foo-0",
+    "foo-1"
+  ]
+}
+
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = "cluster-01"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+}
+
+data "vsphere_virtual_machine" "vms" {
+  count         = length(local.vms)
+  name          = local.vms[count.index]
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+resource "vsphere_compute_cluster_vm_affinity_rule" "vm_affinity_rule" {
+  name                = "vm-affinity-rule"
+  enabled             = true
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
+  virtual_machine_ids = data.vsphere_virtual_machine.vms[*].id
 }
 ```
 
@@ -131,7 +175,7 @@ example is below:
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 ```
-terraform import vsphere_compute_cluster_vm_affinity_rule.cluster_vm_affinity_rule \
-  '{"compute_cluster_path": "/dc1/host/cluster1", \
-  "name": "terraform-test-cluster-vm-affinity-rule"}'
+terraform import vsphere_compute_cluster_vm_affinity_rule.vm_affinity_rule \
+  '{"compute_cluster_path": "/dc-01/host/cluster-01", \
+  "name": "vm-affinity-rule"}'
 ```

--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -28,8 +28,6 @@ An affinity rule places a group of virtual machines on the same
 host within a cluster. When configured, vSphere DRS will make a best effort
 to ensure that the virtual machines run on the same host, or prevent any
 operation that would keep that from happening, depending on the value of the
-[`mandatory`](#mandatory) flag.
-
 -> An affinity rule can only be used to place virtual machines on the same
 _non-specific_ hosts. It cannot be used to pin virtual machines to a host. 
 To enable this capability, use the

--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -24,7 +24,6 @@ ensure that the virtual machines run on the same host, or prevent any operation
 that would keep that from happening, depending on the value of the
 [`mandatory`](#mandatory) flag.
 
-An affinity rule places a group of virtual machines on the same 
 host within a cluster. When configured, vSphere DRS will make a best effort
 to ensure that the virtual machines run on the same host, or prevent any
 -> An affinity rule can only be used to place virtual machines on the same

--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -18,7 +18,7 @@ by the [`vsphere_compute_cluster`][tf-vsphere-cluster-data-source] data source.
 [tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
 [tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html
 
-This rule can be used to tell a set to virtual machines to run together on the
+This rule can be used to tell a set of virtual machines to run together on the
 same host within a cluster. When configured, DRS will make a best effort to
 ensure that the virtual machines run on the same host, or prevent any operation
 that would keep that from happening, depending on the value of the
@@ -61,31 +61,31 @@ data "vsphere_datacenter" "datacenter" {
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore-01"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
   name          = "cluster-01"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "VM Network"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   count            = 2
   name             = "foo-${count.index}"
-  resource_pool_id = "data.vsphere_compute_cluster.cluster.resource_pool_id"
-  datastore_id     = "data.vsphere_datastore.datastore.id"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 1
   memory   = 1024
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "data.vsphere_network.network.id"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -121,7 +121,7 @@ data "vsphere_datacenter" "datacenter" {
 
 data "vsphere_compute_cluster" "cluster" {
   name          = "cluster-01"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_virtual_machine" "vms" {

--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -27,7 +27,6 @@ that would keep that from happening, depending on the value of the
 An affinity rule places a group of virtual machines on the same 
 host within a cluster. When configured, vSphere DRS will make a best effort
 to ensure that the virtual machines run on the same host, or prevent any
-operation that would keep that from happening, depending on the value of the
 -> An affinity rule can only be used to place virtual machines on the same
 _non-specific_ hosts. It cannot be used to pin virtual machines to a host. 
 To enable this capability, use the

--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -24,7 +24,6 @@ ensure that the virtual machines run on the same host, or prevent any operation
 that would keep that from happening, depending on the value of the
 [`mandatory`](#mandatory) flag.
 
-host within a cluster. When configured, vSphere DRS will make a best effort
 -> An affinity rule can only be used to place virtual machines on the same
 _non-specific_ hosts. It cannot be used to pin virtual machines to a host. 
 To enable this capability, use the

--- a/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
@@ -4,42 +4,42 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_vm_anti_affinity_rule"
 sidebar_current: "docs-vsphere-resource-compute-cluster-vm-anti-affinity-rule"
 description: |-
-  Provides a VMware vSphere cluster virtual machine anti-affinity rule. This can be used to manage rules to tell virtual machines to run on separate hosts.
+  Provides the VMware vSphere Distributed Resource Scheduler anti-affinity rule resource.
 ---
 
 # vsphere\_compute\_cluster\_vm\_anti\_affinity\_rule
 
 The `vsphere_compute_cluster_vm_anti_affinity_rule` resource can be used to
-manage VM anti-affinity rules in a cluster, either created by the
+manage virtual machine anti-affinity rules in a cluster, either created by the
 [`vsphere_compute_cluster`][tf-vsphere-cluster-resource] resource or looked up
 by the [`vsphere_compute_cluster`][tf-vsphere-cluster-data-source] data source.
 
 [tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
 [tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html
 
-This rule can be used to tell a set to virtual machines to run on different
-hosts within a cluster, useful for preventing single points of failure in
-application cluster scenarios. When configured, DRS will make a best effort to
-ensure that the virtual machines run on different hosts, or prevent any
+An anti-affinity rule places a group of virtual machines across different 
+hosts within a cluster, and is useful for preventing single points of failure in
+application cluster scenarios. When configured, vSphere DRS will make a best effort
+to ensure that the virtual machines run on different hosts, or prevent any
 operation that would keep that from happening, depending on the value of the
 [`mandatory`](#mandatory) flag.
 
--> Keep in mind that this rule can only be used to tell VMs to run separately
-on _non-specific_ hosts - specific hosts cannot be specified with this rule.
-For that, see the
+-> An anti-affinity rule can only be used to place virtual machines on seperate
+_non-specific_ hosts. Specific hosts cannot be specified with this rule.
+To enable this capability, use VM-Host Groups, see the
 [`vsphere_compute_cluster_vm_host_rule`][tf-vsphere-cluster-vm-host-rule-resource]
 resource.
 
 [tf-vsphere-cluster-vm-host-rule-resource]: /docs/providers/vsphere/r/compute_cluster_vm_host_rule.html
 
-~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
-connections.
+~> **NOTE:** This resource requires vCenter Server and is not available on
+direct ESXi host connections.
 
 ~> **NOTE:** vSphere DRS requires a vSphere Enterprise Plus license.
 
 ## Example Usage
 
-The example below creates two virtual machines in a cluster using the
+The following example creates two virtual machines in a cluster using the
 [`vsphere_virtual_machine`][tf-vsphere-vm-resource] resource, creating the
 virtual machines in the cluster looked up by the
 [`vsphere_compute_cluster`][tf-vsphere-cluster-data-source] data source. It
@@ -49,37 +49,37 @@ they will run on different hosts whenever possible.
 [tf-vsphere-vm-resource]: /docs/providers/vsphere/r/virtual_machine.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore" "datastore" {
-  name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "datastore-01"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
 }
 
 data "vsphere_network" "network" {
-  name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "VM Network"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
 }
 
 resource "vsphere_virtual_machine" "vm" {
   count            = 2
-  name             = "terraform-test-${count.index}"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  name             = "foo-${count.index}"
+  resource_pool_id = "data.vsphere_compute_cluster.cluster.resource_pool_id"
+  datastore_id     = "data.vsphere_datastore.datastore.id"
 
-  num_cpus = 2
-  memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  num_cpus = 1
+  memory   = 1024
+  guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = "data.vsphere_network.network.id"
   }
 
   disk {
@@ -88,10 +88,47 @@ resource "vsphere_virtual_machine" "vm" {
   }
 }
 
-resource "vsphere_compute_cluster_vm_anti_affinity_rule" "cluster_vm_anti_affinity_rule" {
-  name                = "terraform-test-cluster-vm-anti-affinity-rule"
-  compute_cluster_id  = "${data.vsphere_compute_cluster.cluster.id}"
-  virtual_machine_ids = ["${vsphere_virtual_machine.vm.*.id}"]
+resource "vsphere_compute_cluster_vm_anti_affinity_rule" "vm_anti_affinity_rule" {
+  name                = "vm-anti-affinity-rule"
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
+  virtual_machine_ids = [for k, v in vsphere_virtual_machine.vm : v.id]
+}
+```
+
+The following example creates an anti-affinity rule for a set of virtual machines
+in the cluster by looking up the virtual machine UUIDs from the
+[`vsphere_virtual_machine`][tf-vsphere-vm-data-source] data source. 
+
+[tf-vsphere-vm-data-source]: /docs/providers/vsphere/d/virtual_machine.html
+
+```hcl
+locals {
+  vms = [
+    "foo-0",
+    "foo-1"
+  ]
+}
+
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = "cluster-01"
+  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+}
+
+data "vsphere_virtual_machine" "vms" {
+  count         = length(local.vms)
+  name          = local.vms[count.index]
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+resource "vsphere_compute_cluster_vm_anti_affinity_rule" "vm_anti_affinity_rule" {
+  name                = "vm-anti-affinity-rule"
+  enabled             = true
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
+  virtual_machine_ids = data.vsphere_virtual_machine.vms[*].id
 }
 ```
 
@@ -132,7 +169,7 @@ example is below:
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 ```
-terraform import vsphere_compute_cluster_vm_anti_affinity_rule.cluster_vm_anti_affinity_rule \
-  '{"compute_cluster_path": "/dc1/host/cluster1", \
-  "name": "terraform-test-cluster-vm-anti-affinity-rule"}'
+terraform import vsphere_compute_cluster_vm_anti_affinity_rule.vm_anti_affinity_rule \
+  '{"compute_cluster_path": "/dc-01/host/cluster-01", \
+  "name": "vm-anti-affinity-rule"}'
 ```

--- a/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
@@ -55,31 +55,31 @@ data "vsphere_datacenter" "datacenter" {
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore-01"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
   name          = "cluster-01"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "VM Network"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   count            = 2
   name             = "foo-${count.index}"
-  resource_pool_id = "data.vsphere_compute_cluster.cluster.resource_pool_id"
-  datastore_id     = "data.vsphere_datastore.datastore.id"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 1
   memory   = 1024
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "data.vsphere_network.network.id"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -115,7 +115,7 @@ data "vsphere_datacenter" "datacenter" {
 
 data "vsphere_compute_cluster" "cluster" {
   name          = "cluster-01"
-  datacenter_id = "data.vsphere_datacenter.datacenter".id"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_virtual_machine" "vms" {


### PR DESCRIPTION
### Description

- Updates the existing example for both `compute_cluster_anti_affinity_rule` and `compute_cluster_affinity_rule` (and removes legacy interpolation) and updates content.
- Adds an additional example for more usage context for both `compute_cluster_anti_affinity_rule` and `compute_cluster_affinity_rule`.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):

```release-note
Update examples for both `compute_cluster_anti_affinity_rule` and `compute_cluster_affinity_rule`.
```
### References

Closes:  #1393