### PR TITLE
Fix documentation typo in vsphere_content_library_item

### DIFF
--- a/website/docs/r/content_library_item.html.markdown
+++ b/website/docs/r/content_library_item.html.markdown
@@ -39,7 +39,7 @@ resource "vsphere_content_library_item" "ubuntu1804" {
   name        = "Ubuntu Bionic 18.04"
   description = "Ubuntu template"
   library_id  = vsphere_content_library.library.id
-  file_url = "https://fileserver/ubuntu/ubuntu-bionic-18.04-cloudimg.ovf
+  file_url = "https://fileserver/ubuntu/ubuntu-bionic-18.04-cloudimg.ovf"
 }
 
 ```


### PR DESCRIPTION
### Description
Fixes a small typo in the docs.
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
