### PR TITLE
docs: update `resource/virtual_machine`

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -735,6 +735,10 @@ The following options control boot settings on a virtual machine:
 
 The following options control VMware Tools settings on the virtual machine:
 
+* `sync_time_with_host` - (Optional) Enable the guest operating system to synchronization its clock with the host when the virtual machine is powered on or resumed. Requires vSphere 7.0 Update 1 and later. Requires VMware Tools to be installed.
+
+* `sync_time_with_host_periodically` - (Optional) Enable the guest operating system to periodically synchronize its clock with the host. Requires vSphere 7.0 Update 1 and later. On previous versions, setting `sync_time_with_host` is will enable periodic synchronization. Requires VMware Tools to be installed.
+
 * `run_tools_scripts_after_power_on` - (Optional) Enable post-power-on scripts to run when VMware Tools is installed. Default: `true`.
 
 * `run_tools_scripts_after_resume` - (Optional) Enable ost-resume scripts to run when VMware Tools is installed. Default: `true`.


### PR DESCRIPTION
### Description

Updated `resource/virtual_machine` docs for:
- `sync_time_with_host`
- `sync_time_with_host_periodically`

Additional reference: https://kb.vmware.com/s/article/1189

> VMware Tools performs two types of time corrections:
> 
> **One-off time sync:** Guest system clock is synchronized to host time upon specific VM life-cycle events that can cause guest** clock to become incorrect, such as resuming from vMotion or a snapshot. This capability is recommended for use and turned **_ON_** by default.
> 
> **Periodic time sync:** Guest system clock is periodically (every 60 seconds) synchronized to track host time. It is recommended that guests use a native time synchronization service – such as NTPD or Chrony in Linux based operating systems, and W32Time for Microsoft Windows. If that's not viable, periodic time sync provides an alternative. This capability is turned **_OFF_** by default.
> 

This has been confirmed with VMware engineering "time-lords".

### Release Note

### References