### PR TITLE
Update `vsphere_vapp_container` resource documentation

### DIFF
--- a/website/docs/r/vapp_container.html.markdown
+++ b/website/docs/r/vapp_container.html.markdown
@@ -4,7 +4,7 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_vapp_container"
 sidebar_current: "docs-vsphere-resource-compute-vapp-container"
 description: |-
-  Provides a vSphere vApp container resource. This can be used to create and manage vApp container.
+  Provides a VMware vSphere vApp container resource. This can be used to create and manage vApp container.
 ---
 
 # vsphere\_vapp\_container
@@ -12,95 +12,78 @@ description: |-
 The `vsphere_vapp_container` resource can be used to create and manage
 vApps.
 
-For more information on vSphere vApps, see [this
-page][ref-vsphere-vapp].
+For more information on vSphere vApps, see the VMware vSphere [product documentation][ref-vsphere-vapp].
 
-[ref-vsphere-vapp]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A95EBB8-1779-40FA-B4FB-4D0845750879.html
+[ref-vsphere-vapp]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-E6E9D2A9-D358-4996-9BC7-F8D9D9645290.html
 
 ## Example Usage
 
-The basic example below sets up a vApp container in a compute cluster which uses
-the default settings for CPU and memory reservations, shares, and limits. The
-compute cluster needs to already exist in vSphere.  
+## Basic Example
+
+The example below sets up a vSphere vApp container in a compute cluster which uses
+the default settings for CPU and memory reservations, shares, and limits. The compute cluster
+needs to already exist in vSphere.  
 
 ```hcl
-variable "datacenter" {
-  default = "dc1"
-}
-
-variable "cluster" {
-  default = "cluster1"
-}
-
-data "vsphere_datacenter" "dc" {
-  name = "${var.datacenter}"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_compute_cluster" "compute_cluster" {
-  name          = "${var.cluster}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_vapp_container" "vapp_container" {
-  name                    = "terraform-vapp-container-test"
-  parent_resource_pool_id = "${data.vsphere_compute_cluster.compute_cluster.id}"
+  name                    = "vapp-01"
+  parent_resource_pool_id = data.vsphere_compute_cluster.compute_cluster.resource_pool_id
 }
 ```
 
-### Example with virtual machine
+### Example with a Virtual Machine
 
-The below example builds off the basic example, but includes a virtual machine
+The example below builds off the basic example, but includes a virtual machine
 in the new vApp container. To accomplish this, the `resource_pool_id` of the
 virtual machine is set to the `id` of the vApp container.
 
 ```hcl
-variable "datacenter" {
-  default = "dc1"
-}
-
-variable "cluster" {
-  default = "cluster1"
-}
-
-data "vsphere_datacenter" "dc" {
-  name = "${var.datacenter}"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_compute_cluster" "compute_cluster" {
-  name          = "${var.cluster}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "datastore-01"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
 data "vsphere_network" "network" {
-  name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-data "vsphere_datastore" "datastore" {
-  name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "VM Network"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_vapp_container" "vapp_container" {
-  name                    = "terraform-vapp-container-test"
-  parent_resource_pool_id = "${data.vsphere_compute_cluster.compute_cluster.id}"
+  name                    = "vapp-01"
+  parent_resource_pool_id = data.vsphere_compute_cluster.compute_cluster.resource_pool_id
 }
 
 resource "vsphere_virtual_machine" "vm" {
-  name             = "terraform-virutal-machine-test"
-  resource_pool_id = "${vsphere_vapp_container.vapp_container.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
-  num_cpus         = 2
+  name             = "foo"
+  resource_pool_id = data.vsphere_vapp_container.vapp_container.id
+  datastore_id     = data.vsphere_datastore.datastore.id
+  num_cpus         = 1
   memory           = 1024
   guest_id         = "ubuntu64Guest"
-
+  network_interface {
+    network_id = data.vsphere_network.network.id
+  }
   disk {
     label = "disk0"
-    size  = 1
-  }
-
-  network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    size  = 20
   }
 }
 ```
@@ -149,8 +132,7 @@ The following arguments are supported:
   unreserved resources. Default: `true`
 * `memory_limit` - (Optional) The CPU utilization of a vApp container will not
   exceed this limit, even if there are available resources. Set to `-1` for
-  unlimited.
-  Default: `-1`
+  unlimited. Default: `-1`
 * `tags` - (Optional) The IDs of any tags to attach to this resource. See
   [here][docs-applying-tags] for a reference on how to apply tags.
 
@@ -169,10 +151,12 @@ the path to the vApp container, using the following command:
 
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
+Example:
+
 ```
-terraform import vsphere_vapp_container.vapp_container /default-dc/host/cluster1/Resources/resource_pool1/vapp_container1
+terraform import vsphere_vapp_container.vapp_container /dc-01/host/cluster-01/Resources/resource-pool-01/vapp-01
 ```
 
-The above would import the vApp container named `vapp-container1` that is
-located in the resource pool `resource-pool1` that is part of the host cluster
-`cluster1` in the `dc1` datacenter.
+The example above would import the vApp container named `vapp-01` that is
+located in the resource pool `resource-pool-01` that is part of the host cluster
+`cluster-01` in the `dc-01` datacenter.


### PR DESCRIPTION
### Description
- Updates examples in the `vsphere_vapp_container` resource documentation to address issues reported in #1436.
- Simplifies examples and removes legacy interpolation syntax (pre-TF 0.12.14).
- Updates link to the latest VMware vSphere product documentation on vSphere vApps.

### References

Closes:  #1436