### PR TITLE
feat: Add support for custom attributes on `r/vsphere_host`

### DIFF
--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 	"github.com/vmware/govmomi/license"
@@ -78,7 +79,7 @@ func resourceVsphereHost() *schema.Resource {
 			"force": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Force add the host to vsphere, even if it's already managed by a different vSphere instance.",
+				Description: "Force add the host to the vSphere inventory even if it's already managed by a different vCenter Server instance.",
 				Default:     false,
 			},
 			"connected": {
@@ -103,88 +104,11 @@ func resourceVsphereHost() *schema.Resource {
 
 			// Tagging
 			vSphereTagAttributeKey: tagsSchema(),
+
+			// Custom Attributes
+			customattribute.ConfigKey: customattribute.ConfigSchema(),
 		},
 	}
-}
-
-func resourceVsphereHostRead(d *schema.ResourceData, meta interface{}) error {
-	// NOTE: Destroying the host without telling vsphere about it will result in us not
-	// knowing that the host does not exist any more.
-
-	// Look for host
-	client := meta.(*Client).vimClient
-	hostID := d.Id()
-
-	// Find host and get reference to it.
-	hs, err := hostsystem.FromID(client, hostID)
-	if err != nil {
-		if viapi.IsManagedObjectNotFoundError(err) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("error while searching host %s. Error: %s ", hostID, err)
-	}
-
-	maintenanceState, err := hostsystem.HostInMaintenance(hs)
-	if err != nil {
-		return fmt.Errorf("error while checking maintenance status for host %s. Error: %s", hostID, err)
-	}
-	_ = d.Set("maintenance", maintenanceState)
-
-	// Retrieve host's properties.
-	log.Printf("[DEBUG] Got host %s", hs.String())
-	host, err := hostsystem.Properties(hs)
-	if err != nil {
-		return fmt.Errorf("error while retrieving properties for host %s. Error: %s", hostID, err)
-	}
-
-	if host.Parent != nil && host.Parent.Type == "ClusterComputeResource" && !d.Get("cluster_managed").(bool) {
-		_ = d.Set("cluster", host.Parent.Value)
-	} else {
-		_ = d.Set("cluster", "")
-	}
-
-	connectionState, err := hostsystem.GetConnectionState(hs)
-	if err != nil {
-		return fmt.Errorf("error while getting connection state for host %s. Error: %s", hostID, err)
-	}
-
-	if connectionState == types.HostSystemConnectionStateDisconnected {
-		// Config and LicenseManager cannot be used while the host is
-		// disconnected.
-		_ = d.Set("connected", false)
-		return nil
-	}
-	_ = d.Set("connected", true)
-
-	lockdownMode, err := hostLockdownString(host.Config.LockdownMode)
-	if err != nil {
-		return err
-	}
-
-	log.Printf("Setting lockdown to %s", lockdownMode)
-	_ = d.Set("lockdown", lockdownMode)
-
-	licenseKey := d.Get("license").(string)
-	if licenseKey != "" {
-		licFound, err := isLicenseAssigned(client.Client, hostID, licenseKey)
-		if err != nil {
-			return fmt.Errorf("error while checking license assignment for host %s. Error: %s", hostID, err)
-		}
-
-		if !licFound {
-			_ = d.Set("license", "")
-		}
-	}
-
-	// Read tags if we have the ability to do so
-	if tagsClient, _ := meta.(*Client).TagsManager(); tagsClient != nil {
-		if err := readTagsForResource(tagsClient, host, d); err != nil {
-			return fmt.Errorf("error reading tags: %s", err)
-		}
-	}
-
-	return nil
 }
 
 func resourceVsphereHostCreate(d *schema.ResourceData, meta interface{}) error {
@@ -282,15 +206,31 @@ func resourceVsphereHostCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("failed while retrieving host object for host %s. Error: %s", hostID, err)
 	}
 
+	// Load the tags client to validate the vCenter Sever connection before
+	// attempting to proceed if tags have been defined.
 	tagsClient, err := tagsManagerIfDefined(d, meta)
 	if err != nil {
 		return err
 	}
 
-	// Apply any pending tags now
+	// Verify the vCenter Server connection before
+	// attempting to proceed if custom attributes have been defined.
+	attrsProcessor, err := customattribute.GetDiffProcessorIfAttributesDefined(client, d)
+	if err != nil {
+		return err
+	}
+
+	// Apply tags
 	if tagsClient != nil {
 		if err := processTagDiff(tagsClient, d, host); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	// Apply custom attributes
+	if attrsProcessor != nil {
+		if err := attrsProcessor.ProcessDiff(host); err != nil {
+			return err
 		}
 	}
 
@@ -327,6 +267,95 @@ func resourceVsphereHostCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceVsphereHostRead(d, meta)
 }
 
+func resourceVsphereHostRead(d *schema.ResourceData, meta interface{}) error {
+	// NOTE: Destroying the host without telling vsphere about it will result in us not
+	// knowing that the host does not exist any more.
+
+	// Look for host
+	client := meta.(*Client).vimClient
+	hostID := d.Id()
+
+	// Find host and get reference to it.
+	hs, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		if viapi.IsManagedObjectNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error while searching host %s. Error: %s ", hostID, err)
+	}
+
+	maintenanceState, err := hostsystem.HostInMaintenance(hs)
+	if err != nil {
+		return fmt.Errorf("error while checking maintenance status for host %s. Error: %s", hostID, err)
+	}
+	_ = d.Set("maintenance", maintenanceState)
+
+	// Retrieve host's properties.
+	log.Printf("[DEBUG] Got host %s", hs.String())
+	host, err := hostsystem.Properties(hs)
+	if err != nil {
+		return fmt.Errorf("error while retrieving properties for host %s. Error: %s", hostID, err)
+	}
+
+	if host.Parent != nil && host.Parent.Type == "ClusterComputeResource" && !d.Get("cluster_managed").(bool) {
+		_ = d.Set("cluster", host.Parent.Value)
+	} else {
+		_ = d.Set("cluster", "")
+	}
+
+	connectionState, err := hostsystem.GetConnectionState(hs)
+	if err != nil {
+		return fmt.Errorf("error while getting connection state for host %s. Error: %s", hostID, err)
+	}
+
+	if connectionState == types.HostSystemConnectionStateDisconnected {
+		// Config and LicenseManager cannot be used while the host is
+		// disconnected.
+		_ = d.Set("connected", false)
+		return nil
+	}
+	_ = d.Set("connected", true)
+
+	lockdownMode, err := hostLockdownString(host.Config.LockdownMode)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Setting lockdown to %s", lockdownMode)
+	_ = d.Set("lockdown", lockdownMode)
+
+	licenseKey := d.Get("license").(string)
+	if licenseKey != "" {
+		licFound, err := isLicenseAssigned(client.Client, hostID, licenseKey)
+		if err != nil {
+			return fmt.Errorf("error while checking license assignment for host %s. Error: %s", hostID, err)
+		}
+
+		if !licFound {
+			_ = d.Set("license", "")
+		}
+	}
+
+	// Read tags
+	if tagsClient, _ := meta.(*Client).TagsManager(); tagsClient != nil {
+		if err := readTagsForResource(tagsClient, host, d); err != nil {
+			return fmt.Errorf("error reading tags: %s", err)
+		}
+	}
+
+	// Read custom attributes
+	if customattribute.IsSupported(client) {
+		moHost, err := hostsystem.Properties(hs)
+		if err != nil {
+			return err
+		}
+		customattribute.ReadFromResource(moHost.Entity(), d)
+	}
+
+	return nil
+}
+
 func resourceVsphereHostUpdate(d *schema.ResourceData, meta interface{}) error {
 	err := validateFields(d)
 	if err != nil {
@@ -334,6 +363,16 @@ func resourceVsphereHostUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	client := meta.(*Client).vimClient
+
+	tagsClient, err := tagsManagerIfDefined(d, meta)
+	if err != nil {
+		return err
+	}
+
+	attrsProcessor, err := customattribute.GetDiffProcessorIfAttributesDefined(client, d)
+	if err != nil {
+		return err
+	}
 
 	// First let's establish where we are and where we want to go
 	var desiredConnectionState bool
@@ -406,14 +445,17 @@ func resourceVsphereHostUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	tagsClient, err := tagsManagerIfDefined(d, meta)
-	if err != nil {
-		return err
-	}
-
+	// Apply tags
 	if tagsClient != nil {
 		if err := processTagDiff(tagsClient, d, hostObject); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	// Apply custom attributes
+	if attrsProcessor != nil {
+		if err := attrsProcessor.ProcessDiff(hostObject); err != nil {
+			return err
 		}
 	}
 
@@ -753,11 +795,6 @@ func validateFields(d *schema.ResourceData) error {
 	}
 	return nil
 }
-
-// --------------
-// Implementing stuff govmomi should provide for us
-//
-//
 
 type HostAccessManager struct {
 	object.Common

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -26,7 +26,7 @@ resource "vsphere_host" "esx-01" {
   hostname = "esx-01.example.com"
   username   = "root"
   password   = "password"
-  license    = "00000-00000-00000-00000i-00000"
+  license    = "00000-00000-00000-00000-00000"
   datacenter = data.vsphere_datacenter.datacenter.id
 }
 ```
@@ -47,7 +47,7 @@ resource "vsphere_host" "esx-01" {
   hostname = "esx-01.example.com"
   username = "root"
   password = "password"
-  license  = "00000-00000-00000-00000i-00000"
+  license  = "00000-00000-00000-00000-00000"
   cluster  = data.vsphere_compute_cluster.cluster.id
 }
 ```
@@ -74,8 +74,8 @@ The following arguments are supported:
   trusted and no thumbprint is set then the operation will fail.
 * `license` - (Optional) The license key that will be applied to the host.
   The license key is expected to be present in vSphere.
-* `force` - (Optional) If set to true then it will force the host to be added,
-  even if the host is already connected to a different vSphere instance.
+* `force` - (Optional) If set to `true` then it will force the host to be added,
+  even if the host is already connected to a different vCenter Server instance.
   Default is `false`.
 * `connected` - (Optional) If set to false then the host will be disconected.
   Default is `false`.
@@ -86,6 +86,17 @@ The following arguments are supported:
 * `tags` - (Optional) The IDs of any tags to attach to this resource. Please
   refer to the `vsphere_tag` resource for more information on applying
   tags to resources.
+
+~> **NOTE:** Tagging support is not supported on direct ESXi host
+connections and require vCenter Server.
+
+* `custom_attributes` - (Optional) A map of custom attribute IDs and string
+  values to apply to the resource. Please refer to the
+  `vsphere_custom_attributes` resource for more information on applying
+  tags to resources.
+
+~> **NOTE:** Custom attributes are not supported on direct ESXi host
+connections and require vCenter Server.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

- Adds support for `custom_attributes` to the`vsphere_host` resource.
- Moves `resourceVsphereHostCreate` before `resourceVsphereHostRead`
- Updates the `vsphere_host` resource docs to include `custom_attributes` and minor corrections.

### Release Note

`resource/vsphere_host: Added support for custom attributes. (GH-xxxx)`

### References

Closes: #1618 

### Testing

**Plan**

`main.tf`

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

data "vsphere_datacenter" "datacenter" {
  name = "m01-dc01"
}

data "vsphere_custom_attribute" "attribute" {
  depends_on = [
    vsphere_custom_attribute.attribute
  ]
  name = "foo"
}

resource "vsphere_custom_attribute" "attribute" {
  name                = "foo"
  managed_object_type = "HostSystem"
}

resource "vsphere_host" "host" {
  hostname          = "m01-esx02.rainpole.io"
  username          = "root"
  password          = "VMware1!"
  tags              = ["bar"]
  custom_attributes = tomap({ "${data.vsphere_custom_attribute.attribute.id}" = "bar" })
  datacenter        = data.vsphere_datacenter.datacenter.id
}
```

**Plan**:

```console
❯ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.vsphere_custom_attribute.attribute will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_custom_attribute" "attribute"  {
      + id                  = (known after apply)
      + managed_object_type = (known after apply)
      + name                = "foo"
    }

  # vsphere_custom_attribute.attribute will be created
  + resource "vsphere_custom_attribute" "attribute" {
      + id                  = (known after apply)
      + managed_object_type = "HostSystem"
      + name                = "foo"
    }

  # vsphere_host.host will be created
  + resource "vsphere_host" "host" {
      + connected         = true
      + custom_attributes = (known after apply)
      + datacenter        = "datacenter-3"
      + force             = false
      + hostname          = "m01-esx02.rainpole.io"
      + id                = (known after apply)
      + lockdown          = "disabled"
      + maintenance       = false
      + password          = (sensitive value)
      + tags              = [
          + "bar",
        ]
      + username          = "root"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform
apply" now.
```

**Apply**:

```console
❯ terraform apply -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.vsphere_custom_attribute.attribute will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_custom_attribute" "attribute"  {
      + id                  = (known after apply)
      + managed_object_type = (known after apply)
      + name                = "foo"
    }

  # vsphere_custom_attribute.attribute will be created
  + resource "vsphere_custom_attribute" "attribute" {
      + id                  = (known after apply)
      + managed_object_type = "HostSystem"
      + name                = "foo"
    }

  # vsphere_host.host will be created
  + resource "vsphere_host" "host" {
      + connected         = true
      + custom_attributes = (known after apply)
      + datacenter        = "datacenter-3"
      + force             = false
      + hostname          = "m01-esx02.rainpole.io"
      + id                = (known after apply)
      + lockdown          = "disabled"
      + maintenance       = false
      + password          = (sensitive value)
      + tags              = [
          + "bar",
        ]
      + username          = "root"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
vsphere_custom_attribute.attribute: Creating...
vsphere_custom_attribute.attribute: Creation complete after 0s [id=305]
data.vsphere_custom_attribute.attribute: Reading...
data.vsphere_custom_attribute.attribute: Read complete after 0s [id=305]
vsphere_host.host: Creating...
vsphere_host.host: Creation complete after 8s [id=host-56037]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

**State**:

```json
    {
      "mode": "managed",
      "type": "vsphere_host",
      "name": "host",
      "provider": "provider[\"local/hashicorp/vsphere\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "cluster": "",
            "cluster_managed": null,
            "connected": true,
            "custom_attributes": {
              "305": "bar"
            },
            "datacenter": "datacenter-3",
            "force": false,
            "hostname": "m01-esx02.rainpole.io",
            "id": "host-56037",
            "license": null,
            "lockdown": "disabled",
            "maintenance": false,
            "password": "VMware1!",
            "tags": [
              "bar"
            ],
            "thumbprint": null,
            "username": "root"
          },
          "sensitive_attributes": [],
          "private": "bnVsbA==",
          "dependencies": [
            "data.vsphere_custom_attribute.attribute",
            "data.vsphere_datacenter.datacenter",
            "vsphere_custom_attribute.attribute"
          ]
        }
      ]
    }
```

**Modify Plan**:

```console
❯ terraform plan
vsphere_custom_attribute.attribute: Refreshing state... [id=305]
vsphere_host.host: Refreshing state... [id=host-56037]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # vsphere_host.host has changed
  ~ resource "vsphere_host" "host" {
        id                = "host-56037"
      ~ tags              = [
          - "bar",
          + "urn:vmomi:InventoryServiceTag:72f80d4c-d33c-4993-a831-cc89290400d7:GLOBAL",
        ]
        # (9 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan
may include actions to undo or respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # vsphere_host.host will be updated in-place
  ~ resource "vsphere_host" "host" {
      ~ custom_attributes = {
          ~ "305" = "bar" -> "bar-bar-bar"
        }
        id                = "host-56037"
      ~ tags              = [
          + "bar",
          - "urn:vmomi:InventoryServiceTag:72f80d4c-d33c-4993-a831-cc89290400d7:GLOBAL",
        ]
        # (8 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform
apply" now.
```

**Modify Apply**:

```console
❯ terraform apply -auto-approve
vsphere_custom_attribute.attribute: Refreshing state... [id=305]
vsphere_host.host: Refreshing state... [id=host-56037]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # vsphere_host.host has changed
  ~ resource "vsphere_host" "host" {
        id                = "host-56037"
      ~ tags              = [
          - "bar",
          + "urn:vmomi:InventoryServiceTag:72f80d4c-d33c-4993-a831-cc89290400d7:GLOBAL",
        ]
        # (9 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan
may include actions to undo or respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # vsphere_host.host will be updated in-place
  ~ resource "vsphere_host" "host" {
      ~ custom_attributes = {
          ~ "305" = "bar" -> "bar-bar-bar"
        }
        id                = "host-56037"
      ~ tags              = [
          + "bar",
          - "urn:vmomi:InventoryServiceTag:72f80d4c-d33c-4993-a831-cc89290400d7:GLOBAL",
        ]
        # (8 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
vsphere_host.host: Modifying... [id=host-56037]
vsphere_host.host: Modifications complete after 1s [id=host-56037]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

**Modified State**: 

```json
    {
      "mode": "managed",
      "type": "vsphere_host",
      "name": "host",
      "provider": "provider[\"local/hashicorp/vsphere\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "cluster": "",
            "cluster_managed": null,
            "connected": true,
            "custom_attributes": {
              "305": "bar-bar-bar"
            },
            "datacenter": "datacenter-3",
            "force": false,
            "hostname": "m01-esx02.rainpole.io",
            "id": "host-56037",
            "license": null,
            "lockdown": "disabled",
            "maintenance": false,
            "password": "VMware1!",
            "tags": [
              "bar"
            ],
            "thumbprint": null,
            "username": "root"
          },
          "sensitive_attributes": [],
          "private": "bnVsbA==",
          "dependencies": [
            "data.vsphere_custom_attribute.attribute",
            "data.vsphere_datacenter.datacenter"
          ]
        }
      ]
    }
  ]
```