### PR TITLE
feat: Add support for paravirtual RDMA network interface adapter type

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -30,6 +30,7 @@ const (
 	networkInterfaceSubresourceTypeE1000e  = "e1000e"
 	networkInterfaceSubresourceTypePCNet32 = "pcnet32"
 	networkInterfaceSubresourceTypeSriov   = "sriov"
+	networkInterfaceSubresourceTypeVRdma   = "vmxnet3vrdma"
 	networkInterfaceSubresourceTypeVmxnet2 = "vmxnet2"
 	networkInterfaceSubresourceTypeVmxnet3 = "vmxnet3"
 	networkInterfaceSubresourceTypeUnknown = "unknown"
@@ -39,6 +40,7 @@ var networkInterfaceSubresourceTypeAllowedValues = []string{
 	networkInterfaceSubresourceTypeE1000,
 	networkInterfaceSubresourceTypeE1000e,
 	networkInterfaceSubresourceTypeVmxnet3,
+	networkInterfaceSubresourceTypeVRdma,
 }
 
 // NetworkInterfaceSubresourceSchema returns the schema for the disk
@@ -86,7 +88,7 @@ func NetworkInterfaceSubresourceSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Default:      networkInterfaceSubresourceTypeVmxnet3,
-			Description:  "The controller type. Can be one of e1000, e1000e, or vmxnet3.",
+			Description:  "The controller type. Can be one of e1000, e1000e, vmxnet3 or vrdma.",
 			ValidateFunc: validation.StringInSlice(networkInterfaceSubresourceTypeAllowedValues, false),
 		},
 		"use_static_mac": {
@@ -605,6 +607,8 @@ func baseVirtualEthernetCardToBaseVirtualDevice(v types.BaseVirtualEthernetCard)
 		return types.BaseVirtualDevice(t)
 	case *types.VirtualVmxnet3:
 		return types.BaseVirtualDevice(t)
+	case *types.VirtualVmxnet3Vrdma:
+		return types.BaseVirtualDevice(t)
 	}
 	panic(fmt.Errorf("unknown ethernet card type %T", v))
 }
@@ -633,6 +637,8 @@ func virtualEthernetCardString(d types.BaseVirtualEthernetCard) string {
 		return networkInterfaceSubresourceTypeVmxnet2
 	case *types.VirtualVmxnet3:
 		return networkInterfaceSubresourceTypeVmxnet3
+	case *types.VirtualVmxnet3Vrdma:
+		return networkInterfaceSubresourceTypeVRdma
 	}
 	return networkInterfaceSubresourceTypeUnknown
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -88,7 +88,7 @@ func NetworkInterfaceSubresourceSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Default:      networkInterfaceSubresourceTypeVmxnet3,
-			Description:  "The controller type. Can be one of e1000, e1000e, vmxnet3 or vrdma.",
+			Description:  "The controller type. Can be one of e1000, e1000e, vmxnet3, or vrdma.",
 			ValidateFunc: validation.StringInSlice(networkInterfaceSubresourceTypeAllowedValues, false),
 		},
 		"use_static_mac": {

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -118,7 +118,7 @@ The following attributes are exported:
  * `unit_number` - The disk number on the storage bus.
 * `network_interface_types` - The network interface types for each network
   interface found on the virtual machine, in device bus order. Will be one of
-  `e1000`, `e1000e`, `pcnet32`, `sriov`, `vmxnet2`, `vmxnet3vrdma` or `vmxnet3`.
+  `e1000`, `e1000e`, `pcnet32`, `sriov`, `vmxnet2`, `vmxnet3vrdma`, or `vmxnet3`.
 * `network_interfaces` - Information about each of the network interfaces on this 
   virtual machine or template. These are sorted by device bus order so that they 
   can be applied to a `vsphere_virtual_machine` resource in the order the resource 
@@ -128,7 +128,7 @@ The following attributes are exported:
   The sub-attributes are:
  * `adapter_type` -  The network interface types for each network interface found 
   on the virtual machine, in device bus order. Will be one of `e1000`, `e1000e`, 
-  `vmxnet3vrdma` or `vmxnet3`.
+  `vmxnet3vrdma`, or `vmxnet3`.
  * `bandwidth_limit` - The upper bandwidth limit of this network interface, 
   in Mbits/sec.
  * `bandwidth_reservation` - The bandwidth reservation of this network interface, 

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -118,7 +118,7 @@ The following attributes are exported:
  * `unit_number` - The disk number on the storage bus.
 * `network_interface_types` - The network interface types for each network
   interface found on the virtual machine, in device bus order. Will be one of
-  `e1000`, `e1000e`, `pcnet32`, `sriov`, `vmxnet2`, or `vmxnet3`.
+  `e1000`, `e1000e`, `pcnet32`, `sriov`, `vmxnet2`, `vmxnet3vrdma` or `vmxnet3`.
 * `network_interfaces` - Information about each of the network interfaces on this 
   virtual machine or template. These are sorted by device bus order so that they 
   can be applied to a `vsphere_virtual_machine` resource in the order the resource 
@@ -127,8 +127,8 @@ The following attributes are exported:
   data source must be the same on the destination virtual machine as the source.
   The sub-attributes are:
  * `adapter_type` -  The network interface types for each network interface found 
-  on the virtual machine, in device bus order. Will be one of `e1000`, `e1000e` or 
-  `vmxnet3`.
+  on the virtual machine, in device bus order. Will be one of `e1000`, `e1000e`, 
+  `vmxnet3vrdma` or `vmxnet3`.
  * `bandwidth_limit` - The upper bandwidth limit of this network interface, 
   in Mbits/sec.
  * `bandwidth_reservation` - The bandwidth reservation of this network interface, 


### PR DESCRIPTION
### Description

With VMware PVRDMA — the paravirtual RDMA device that takes advantage of any RoCE-capable hardware on an ESXi host — ESXi can support running workloads with high performance while still maintaining the flexibility offered by virtualization, including operational flexibility, better resilience, higher availability, and lifecycle management capabilities. This high performance is possible because PVRDMA allows for direct memory transfers (DMA) between guest memory to
the RoCE-capable hardware without CPU intervention. Using the RDMA protocol enables the potential for memory-to-memory zero-copy transfers between guests on two different hosts.

### Release Note

`resource/virtual_machine` : Add support for the PVRDMA `vmxnet3vrdma` network interface adapter type. ([#1598](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1598))

### References
Closes: #1597
