### PR TITLE
Check for 404 Not found on tag and tag_category

### DIFF
--- a/vsphere/resource_vsphere_tag.go
+++ b/vsphere/resource_vsphere_tag.go
@@ -78,7 +78,7 @@ func resourceVSphereTagRead(d *schema.ResourceData, meta interface{}) error {
 	defer cancel()
 	tag, err := tm.GetTag(ctx, id)
 	if err != nil {
-		if strings.Contains(err.Error(), "com.vmware.vapi.std.errors.not_found") {
+		if strings.Contains(err.Error(), "com.vmware.vapi.std.errors.not_found") || strings.Contains(err.Error(), "404 Not Found") {
 			log.Printf("[DEBUG] Tag %s: Resource has been deleted", id)
 			d.SetId("")
 			return nil

--- a/vsphere/resource_vsphere_tag_category.go
+++ b/vsphere/resource_vsphere_tag_category.go
@@ -107,7 +107,7 @@ func resourceVSphereTagCategoryRead(d *schema.ResourceData, meta interface{}) er
 	defer cancel()
 	category, err := tm.GetCategory(ctx, id)
 	if err != nil {
-		if strings.Contains(err.Error(), "com.vmware.vapi.std.errors.not_found") {
+		if strings.Contains(err.Error(), "com.vmware.vapi.std.errors.not_found") || strings.Contains(err.Error(), "404 Not Found") {
 			log.Printf("[DEBUG] Tag category %s: Resource has been deleted", id)
 			d.SetId("")
 			return nil


### PR DESCRIPTION
### Description
<!--- Please leave a helpful description of the pull request here. --->
It appears at some point the error message returned for tag/tag_category not found changed to include `404 Not found`. That string is searched for in a few other resources so I added it as a check to ensure the instance is removed from state on read if not found. I left the old check as well for any backwards compatibility to when that used to be the error message?
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?
- [x] Manually tested

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/tag`: Fix deletion detection in `tag` and `tag_category`.
```
### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
Closes #1548
