### PR TITLE
Update`resourceVSphereDatacenterImport` to import folder

### DIFF
--- a/vsphere/resource_vsphere_datacenter.go
+++ b/vsphere/resource_vsphere_datacenter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -285,6 +286,18 @@ func resourceVSphereDatacenterImport(d *schema.ResourceData, meta interface{}) (
 	if err != nil {
 		return nil, err
 	}
+
+	f, err := folder.ParentFromPath(client, p, folder.VSphereFolderTypeDatacenter, dc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot locate folder: %s", err)
+	}
+
+	path := strings.TrimPrefix(f.InventoryPath, "/")
+
+	if err := d.Set("folder", path); err != nil {
+		return nil, err
+	}
+
 	d.SetId(dc.Name())
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
### Description

Updates `resourceVSphereDatacenterImport` to include the datacenter folder(s) in which the datacenter object **_may_** exist. 

- If found in a datacenter folder, the leading "`/`" is removed and the inventory path is used for the `folder` attribute during the import. 

- If the datacenter does not reside in a folder, the value is left empty during the import. 

### Release Note

`r/datacenter` - Updates `resourceVSphereDatacenterImport` to include the datacenter folder in which the datacenter object may exist. [GH-XXXX]

### References

Closes #1374

- - -

### Test 1 (With Datacenter Folders)

`main.tf`

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

resource "vsphere_folder" "folder1" {
  path = "hello"
  type = "datacenter"
}

resource "vsphere_folder" "folder2" {
  depends_on = [
    vsphere_folder.folder1,
  ]
  path = "hello/there"
  type = "datacenter"
}

resource "vsphere_datacenter" "datacenter" {
  depends_on = [
    vsphere_folder.folder1,
    vsphere_folder.folder2,
  ]
  name   = "world"
  folder = "hello/there"
}
```

```console
❯ terraform import vsphere_folder.folder1 /hello
vsphere_folder.folder1: Importing from ID "/hello"...
vsphere_folder.folder1: Import prepared!
  Prepared vsphere_folder for import
vsphere_folder.folder1: Refreshing state... [id=group-d50057]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

❯ terraform import vsphere_folder.folder2 /hello/there
vsphere_folder.folder2: Importing from ID "/hello/there"...
vsphere_folder.folder2: Import prepared!
  Prepared vsphere_folder for import
vsphere_folder.folder2: Refreshing state... [id=group-d50058]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

❯ terraform import vsphere_datacenter.datacenter /hello/world
vsphere_datacenter.datacenter: Importing from ID "/hello/world"...
vsphere_datacenter.datacenter: Import prepared!
  Prepared vsphere_datacenter for import
vsphere_datacenter.datacenter: Refreshing state... [id=world]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

```json
  "resources": [
    {
      "mode": "managed",
      "type": "vsphere_datacenter",
      "name": "datacenter",
      "provider": "provider[\"local/hashicorp/vsphere\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "custom_attributes": {},
            "folder": "hello/there",
            "id": "world",
            "moid": "datacenter-50073",
            "name": "world",
            "tags": []
          },
          "sensitive_attributes": [],
          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
        }
      ]
    },
```

### Test 2 (_Without_ Datacenter Folders)

`main.tf`

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

resource "vsphere_folder" "folder1" {
  path = "hello"
  type = "datacenter"
}

resource "vsphere_folder" "folder2" {
  depends_on = [
    vsphere_folder.folder1,
  ]
  path = "hello/there"
  type = "datacenter"
}

resource "vsphere_datacenter" "datacenter" {
  depends_on = [
    vsphere_folder.folder1,
    vsphere_folder.folder2,
  ]
  name   = "world"
}
```

```console
❯ terraform import vsphere_folder.folder1 /hello
vsphere_folder.folder1: Importing from ID "/hello"...
vsphere_folder.folder1: Import prepared!
  Prepared vsphere_folder for import
vsphere_folder.folder1: Refreshing state... [id=group-d50064]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

❯ terraform import vsphere_folder.folder2 /hello/there
vsphere_folder.folder2: Importing from ID "/hello/there"...
vsphere_folder.folder2: Import prepared!
  Prepared vsphere_folder for import
vsphere_folder.folder2: Refreshing state... [id=group-d50065]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

❯ terraform import vsphere_datacenter.datacenter /world
vsphere_datacenter.datacenter: Importing from ID "/world"...
vsphere_datacenter.datacenter: Import prepared!
  Prepared vsphere_datacenter for import
vsphere_datacenter.datacenter: Refreshing state... [id=world]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

❯ terraform plan
vsphere_folder.folder1: Refreshing state... [id=group-d50078]
vsphere_folder.folder2: Refreshing state... [id=group-d50079]
vsphere_datacenter.datacenter: Refreshing state... [id=world]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no
differences, so no changes are needed.
```

```json
  "resources": [
    {
      "mode": "managed",
      "type": "vsphere_datacenter",
      "name": "datacenter",
      "provider": "provider[\"local/hashicorp/vsphere\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "custom_attributes": {},
            "folder": "",
            "id": "world",
            "moid": "datacenter-50066",
            "name": "world",
            "tags": []
          },
          "sensitive_attributes": [],
          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
        }
      ]
    },
```