### PR TITLE
Update documentation links to vSphere 7.0 documentation

### DIFF
--- a/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
+++ b/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
@@ -50,7 +50,7 @@ func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context
 		return nil, err
 	}
 
-	// From the docs at https://code.vmware.com/apis/196/vsphere/doc/vim.dvs.DistributedVirtualPortgroup.ConfigInfo.html:
+	// From the docs at https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.dvs.DistributedVirtualPortgroup.ConfigInfo.html:
 	// "This property should always be set unless the user's setting does not have System.Read privilege on the object referred to by this property."
 	// Note that "the object" refers to the Switch, not the PortGroup.
 	if dvp.Config.DistributedVirtualSwitch == nil {

--- a/website/docs/d/dynamic.html.markdown
+++ b/website/docs/d/dynamic.html.markdown
@@ -47,7 +47,8 @@ The following arguments are supported:
 * `name_regex` - (Optional) A regular expression that will be used to match
   the object's name.
 * `type` - (Optional) The managed object type the returned object must match.
-  For a full list, click [here](https://code.vmware.com/apis/196/vsphere).
+  The managed object types can be found in the managed object type section 
+  [here](https://developer.vmware.com/apis/968/vsphere).
 
 ## Attribute Reference
 

--- a/website/docs/d/resource_pool.html.markdown
+++ b/website/docs/d/resource_pool.html.markdown
@@ -51,7 +51,7 @@ data "vsphere_resource_pool" "pool" {
 For more information on the root resource pool, see [Managing Resource
 Pools][vmware-docs-resource-pools] in the vSphere documentation.
 
-[vmware-docs-resource-pools]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-60077B40-66FF-4625-934A-641703ED7601.html
+[vmware-docs-resource-pools]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-60077B40-66FF-4625-934A-641703ED7601.html
 
 ## Argument Reference
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -175,7 +175,7 @@ to work with. Read-only access should be sufficient when only using data
 sources on some features. You can read more about vSphere permissions and user
 management [here][vsphere-docs-user-management].
 
-[vsphere-docs-user-management]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html
+[vsphere-docs-user-management]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html
 
 There are a couple of exceptions to keep in mind when setting up a restricted
 provisioning user:
@@ -187,7 +187,7 @@ Terraform will always attempt to read tags from a resource, even if you do not
 have any tags defined. Ensure that your user has access to at least read tags,
 or else you will encounter errors.
 
-[vsphere-docs-tags]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html
+[vsphere-docs-tags]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html
 
 ### Events
 
@@ -267,7 +267,7 @@ have the MOB disabled by default, at the very least on ESXi systems. For more
 information on current security best practices related to the MOB on ESXi,
 click [here][vsphere-docs-esxi-mob].
 
-[vsphere-docs-esxi-mob]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.security.doc/GUID-0EF83EA7-277C-400B-B697-04BDC9173EA3.html
+[vsphere-docs-esxi-mob]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-0EF83EA7-277C-400B-B697-04BDC9173EA3.html
 
 ## Bug Reports and Contributing
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -259,7 +259,7 @@ inventory as it's presented to the API. It's normally accessed via
 `https://VSPHERE_SERVER/mob`. For more information, see
 [here][vsphere-docs-using-mob].
 
-[vsphere-docs-using-mob]: https://code.vmware.com/doc/preview?id=4205#/doc/PG_Appx_Using_MOB.21.2.html#994699
+[vsphere-docs-using-mob]: https://developer.vmware.com/doc/PG_Appx_Using_MOB.21.2.html#994699
 
 ~> **NOTE:** The MOB also offers API method invocation capabilities, and for
 security reasons should be used sparingly. Modern vSphere installations may

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -29,8 +29,8 @@ For more information on vSphere clusters and DRS, see [this
 page][ref-vsphere-drs-clusters]. For more information on vSphere HA, see [this
 page][ref-vsphere-ha-clusters].
 
-[ref-vsphere-drs-clusters]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html
-[ref-vsphere-ha-clusters]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html
+[ref-vsphere-drs-clusters]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html
+[ref-vsphere-ha-clusters]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html
 
 ~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
 connections.
@@ -48,7 +48,7 @@ Note that the following example assumes each host has been configured correctly
 according to the requirements of vSphere HA. For more information, click
 [here][ref-vsphere-ha-checklist].
 
-[ref-vsphere-ha-checklist]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-BA85FEC4-A37C-45BA-938D-37B309010D93.html
+[ref-vsphere-ha-checklist]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.avail.doc/GUID-BA85FEC4-A37C-45BA-938D-37B309010D93.html
 
 ```hcl
 variable "datacenter" {
@@ -193,7 +193,7 @@ cluster to manage host capacity on-demand depending on the needs of the
 cluster, powering on hosts when capacity is needed, and placing hosts in
 standby when there is excess capacity in the cluster.
 
-[ref-vsphere-dpm]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-5E5E349A-4644-4C9C-B434-1C0243EBDC80.html#GUID-5E5E349A-4644-4C9C-B434-1C0243EBDC80
+[ref-vsphere-dpm]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-5E5E349A-4644-4C9C-B434-1C0243EBDC80.html
 
 * `dpm_enabled` - (Optional) Enable DPM support for DRS in this cluster.
   Requires [`drs_enabled`](#drs_enabled) to be `true` in order to be effective.
@@ -434,7 +434,7 @@ external providers and make decisions based on the data reported.
 Working with Proactive HA is outside the scope of this document. For more
 details, see the referenced link in the above paragraph.
 
-[ref-vsphere-proactive-ha]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-3E3B18CC-8574-46FA-9170-CF549B8E55B8.html
+[ref-vsphere-proactive-ha]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.avail.doc/GUID-3E3B18CC-8574-46FA-9170-CF549B8E55B8.html
 
 * `proactive_ha_enabled` - (Optional) Enables Proactive HA. Default: `false`.
   <sup>[\*](#vsphere-version-requirements)</sup>

--- a/website/docs/r/datastore_cluster.html.markdown
+++ b/website/docs/r/datastore_cluster.html.markdown
@@ -17,7 +17,7 @@ through Storage DRS.
 For more information on vSphere datastore clusters and Storage DRS, see [this
 page][ref-vsphere-datastore-clusters].
 
-[ref-vsphere-datastore-clusters]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html
+[ref-vsphere-datastore-clusters]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html
 
 ~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
 connections.

--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -155,7 +155,7 @@ specify `number_of_ports`, you may wish to set `auto_expand` to `false`.
   the ports in this port group. See the `portNameFormat` attribute listed
   [here][ext-vsphere-portname-format] for details on the format syntax.
 
-[ext-vsphere-portname-format]: https://code.vmware.com/apis/196/vsphere#/doc/vim.dvs.DistributedVirtualPortgroup.ConfigInfo.html#portNameFormat
+[ext-vsphere-portname-format]: https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.dvs.DistributedVirtualPortgroup.ConfigInfo.html#portNameFormat
 
 * `network_resource_pool_key` - (Optional) The key of a network resource pool
   to associate with this port group. The default is `-1`, which implies no

--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -23,8 +23,8 @@ page][ref-vsphere-net-concepts]. For more information on vSphere DVS
 portgroups, see [this page][ref-vsphere-dvportgroup].
 
 [distributed-virtual-switch]: /docs/providers/vsphere/r/distributed_virtual_switch.html
-[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
-[ref-vsphere-dvportgroup]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-69933F6E-2442-46CF-AA17-1196CB9A0A09.html
+[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
+[ref-vsphere-dvportgroup]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-69933F6E-2442-46CF-AA17-1196CB9A0A09.html
 
 ~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
 connections.

--- a/website/docs/r/distributed_virtual_switch.html.markdown
+++ b/website/docs/r/distributed_virtual_switch.html.markdown
@@ -24,8 +24,8 @@ page][ref-vsphere-net-concepts]. For more information on vSphere VDS, see [this
 page][ref-vsphere-vds].
 
 [distributed-port-group]: /docs/providers/vsphere/r/distributed_port_group.html
-[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
-[ref-vsphere-vds]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-375B45C7-684C-4C51-BA3C-70E48DFABF04.html
+[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
+[ref-vsphere-vds]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-375B45C7-684C-4C51-BA3C-70E48DFABF04.html
 
 ~> **NOTE:** This resource requires vCenter Server and is not available on direct ESXi host
 connections.

--- a/website/docs/r/dpm_host_override.html.markdown
+++ b/website/docs/r/dpm_host_override.html.markdown
@@ -17,7 +17,7 @@ at the default power management settings.
 For more information on DPM within vSphere clusters, see [this
 page][ref-vsphere-cluster-dpm].
 
-[ref-vsphere-cluster-dpm]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-5E5E349A-4644-4C9C-B434-1C0243EBDC80.html
+[ref-vsphere-cluster-dpm]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-5E5E349A-4644-4C9C-B434-1C0243EBDC80.html
 
 ~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
 connections.

--- a/website/docs/r/drs_vm_override.html.markdown
+++ b/website/docs/r/drs_vm_override.html.markdown
@@ -17,7 +17,7 @@ without affecting the rest of the cluster.
 For more information on vSphere clusters and DRS, see [this
 page][ref-vsphere-drs-clusters].
 
-[ref-vsphere-drs-clusters]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html
+[ref-vsphere-drs-clusters]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html
 
 ~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
 connections.

--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -17,7 +17,7 @@ virtual switches, which can be managed by the
 For an overview on vSphere networking concepts, see [this page][ref-vsphere-net-concepts].
 
 [host-virtual-switch]: /docs/providers/vsphere/r/host_virtual_switch.html
-[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
+[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
 
 ## Example Usages
 

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -18,7 +18,7 @@ For an overview on vSphere networking concepts, see [this
 page][ref-vsphere-net-concepts].
 
 [host-port-group]: /docs/providers/vsphere/r/host_port_group.html
-[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
+[ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
 
 ## Example Usages
 

--- a/website/docs/r/resource_pool.html.markdown
+++ b/website/docs/r/resource_pool.html.markdown
@@ -15,7 +15,7 @@ resource pools in standalone hosts or on compute clusters.
 For more information on vSphere resource pools, see [this
 page][ref-vsphere-resource_pools].
 
-[ref-vsphere-resource_pools]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-60077B40-66FF-4625-934A-641703ED7601.html
+[ref-vsphere-resource_pools]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-60077B40-66FF-4625-934A-641703ED7601.html
 
 ## Example Usage
 

--- a/website/docs/r/storage_drs_vm_override.html.markdown
+++ b/website/docs/r/storage_drs_vm_override.html.markdown
@@ -18,7 +18,7 @@ of the datastore cluster.
 For more information on vSphere datastore clusters and Storage DRS, see [this
 page][ref-vsphere-datastore-clusters].
 
-[ref-vsphere-datastore-clusters]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html
+[ref-vsphere-datastore-clusters]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html
 
 ## Example Usage
 

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -15,7 +15,7 @@ objects more sortable and searchable.
 
 For more information about tags, click [here][ext-tags-general].
 
-[ext-tags-general]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html
+[ext-tags-general]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html
 
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.

--- a/website/docs/r/tag_category.html.markdown
+++ b/website/docs/r/tag_category.html.markdown
@@ -17,8 +17,8 @@ For more information about tags, click [here][ext-tags-general]. For more
 information about tag categories specifically, click
 [here][ext-tag-categories].
 
-[ext-tags-general]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html
-[ext-tag-categories]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-BA3D1794-28F2-43F3-BCE9-3964CB207FB6.html
+[ext-tags-general]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html
+[ext-tag-categories]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-BA3D1794-28F2-43F3-BCE9-3964CB207FB6.html
 
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.

--- a/website/docs/r/vapp_entity.html.markdown
+++ b/website/docs/r/vapp_entity.html.markdown
@@ -15,7 +15,7 @@ entity (virtual machine or sub-vApp container) in a vApp container.
 For more information on vSphere vApps, see [this
 page][ref-vsphere-vapp].
 
-[ref-vsphere-vapp]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A95EBB8-1779-40FA-B4FB-4D0845750879.html
+[ref-vsphere-vapp]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-2A95EBB8-1779-40FA-B4FB-4D0845750879.html
 
 ## Example Usage
 

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -49,7 +49,7 @@ immutable and force a new resource if changed.
   information on what each kind of disk provisioning policy means, click
   [here][docs-vmware-vm-disk-provisioning].
 
-[docs-vmware-vm-disk-provisioning]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-4C0F4D73-82F2-4B81-8AA7-1DD752A8A5AC.html
+[docs-vmware-vm-disk-provisioning]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-4C0F4D73-82F2-4B81-8AA7-1DD752A8A5AC.html
 
 * `adapter_type` - (Optional) The adapter type for this virtual disk. Can be
   one of `ide`, `lsiLogic`, or `busLogic`.  Default: `lsiLogic`.

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -674,7 +674,7 @@ The following options are general virtual machine and provider workflow options:
 
 * `guest_id` - (Optional) The guest ID for the operating system type. For a full list of possible values, see [here][vmware-docs-guest-ids]. Default: `otherGuest64`.
 
-[vmware-docs-guest-ids]: https://code.vmware.com/apis/358/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
+[vmware-docs-guest-ids]: https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
 
 * `alternate_guest_name` - (Optional) The guest name for the operating system when `guest_id` is `otherGuest` or `otherGuest64`.
 

--- a/website/docs/r/virtual_machine_snapshot.html.markdown
+++ b/website/docs/r/virtual_machine_snapshot.html.markdown
@@ -15,7 +15,7 @@ for a virtual machine.
 For more information on managing snapshots and how they work in VMware, see
 [here][ext-vm-snapshot-management].
 
-[ext-vm-snapshot-management]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-CA948C69-7F58-4519-AEB1-739545EA94E5.html
+[ext-vm-snapshot-management]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-CA948C69-7F58-4519-AEB1-739545EA94E5.html
 
 ~> **NOTE:** A snapshot in VMware differs from traditional disk snapshots, and
 can contain the actual running state of the virtual machine, data for all disks
@@ -30,7 +30,7 @@ NOT recommend using them as as backup feature. For more information on the
 limitation of virtual machine snapshots, see [here][ext-vm-snap-limitations].
 
 [docs-vsphere-virtual-machine-disk-attach]: /docs/providers/vsphere/r/virtual_machine.html#attach
-[ext-vm-snap-limitations]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-53F65726-A23B-4CF0-A7D5-48E584B88613.html
+[ext-vm-snap-limitations]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-53F65726-A23B-4CF0-A7D5-48E584B88613.html
 
 ## Example Usage
 

--- a/website/docs/r/vsphere_entity_permissions.html.markdown
+++ b/website/docs/r/vsphere_entity_permissions.html.markdown
@@ -18,7 +18,7 @@ Permissions can be created on an entity for a given user or group with the speci
 This example creates entity permissions on the virtual machine VM1 for the user group DCClients with role Datastore 
 consumer and for user group ExternalIDPUsers with role my_terraform_role. The `entity_id` can be the managed object id
 (or uuid for some resources). The `entity_type` is one of the vmware managed object types which can be found from the 
-managed object types section in [vmware_api_7](https://code.vmware.com/apis/968/vsphere). Keep the permissions sorted
+managed object types section in [vmware_api_7](https://developer.vmware.com/apis/968/vsphere). Keep the permissions sorted
 alphabetically, ignoring case on `user_or_group` for a better user experience.
 
 
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `entity_id`   - (Required) The managed object id (uuid for some entities) on which permissions are to be created.
 * `entity_type` - (Required) The managed object type, types can be found in the managed object type section 
-   [here](https://code.vmware.com/apis/968/vsphere).
+   [here](https://developer.vmware.com/apis/968/vsphere).
 
 * `permissions`     - (Required) The permissions to be given on this entity. Keep the permissions sorted
                        alphabetically on `user_or_group` for a better user experience.


### PR DESCRIPTION
### Description

Per the VMware [Product Lifecycle Matrix](https://lifecycle.vmware.com), both vSphere 6.5 and 6.7 are slated for End of General Support on 2022-10-15. 

This pull request updates links across the documentation to the latest release supported by the provider, vSphere 7.0 ahead of this date. 

> The README.md will **still note** that vSphere 6.5 and later are supported.

- Updates all documentation links from vSphere 6.5 to 7.0.
- Updates all links from code.vmware.com to developer.vmware.com.
- Updates all vdc-download.vmware.com links from vSphere 6.5 to 7.0.

### Release Note

```release-note
Updates documentation links to vSphere 7.0 documentation
```
