### PR TITLE
Fix disk migration when `datastore_cluster_id` changes

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -816,7 +816,9 @@ func DiskMigrateRelocateOperation(d *schema.ResourceData, c *govmomi.Client, l o
 	ods, nds := d.GetChange(subresourceTypeDisk)
 
 	var relocators []types.VirtualMachineRelocateSpecDiskLocator
-	var relocateOK bool
+
+	// We definitely need to relocate if the datastore cluster changed
+	relocateOK := d.HasChange("datastore_cluster_id")
 
 	// We are only concerned with resources that would normally be updated, as
 	// incoming or outgoing disks obviously won't need migrating. Hence, this is


### PR DESCRIPTION
### Description

When changing the `datastore_cluster_id` of a `vsphere_virtual_machine` the disks are not migrated to datastores of the new datastore cluster because no storage migration is triggered. This PR fixes this.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
  
   No. There used to be acceptance tests for this functionality that have been disabled with #1090 and removed with #1416.

### Release Note

`resource/virtual_machine`: Fix migration of all disks and configuration files when the `datastore_cluster_id` is changed on the resource. GH-1546

### References

Closes https://github.com/hashicorp/terraform-provider-vsphere/issues/1454

- This fixes the issue described in my comment on https://github.com/hashicorp/terraform-provider-vsphere/issues/1268#issuecomment-980014586, which is different from #1268 itself.
- I think storage migration broke due to https://github.com/hashicorp/terraform-plugin-sdk/issues/165
