### PR TITLE
Add GitHub Action for state issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+---
+name: Manage Stale Items
+'on':
+  schedule:
+    - cron: 00 00 * * *
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v4
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          days-before-stale: 180
+          days-before-close: 30
+          exempt-issue-labels: 'needs-triage, acknowledged, in-progress'
+          exempt-pr-labels: 'needs-review, under-review, acknowledged, planned'
+          remove-stale-when-updated: true
+          delete-branch: false
+          stale-issue-label: stale
+          stale-issue-message: >
+            Marking this issue as stale due to inactivity in the past 180 days.
+            This helps us focus on the active issues. If this issue is
+            reproducible with the [latest](https://github.com/hashicorp/terraform-provider-vsphere/releases/latest)
+            version of the provider, please comment. If this issue receives no
+            comments in the next 30 days it will automatically be closed.
+
+            If this issue was automatically closed and you feel this issue
+            should be reopened, we encourage creating a new issue linking back
+            to this one for added context. Thank you!
+          stale-pr-label: stale
+          stale-pr-message: >
+            Marking this pull request as stale due to inactivity in the past
+            180 days. This helps us focus on the active pull requests. If this
+            pull request receives no comments in the next 30 days it will 
+            automatically be closed.
+
+            If this pull request was automatically closed and you feel this
+            pull request should be reopened, we encourage creating a new pull
+            request linking back to this one for added context. Thank you!


### PR DESCRIPTION
### Description

- Adds back stale issue and pull request management that was temporarily disabled in #1250 by @aareet.
- Updates to `actions/stale@v4` from `actions/stale@v1.1.0`
- Marked as `stale` if no activity in **180 days**.
- Closed if no activity **30 days** after being marked as stale.
- Exemptions include:
  - Issues with `needs-triage`, `acknowledged`, and `in-progress` labels.
  - PRs with `needs-review`, `under-review`, `acknowledged`, and `planned` labels.

### References

PR #1250
