### PR TITLE
Update `resource/content_library_item` docs

### DIFF
--- a/website/docs/r/content_library_item.html.markdown
+++ b/website/docs/r/content_library_item.html.markdown
@@ -47,7 +47,7 @@ data "vsphere_datacenter" "datacenter" {
   name = "dc-01"
 }
 
-data "vsphere_content_library" "_content_library" {
+data "vsphere_content_library" "content_library" {
   name = "clb-01"
 }
 

--- a/website/docs/r/content_library_item.html.markdown
+++ b/website/docs/r/content_library_item.html.markdown
@@ -4,42 +4,81 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_content_library_item"
 sidebar_current: "docs-vsphere-resource-content-library-item"
 description: |-
-  Creates an item in a Content Library. Each item can contain multiple files.
+  Creates an item in a vSphere content library. Each item can contain multiple files.
 ---
 
 # vsphere\_content\_library_item
 
-The `vsphere_content_library_item` resource can be used to create items in a Content Library.
-`file_url` must be accessible from the vSphere environment as it will be downloaded from the
-specified location and stored on the Content Library's storage backing.
+The `vsphere_content_library_item` resource can be used to create items in a
+vSphere content library. The `file_url` must be accessible from the vSphere
+environment as it will be downloaded from the specified location and stored
+on the content library's storage backing.
 
 ## Example Usage
 
-The example below creates an Ubuntu template on "Content Library Test".
+The first example below imports an OVF Template to a content
+library.
 
 [tf-vsphere-vm-resource]: /docs/providers/vsphere/r/virtual_machine.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
-data "vsphere_datastore" "datastore" {
-  name          = "datastore1"
-  datacenter_id = data.vsphere_datacenter.dc.id
+data "vsphere_content_library" "content_library" {
+  name = "clb-01"
 }
 
-resource "vsphere_content_library" "library" {
-  name            = "Content Library Test"
-  storage_backing = data.vsphere_datastore.datastore.id
-  description     = "A new source of content"
+resource "vsphere_content_library_item" "content_library_item" {
+  name        = "ovf-linux-ubuntu-server-lts"
+  description = "Ubuntu Server LTS OVF Template"
+  file_url    = "https://releases.example.com/ubuntu/ubuntu/ubuntu-live-server-amd64.ovf"
+  library_id  = data.vsphere_content_library.content_library.id
+}
+```
+
+The next example imports an .iso image to a content library.
+
+[tf-vsphere-vm-resource]: /docs/providers/vsphere/r/virtual_machine.html
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
-resource "vsphere_content_library_item" "ubuntu1804" {
-  name        = "Ubuntu Bionic 18.04"
-  description = "Ubuntu template"
-  library_id  = vsphere_content_library.library.id
-  file_url    = "https://fileserver/ubuntu/ubuntu-bionic-18.04-cloudimg.ovf"
+data "vsphere_content_library" "_content_library" {
+  name = "clb-01"
+}
+
+resource "vsphere_content_library_item" "content_library_item" {
+  name        = "iso-linux-ubuntu-server-lts"
+  description = "Ubuntu Server LTS .iso"
+  type        = "iso"
+  file_url    = "https://releases.example.com/ubuntu/ubuntu-live-server-amd64.iso"
+  library_id  = data.vsphere_content_library.content_library.id
+}
+```
+
+The last example imports a virtual machine image to a content library from an
+existing virtual machine.
+
+[tf-vsphere-vm-resource]: /docs/providers/vsphere/r/virtual_machine.html
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_content_library" "content_library" {
+  name = "clb-01"
+}
+
+resource "vsphere_content_library_item" "content_library_item" {
+  name        = "tpl-linux-ubuntu-server-lts"
+  description = "Ubuntu Server LTS"
+  source_uuid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  library_id  = data.vsphere_content_library.content_library.id
 }
 ```
 
@@ -47,12 +86,13 @@ resource "vsphere_content_library_item" "ubuntu1804" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the item to be created in the Content Library.
-* `library_id` - (Required) The ID of the Content Library the item should be created in.
-* `file_url` - (Optional) File to import into the Content Library item. OVFs and
-  OVAs will be parsed and associated files will also be imported.
-* `source_uuid` - (Optional) Virtual machine UUID to clone to Content Library.
-* `description` - (Optional) A description for the item.
+* `name` - (Required) The name of the item to be created in the content library.
+* `library_id` - (Required) The ID of the content library in which to create the item.
+* `file_url` - (Optional) File to import as the content library item.
+* `source_uuid` - (Optional) Virtual machine UUID to clone to content library.
+* `description` - (Optional) A description for the content library item.
+* `type` - (Optional) Type of content library item.
+   One of "ovf", "iso", or "vm-template". Default: `ovf`.
 
 ## Attribute Reference
 
@@ -63,10 +103,10 @@ cluster, and the name of the virtual machine group.
 ## Importing
 
 An existing content library item can be [imported][docs-import] into this resource by
-supplying the Content Library's ID. An example is below:
+supplying the content library ID. An example is below:
 
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 ```
-terraform import vsphere_content_library_item  ubuntu1804 f42a4b25-844a-44ec-9063-a3a5e9cc88c7
+terraform import vsphere_content_library_item iso-linux-ubuntu-server-lts xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```


### PR DESCRIPTION
### Description

Update `resource/content_library_item` docs.
- Improves content and clarity.
- Simplifies using generic Ubuntu examples
- Adds examples for `.iso` and `source_uuid`.
- Adds missing `type` argument.

### Release Note

`resource/content_library_item`: Documentation improvements [GH-1586]

### References

Content supersedes #1585. Merge **after** (or in lieu of.)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
