### PR TITLE
Add `RequiredWith` to options require to join a domain

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
@@ -150,6 +150,7 @@ func VirtualMachineCustomizeSchema() map[string]*schema.Schema {
 					Optional:      true,
 					ConflictsWith: []string{cWindowsKeyPrefix + "." + "workgroup"},
 					Description:   "The user account of the domain administrator used to join this virtual machine to the domain.",
+					RequiredWith:  []string{cWindowsKeyPrefix + "." + "join_domain"},
 				},
 				"domain_admin_password": {
 					Type:          schema.TypeString,
@@ -157,12 +158,14 @@ func VirtualMachineCustomizeSchema() map[string]*schema.Schema {
 					Sensitive:     true,
 					ConflictsWith: []string{cWindowsKeyPrefix + "." + "workgroup"},
 					Description:   "The password of the domain administrator used to join this virtual machine to the domain.",
+					RequiredWith:  []string{cWindowsKeyPrefix + "." + "join_domain"},
 				},
 				"join_domain": {
 					Type:          schema.TypeString,
 					Optional:      true,
 					ConflictsWith: []string{cWindowsKeyPrefix + "." + "workgroup"},
 					Description:   "The domain that the virtual machine should join.",
+					RequiredWith:  []string{cWindowsKeyPrefix + "." + "domain_admin_user", cWindowsKeyPrefix + "." + "domain_admin_password"},
 				},
 				"workgroup": {
 					Type:          schema.TypeString,


### PR DESCRIPTION
### Description

Adds `RequiredWith` to options related to joining a domain in `windows_option`. This will ensure all required options / arguments for joining a domain are provided.

> **Note**: The `vsphere_virtual_machine` resource documentation **already** states as "optional", but "required if setting `join_domain`" Thus, no changes are required to the docs.

Building the provider with the following changes: 

```go
 "join_domain": { 
 	Type:          schema.TypeString, 
 	Optional:      true, 
 	ConflictsWith: []string{cWindowsKeyPrefix + "." + "workgroup"}, 
 	Description:   "The domain that the virtual machine should join.", 
        RequiredWith:  []string{cWindowsKeyPrefix + "." + "domain_admin_user", cWindowsKeyPrefix + "." + "domain_admin_password"},
 }, 
```

The results of the change are, in a plan with the following:

```hcl
resource "vsphere_virtual_machine" "vm" {
  name                    = var.vm_name
  folder                  = var.vsphere_folder
  num_cpus                = var.vm_cpus
  memory                  = var.vm_memory
  firmware                = var.vm_firmware
  efi_secure_boot_enabled = var.vm_efi_secure_boot_enabled
  guest_id                = data.vsphere_virtual_machine.template.guest_id
  datastore_id            = data.vsphere_datastore.datastore.id
  resource_pool_id        = data.vsphere_resource_pool.pool.id
  network_interface {
    network_id = data.vsphere_network.network.id
  }
  disk {
    label            = "disk0"
    size             = data.vsphere_virtual_machine.template.disks.0.size
    eagerly_scrub    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
    thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
  }
  clone {
    template_uuid = data.vsphere_virtual_machine.template.id
    customize {
      windows_options {
        computer_name         = var.vm_name
        join_domain           = var.domain
        domain_admin_user     = var.domain_admin_username
        domain_admin_password = var.domain_admin_password
        admin_password        = var.vm_admin_password
      }
      network_interface {
        ipv4_address = var.vm_ipv4_address
        ipv4_netmask = var.vm_ipv4_netmask
      }

      ipv4_gateway    = var.vm_ipv4_gateway
      dns_suffix_list = var.vm_dns_suffix_list
      dns_server_list = var.vm_dns_server_list
    }
  }
```

With `domain_admin_user` and `domain_admin_password` commented out / omitted, the following will be displayed denoting that `join_domain` is required arguments

```console
❯ terraform plan
╷
│ Error: Missing required argument
│ 
│   with vsphere_virtual_machine.vm,
│   on main.tf line 59, in resource "vsphere_virtual_machine" "vm":
│   59:       windows_options {
│ 
│ "clone.0.customize.0.windows_options.0.domain_admin_user": all of
│ `clone.0.customize.0.windows_options.0.domain_admin_user,clone.0.customize.0.windows_options.0.join_domain` must be specified
╵
╷
│ Error: Missing required argument
│ 
│   with vsphere_virtual_machine.vm,
│   on main.tf line 59, in resource "vsphere_virtual_machine" "vm":
│   59:       windows_options {
│ 
│ "clone.0.customize.0.windows_options.0.domain_admin_password": all of
│ `clone.0.customize.0.windows_options.0.domain_admin_password,clone.0.customize.0.windows_options.0.join_domain` must be specified
╵
```

If I comment out / omit only `join_domain` the following will result denoting that `domain_admin_user` and `domain_admin_password` are required arguments.

```console
❯ terraform plan
╷
│ Error: Missing required argument
│ 
│   with vsphere_virtual_machine.vm,
│   on main.tf line 59, in resource "vsphere_virtual_machine" "vm":
│   59:       windows_options {
│ 
│ "clone.0.customize.0.windows_options.0.domain_admin_user": all of
│ `clone.0.customize.0.windows_options.0.domain_admin_user,clone.0.customize.0.windows_options.0.join_domain` must be specified
╵
╷
│ Error: Missing required argument
│ 
│   with vsphere_virtual_machine.vm,
│   on main.tf line 59, in resource "vsphere_virtual_machine" "vm":
│   59:       windows_options {
│ 
│ "clone.0.customize.0.windows_options.0.domain_admin_password": all of
│ `clone.0.customize.0.windows_options.0.domain_admin_password,clone.0.customize.0.windows_options.0.join_domain` must be specified
```

### Release Note

```release-note
`resource/virtual_machine > virtual_machine_customize_subresource` : Updates `windows_options` to ensure all required options for domain join are provided
```

### References

Closes #1350