### PR TITLE
Update the examples for the `vsphere_virtual_machine` data source

### DIFF
--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # vsphere\_virtual\_machine
 
 The `vsphere_virtual_machine` data source can be used to find the UUID of an
-existing virtual machine or template. THe most common purpose is for finding
+existing virtual machine or template. The most common purpose is for finding
 the UUID of a template to be used as the source for cloning to a new
 [`vsphere_virtual_machine`][docs-virtual-machine-resource] resource. It also
 reads the guest ID so that can be supplied as well.

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -3,14 +3,14 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_machine"
 sidebar_current: "docs-vsphere-data-source-virtual-machine"
 description: |-
-  Provides a vSphere virtual machine data source. This can be used to get data from a virtual machine or template.
+  Provides a VMware vSphere virtual machine data source. This can be used to return data from a virtual machine or template.
 ---
 
 # vsphere\_virtual\_machine
 
 The `vsphere_virtual_machine` data source can be used to find the UUID of an
-existing virtual machine or template. Its most relevant purpose is for finding
-the UUID of a template to be used as the source for cloning into a new
+existing virtual machine or template. THe most common purpose is for finding
+the UUID of a template to be used as the source for cloning to a new
 [`vsphere_virtual_machine`][docs-virtual-machine-resource] resource. It also
 reads the guest ID so that can be supplied as well.
 
@@ -18,14 +18,35 @@ reads the guest ID so that can be supplied as well.
 
 ## Example Usage
 
+In the following example, a virtual machine template is returned by its
+unique name within the `vsphere_datacenter`.
+
 ```hcl
 data "vsphere_datacenter" "datacenter" {
-  name = "dc1"
+  name = "dc-01"
 }
 
 data "vsphere_virtual_machine" "template" {
-  name          = "test-vm-template"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  name          = "ubuntu-server-template"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+```
+In the following example, each virtual machine template is returned by its
+unique full path within the `vsphere_datacenter`.
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_virtual_machine" "production_template" {
+  name          = "production/templates/ubuntu-server-template"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+data "vsphere_virtual_machine" "development_template" {
+  name          = "development/templates/ubuntu-server-template"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 ```
 
@@ -34,7 +55,7 @@ data "vsphere_virtual_machine" "template" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the virtual machine. This can be a name or
-  path.
+  the full path relative to the datacenter.
 * `datacenter_id` - (Optional) The [managed object reference
   ID][docs-about-morefs] of the datacenter the virtual machine is located in.
   This can be omitted if the search path used in `name` is an absolute path.
@@ -47,11 +68,10 @@ The following arguments are supported:
 
 ~> **NOTE:** For best results, ensure that all the disks on any templates you
 use with this data source reside on the primary controller, and leave this
-value at the default. See the
-[`vsphere_virtual_machine`][docs-virtual-machine-resource] resource
-documentation for the significance of this setting, specifically the
-[additional requirements and notes for
-cloning][docs-virtual-machine-resource-cloning] section.
+value at the default. See the [`vsphere_virtual_machine`][docs-virtual-machine-resource]
+resource documentation for the significance of this setting, specifically the
+[additional requirements and notes for cloning][docs-virtual-machine-resource-cloning] 
+section.
 
 [docs-virtual-machine-resource-cloning]: /docs/providers/vsphere/r/virtual_machine.html#additional-requirements-and-notes-for-cloning
 
@@ -62,7 +82,7 @@ The following attributes are exported:
 * `id` - The UUID of the virtual machine or template.
 * `guest_id` - The guest ID of the virtual machine or template.
 * `alternate_guest_name` - The alternate guest name of the virtual machine when
-  guest_id is a non-specific operating system, like `otherGuest`.
+`guest_id` is a non-specific operating system, like `otherGuest` or `otherGuest64`.
 * `annotation` - The user-provided description of this virtual machine.
 * `memory` - The size of the virtual machine's memory, in MB.
 * `num_cpus` - The total number of virtual processor cores assigned to this


### PR DESCRIPTION
### Description
- Updates the existing example for the `vsphere_virtual_machine` data source.
- Adds a second example demonstrating the use of the full path in the `name` argument in the `vsphere_virtual_machine` data source.
- Minor context corrections.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):

```release-note
Updates of the examples for the `vsphere_virtual_machine` data source
```
### References

Closes: #830
