### PR TITLE
Revert type change of vsan_disk_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 2.2.0 (Unreleased)
+## 2.1.1 (Unreleased)
+
+**If you are using v2.1.0, please upgrade to this new version as soon as possible.**
+
+BUG FIXES:
+* `resource/compute_cluster`: Revert [GH-1432] switching `vsan_disk_group` back to `TypeList`. Switching from `TypeList` to `TypeSet` is a sore spot when it comes to what is considered a breaking change to provider configuration. Generally we accept that users may use list indices within their config. When this attribute switched to `TypeSet` this caused a breaking change for configurations doing that, as `TypeSet` is indexed by a hash value that Terraform calculates. Furthermore other code around type assertions was not changed and this attribute actually crashed the provider in `v2.1.0`, we will address the now re-opened [GH-1205] in `v3.0.0` of the provider. [GH-1615]
 
 FEATURES:
 * `resource/virtual_machine`: Adds support to check the power state of the resource. ([#1407](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1407))

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -478,7 +478,7 @@ func resourceVSphereComputeCluster() *schema.Resource {
 				Description: "Whether the VSAN service is enabled for the cluster.",
 			},
 			"vsan_disk_group": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Description: "A list of disk UUIDs to add to the vSAN cluster.",


### PR DESCRIPTION
Reverts change from #1432 as it was an accidental breaking change from a configuration perspective, it also caused the provider to panic since the type assertions were not updated correctly. We have re-opened #1205 and will address it for `v3.0.0` of the provider.