### PR TITLE
Update `r/vsphere_file` resource and docs

### DIFF
--- a/vsphere/resource_vsphere_file.go
+++ b/vsphere/resource_vsphere_file.go
@@ -70,7 +70,6 @@ func resourceVSphereFile() *schema.Resource {
 			"create_directories": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 		},
 	}

--- a/vsphere/resource_vsphere_file.go
+++ b/vsphere/resource_vsphere_file.go
@@ -70,6 +70,7 @@ func resourceVSphereFile() *schema.Resource {
 			"create_directories": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 		},
 	}
@@ -208,12 +209,6 @@ func createFile(client *govmomi.Client, f *file) error {
 			return fmt.Errorf("error %s", err)
 		}
 
-		// Delete temporary directory where VMDK was uploaded.
-		tempDstDir, _ := path.Split(tempDstFile)
-		err = dstDfm.Delete(context.TODO(), tempDstDir)
-		if err != nil {
-			return fmt.Errorf("error %s", err)
-		}
 	default:
 		err = fileUpload(client, dstDatacenter, dstDatastore, f.sourceFile, f.destinationFile)
 		if err != nil {

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -22,7 +22,7 @@ values of the new settings.  If any source parameter is changed, such as
 `source_datastore`, `source_datacenter`, or `source_file`), the resource will
 be re-created. Depending on if destination parameters are being changed,
 this may result in the destination file either being overwritten or
-deleted from the previoud location.
+deleted from the previous location.
 
 ## Example Usages
 

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -4,47 +4,49 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_file"
 sidebar_current: "docs-vsphere-resource-storage-file"
 description: |-
-  Provides a VMware vSphere virtual machine file resource. This can be used to upload files (e.g. vmdk disks) from the Terraform host machine to a remote vSphere or copy fields within vSphere.
+  Provides a VMware vSphere file resource. This can be used to upload files
+  (e.g. .iso and .vmdk) from the Terraform host machine to a remote vSphere
+  or copy files within vSphere.
 ---
 
 # vsphere\_file
 
-The `vsphere_file` resource can be used to upload files (such as virtual disk
-files) from the host machine that Terraform is running on to a target
+The `vsphere_file` resource can be used to upload files (such as ISOs and
+virtual disk files) from the host machine that Terraform is running on to a
 datastore.  The resource can also be used to copy files between datastores, or
 from one location to another on the same datastore.
 
 Updates to destination parameters such as `datacenter`, `datastore`, or
 `destination_file` will move the managed file a new destination based on the
 values of the new settings.  If any source parameter is changed, such as
-`source_datastore`, `source_datacenter` or `source_file`), the resource will be
-re-created. Depending on if destination parameters are being changed as well,
-this may result in the destination file either being overwritten or deleted at
-the old location.
+`source_datastore`, `source_datacenter`, or `source_file`), the resource will
+be re-created. Depending on if destination parameters are being changed,
+this may result in the destination file either being overwritten or
+deleted from the previoud location.
 
 ## Example Usages
 
-### Uploading a file
+### Uploading a File
 
 ```hcl
-resource "vsphere_file" "ubuntu_disk_upload" {
-  datacenter       = "my_datacenter"
-  datastore        = "local"
-  source_file      = "/home/ubuntu/my_disks/custom_ubuntu.vmdk"
-  destination_file = "/my_path/disks/custom_ubuntu.vmdk"
+resource "vsphere_file" "ubuntu_vmdk_upload" {
+  datacenter       = "dc-01"
+  datastore        = "datastore-01"
+  source_file      = "/my/src/path/custom_ubuntu.vmdk"
+  destination_file = "/my/dst/path/custom_ubuntu.vmdk"
 }
 ```
 
-### Copying a file
+### Copying a File
 
 ```hcl
-resource "vsphere_file" "ubuntu_disk_copy" {
-  source_datacenter = "my_datacenter"
-  datacenter        = "my_datacenter"
-  source_datastore  = "local"
-  datastore         = "local"
-  source_file       = "/my_path/disks/custom_ubuntu.vmdk"
-  destination_file  = "/my_path/custom_ubuntu_id.vmdk"
+resource "vsphere_file" "ubuntu_copy" {
+  source_datacenter = "dc-01"
+  datacenter        = "dc-01"
+  source_datastore  = "datastore-01"
+  datastore         = "datastore-01"
+  source_file       = "/my/src/path/custom_ubuntu.vmdk"
+  destination_file  = "/my/dst/path/custom_ubuntu.vmdk"
 }
 ```
 
@@ -58,21 +60,22 @@ will copy from within specified locations in vSphere.
 The following arguments are supported:
 
 * `source_file` - (Required) The path to the file being uploaded from the
-  Terraform host to vSphere or copied within vSphere. Forces a new resource if
-  changed.
+  Terraform host to the vSphere environment or copied within vSphere
+  environment. Forces a new resource if changed.
 * `destination_file` - (Required) The path to where the file should be uploaded
-  or copied to on vSphere.
-* `source_datacenter` - (Optional) The name of a datacenter in which the file
-  will be copied from. Forces a new resource if changed.
-* `datacenter` - (Optional) The name of a datacenter in which the file will be
-  uploaded to.
-* `source_datastore` - (Optional) The name of the datastore in which file will
-  be copied from. Forces a new resource if changed.
-* `datastore` - (Required) The name of the datastore in which to upload the
-  file to.
+  or copied to on the destination `datastore` in vSphere.
+* `source_datacenter` - (Optional) The name of a datacenter from which the file
+  will be copied. Forces a new resource if changed.
+* `datacenter` - (Optional) The name of a datacenter to which the file will be
+  uploaded.
+* `source_datastore` - (Optional) The name of the datastore from which file will
+  be copied. Forces a new resource if changed.
+* `datastore` - (Required) The name of the datastore to which to upload the
+  file.
 * `create_directories` - (Optional) Create directories in `destination_file`
-  path parameter if any missing for copy operation. 
-  
-~> **NOTE:** Any directory created as part of the operation when
-`create_directories` is enabled will not be deleted when the resource is
-destroyed.
+  path parameter on first apply if any are missing for copy operation.
+  Default: `true`.
+
+~> **NOTE:** Any directory created as part of the `create_directories` argument
+  will not be deleted when the resource is destroyed. New directoriea are not
+  created if the `destination_file` path is change in subsequent applies.

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -78,5 +78,5 @@ The following arguments are supported:
   path parameter on first apply if any are missing for copy operation.
 
 ~> **NOTE:** Any directory created as part of the `create_directories` argument
-  will not be deleted when the resource is destroyed. New directoriea are not
+  will not be deleted when the resource is destroyed. New directories are not
   created if the `destination_file` path is change in subsequent applies.

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -30,10 +30,11 @@ deleted from the previoud location.
 
 ```hcl
 resource "vsphere_file" "ubuntu_vmdk_upload" {
-  datacenter       = "dc-01"
-  datastore        = "datastore-01"
-  source_file      = "/my/src/path/custom_ubuntu.vmdk"
-  destination_file = "/my/dst/path/custom_ubuntu.vmdk"
+  datacenter         = "dc-01"
+  datastore          = "datastore-01"
+  source_file        = "/my/src/path/custom_ubuntu.vmdk"
+  destination_file   = "/my/dst/path/custom_ubuntu.vmdk"
+  create_directories = true
 }
 ```
 
@@ -41,12 +42,13 @@ resource "vsphere_file" "ubuntu_vmdk_upload" {
 
 ```hcl
 resource "vsphere_file" "ubuntu_copy" {
-  source_datacenter = "dc-01"
-  datacenter        = "dc-01"
-  source_datastore  = "datastore-01"
-  datastore         = "datastore-01"
-  source_file       = "/my/src/path/custom_ubuntu.vmdk"
-  destination_file  = "/my/dst/path/custom_ubuntu.vmdk"
+  source_datacenter  = "dc-01"
+  datacenter         = "dc-01"
+  source_datastore   = "datastore-01"
+  datastore          = "datastore-01"
+  source_file        = "/my/src/path/custom_ubuntu.vmdk"
+  destination_file   = "/my/dst/path/custom_ubuntu.vmdk"
+  create_directories = true
 }
 ```
 
@@ -74,7 +76,6 @@ The following arguments are supported:
   file.
 * `create_directories` - (Optional) Create directories in `destination_file`
   path parameter on first apply if any are missing for copy operation.
-  Default: `true`.
 
 ~> **NOTE:** Any directory created as part of the `create_directories` argument
   will not be deleted when the resource is destroyed. New directoriea are not

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -79,4 +79,4 @@ The following arguments are supported:
 
 ~> **NOTE:** Any directory created as part of the `create_directories` argument
   will not be deleted when the resource is destroyed. New directories are not
-  created if the `destination_file` path is change in subsequent applies.
+  created if the `destination_file` path is changed in subsequent applies.


### PR DESCRIPTION
### Description

- Updates the `r/vsphere_file` docs content and examples.
- Removed the code to remove the temporary directory where the VMDK is uploaded as this is automatically deleted as part of the VMDK move.

**Plan**:

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

resource "vsphere_file" "upload" {
  datacenter         = "m01-dc01"
  datastore          = "local-hdd-01"
  source_file        = "/Users/johnsonryan/Downloads/VMware-Appliance-FaH_1.0.5.vmdk"
  destination_file   = "/muffin/VMware-Appliance-FaH_1.0.5.vmdk"
  create_directories = true
}
```

**Apply:**

```console
% terraform apply -auto-approve  

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_file.upload will be created
  + resource "vsphere_file" "upload" {
      + create_directories = true
      + datacenter         = "m01-dc01"
      + datastore          = "local-hdd-01"
      + destination_file   = "/muffin/VMware-Appliance-FaH_1.0.5.vmdk"
      + id                 = (known after apply)
      + source_file        = "/Users/johnsonryan/Downloads/VMware-Appliance-FaH_1.0.5.vmdk"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
vsphere_file.upload: Creating...
vsphere_file.upload: Still creating... [10s elapsed]
vsphere_file.upload: Still creating... [20s elapsed]
vsphere_file.upload: Still creating... [30s elapsed]
vsphere_file.upload: Still creating... [40s elapsed]
vsphere_file.upload: Still creating... [50s elapsed]
vsphere_file.upload: Still creating... [1m0s elapsed]
vsphere_file.upload: Still creating... [1m10s elapsed]
vsphere_file.upload: Still creating... [1m20s elapsed]
vsphere_file.upload: Still creating... [1m30s elapsed]
vsphere_file.upload: Still creating... [1m40s elapsed]
vsphere_file.upload: Still creating... [1m50s elapsed]
vsphere_file.upload: Still creating... [2m0s elapsed]
vsphere_file.upload: Still creating... [2m10s elapsed]
vsphere_file.upload: Still creating... [2m20s elapsed]
vsphere_file.upload: Still creating... [2m30s elapsed]
vsphere_file.upload: Still creating... [2m40s elapsed]
vsphere_file.upload: Still creating... [2m50s elapsed]
vsphere_file.upload: Still creating... [3m0s elapsed]
vsphere_file.upload: Creation complete after 3m9s [id=[local-hdd-01] m01-dc01//muffin/VMware-Appliance-FaH_1.0.5.vmdk]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

**Destroy:**

``` console
% terraform destroy -auto-approve
vsphere_file.upload: Refreshing state... [id=[local-hdd-01] m01-dc01//muffin/VMware-Appliance-FaH_1.0.5.vmdk]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # vsphere_file.upload will be destroyed
  - resource "vsphere_file" "upload" {
      - create_directories = true -> null
      - datacenter         = "m01-dc01" -> null
      - datastore          = "local-hdd-01" -> null
      - destination_file   = "/muffin/VMware-Appliance-FaH_1.0.5.vmdk" -> null
      - id                 = "[local-hdd-01] m01-dc01//muffin/VMware-Appliance-FaH_1.0.5.vmdk" -> null
      - source_file        = "/Users/johnsonryan/Downloads/VMware-Appliance-FaH_1.0.5.vmdk" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
vsphere_file.upload: Destroying... [id=[local-hdd-01] m01-dc01//muffin/VMware-Appliance-FaH_1.0.5.vmdk]
vsphere_file.upload: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```

### References

Closes  #1587