### PR TITLE
Set `annotation` on `r/vsphere_virtual_machine` to computed

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -249,6 +249,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"annotation": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 			Description: "User-provided description of the virtual machine.",
 		},
 		"guest_id": {


### PR DESCRIPTION
### Description

Sets `annotation` on `r/vsphere_virtual_machine` to computed if not provided.

This will ensure that the annotation is added to state and that, if changed externally, it will also be updated in a state refresh.

### Release Note

`resource/vsphere_virtual_machine`: Sets `annotation` to computed. [GH-1588]

### References

Closes #1459