### PR TITLE
fix: Add and apply `PciPassthroughPostCloneOperation()` to subresource

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -1025,7 +1025,7 @@ func PciPassthroughApplyOperation(d *schema.ResourceData, c *govmomi.Client, l o
 		Spec:          []types.BaseVirtualDeviceConfigSpec{},
 		VirtualDevice: l,
 	}
-	if addDevs.Len() <= 0 && delDevs.Len() <= 0 {
+	if addDevs.Len() == 0 && delDevs.Len() == 0 {
 		return applyConfig.VirtualDevice, applyConfig.Spec, nil
 	}
 

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -1048,3 +1048,42 @@ func PciPassthroughApplyOperation(d *schema.ResourceData, c *govmomi.Client, l o
 	}
 	return applyConfig.VirtualDevice, applyConfig.Spec, nil
 }
+
+// PciPassthroughPostCloneOperation normalizes the PCI passthrough devices
+// on a newly-cloned virtual machine and outputs any necessary device change
+// operations. It also sets the state in advance of the post-create read.
+func PciPassthroughPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.VirtualDeviceList) (object.VirtualDeviceList, []types.BaseVirtualDeviceConfigSpec, error) {
+	old, newValue := d.GetChange("pci_device_id")
+	oldDevIds := old.(*schema.Set)
+	newDevIds := newValue.(*schema.Set)
+
+	delDevs := oldDevIds.Difference(newDevIds)
+	addDevs := newDevIds.Difference(oldDevIds)
+	applyConfig := &pciApplyConfig{
+		Client:        c,
+		ResourceData:  d,
+		Spec:          []types.BaseVirtualDeviceConfigSpec{},
+		VirtualDevice: l,
+	}
+	if addDevs.Len() <= 0 && delDevs.Len() <= 0 {
+		return applyConfig.VirtualDevice, applyConfig.Spec, nil
+	}
+
+	err := applyConfig.getPciSysID()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Add new PCI passthrough devices
+	err = applyConfig.modifyVirtualPciDevices(addDevs, types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Remove deleted PCI passthrough devices
+	err = applyConfig.modifyVirtualPciDevices(delDevs, types.VirtualDeviceConfigSpecOperationRemove)
+	if err != nil {
+		return nil, nil, err
+	}
+	return applyConfig.VirtualDevice, applyConfig.Spec, nil
+}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1591,6 +1591,17 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 		)
 	}
 	cfgSpec.DeviceChange = virtualdevice.AppendDeviceChangeSpec(cfgSpec.DeviceChange, delta...)
+	// PCI passthrough devices
+	devices, delta, err = virtualdevice.PciPassthroughPostCloneOperation(d, client, devices)
+	if err != nil {
+		return resourceVSphereVirtualMachineRollbackCreate(
+			d,
+			meta,
+			vm,
+			fmt.Errorf("error processing PCI passthrough device changes post-clone: %s", err),
+		)
+	}
+	cfgSpec.DeviceChange = virtualdevice.AppendDeviceChangeSpec(cfgSpec.DeviceChange, delta...)
 	log.Printf("[DEBUG] %s: Final device list: %s", resourceVSphereVirtualMachineIDString(d), virtualdevice.DeviceListString(devices))
 	log.Printf("[DEBUG] %s: Final device change cfgSpec: %s", resourceVSphereVirtualMachineIDString(d), virtualdevice.DeviceChangeString(cfgSpec.DeviceChange))
 


### PR DESCRIPTION
### Description

Added a `PciPassthroughPostCloneOperation()` implementation on the subresource and added to the function to the `resourceVSphereVirtualMachinePostDeployChanges`. #1137

### Testing

```console
❯ terraform apply -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_virtual_machine.vm will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = (known after apply)
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-148"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + force_power_off                         = true
      + guest_id                                = "ubuntu64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = "host-147"
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_reservation                      = 4096
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "ryan-gpu-terraform"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + pci_device_id                           = [
          + "0000:d8:00.1",
        ]
      + power_state                             = (known after apply)
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-100"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tools_upgrade_policy                    = "manual"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + template_uuid = "420c2d6e-4f7a-c031-bdf9-998a2c4558f0"
          + timeout       = 30

          + customize {
              + timeout = 10

              + linux_options {
                  + domain       = "rainpole.io"
                  + host_name    = "ryan-gpu-terraform"
                  + hw_clock_utc = true
                }

              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 40
          + storage_policy_id = (known after apply)
          + thin_provisioned  = false
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-4199"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
vsphere_virtual_machine.vm: Creating...
vsphere_virtual_machine.vm: Still creating... [10s elapsed]
vsphere_virtual_machine.vm: Still creating... [20s elapsed]
vsphere_virtual_machine.vm: Still creating... [30s elapsed]
vsphere_virtual_machine.vm: Still creating... [40s elapsed]
vsphere_virtual_machine.vm: Still creating... [50s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m0s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m10s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m20s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m30s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m40s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m50s elapsed]
vsphere_virtual_machine.vm: Still creating... [2m0s elapsed]
vsphere_virtual_machine.vm: Still creating... [2m10s elapsed]
vsphere_virtual_machine.vm: Still creating... [2m20s elapsed]
vsphere_virtual_machine.vm: Creation complete after 2m25s [id=420ce5db-853b-fc11-9af4-78f1313c7c54]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ terraform state list vsphere_virtual_machine.vm
vsphere_virtual_machine.vm
❯ terraform state show  vsphere_virtual_machine.vm
# vsphere_virtual_machine.vm:
resource "vsphere_virtual_machine" "vm" {
    boot_delay                              = 0
    boot_retry_delay                        = 10000
    boot_retry_enabled                      = false
    change_version                          = "2022-03-18T17:58:03.682262Z"
    cpu_hot_add_enabled                     = false
    cpu_hot_remove_enabled                  = false
    cpu_limit                               = -1
    cpu_performance_counters_enabled        = false
    cpu_reservation                         = 0
    cpu_share_count                         = 2000
    cpu_share_level                         = "normal"
    datastore_id                            = "datastore-148"
    default_ip_address                      = "10.118.232.85"
    efi_secure_boot_enabled                 = false
    enable_disk_uuid                        = false
    enable_logging                          = false
    ept_rvi_mode                            = "automatic"
    firmware                                = "bios"
    force_power_off                         = true
    guest_id                                = "ubuntu64Guest"
    guest_ip_addresses                      = [
        "10.118.232.85",
        "fe80::250:56ff:fe8c:4dbb",
    ]
    hardware_version                        = 17
    host_system_id                          = "host-147"
    hv_mode                                 = "hvAuto"
    id                                      = "420ce5db-853b-fc11-9af4-78f1313c7c54"
    ide_controller_count                    = 2
    latency_sensitivity                     = "normal"
    memory                                  = 4096
    memory_hot_add_enabled                  = false
    memory_limit                            = -1
    memory_reservation                      = 4096
    memory_share_count                      = 40960
    memory_share_level                      = "normal"
    migrate_wait_timeout                    = 30
    moid                                    = "vm-4215"
    name                                    = "ryan-gpu-terraform"
    nested_hv_enabled                       = false
    num_cores_per_socket                    = 1
    num_cpus                                = 2
    pci_device_id                           = [
        "0000:d8:00.1",
    ]
    power_state                             = "on"
    poweron_timeout                         = 300
    reboot_required                         = false
    resource_pool_id                        = "resgroup-100"
    run_tools_scripts_after_power_on        = true
    run_tools_scripts_after_resume          = true
    run_tools_scripts_before_guest_reboot   = false
    run_tools_scripts_before_guest_shutdown = true
    run_tools_scripts_before_guest_standby  = true
    sata_controller_count                   = 0
    scsi_bus_sharing                        = "noSharing"
    scsi_controller_count                   = 1
    scsi_type                               = "pvscsi"
    shutdown_wait_timeout                   = 3
    swap_placement_policy                   = "inherit"
    sync_time_with_host                     = false
    sync_time_with_host_periodically        = false
    tools_upgrade_policy                    = "manual"
    uuid                                    = "420ce5db-853b-fc11-9af4-78f1313c7c54"
    vapp_transport                          = []
    vbs_enabled                             = false
    vmware_tools_status                     = "guestToolsRunning"
    vmx_path                                = "ryan-gpu-terraform/ryan-gpu-terraform.vmx"
    vvtd_enabled                            = false
    wait_for_guest_ip_timeout               = 0
    wait_for_guest_net_routable             = true
    wait_for_guest_net_timeout              = 5

    clone {
        linked_clone  = false
        template_uuid = "420c2d6e-4f7a-c031-bdf9-998a2c4558f0"
        timeout       = 30

        customize {
            timeout = 10

            linux_options {
                domain       = "rainpole.io"
                host_name    = "ryan-gpu-terraform"
                hw_clock_utc = true
            }

            network_interface {}
        }
    }

    disk {
        attach           = false
        controller_type  = "scsi"
        datastore_id     = "datastore-148"
        device_address   = "scsi:0:0"
        disk_mode        = "persistent"
        disk_sharing     = "sharingNone"
        eagerly_scrub    = false
        io_limit         = -1
        io_reservation   = 0
        io_share_count   = 1000
        io_share_level   = "normal"
        keep_on_remove   = false
        key              = 2000
        label            = "disk0"
        path             = "ryan-pci-terraform/ryan-pci-terraform.vmdk"
        size             = 40
        thin_provisioned = false
        unit_number      = 0
        uuid             = "6000C296-6546-84e5-f892-f6fc84a18518"
        write_through    = false
    }

    network_interface {
        adapter_type          = "vmxnet3"
        bandwidth_limit       = -1
        bandwidth_reservation = 0
        bandwidth_share_count = 50
        bandwidth_share_level = "normal"
        device_address        = "pci:0:7"
        key                   = 4000
        mac_address           = "00:50:56:8c:4d:bb"
        network_id            = "dvportgroup-4199"
        use_static_mac        = false
    }
}
```

### Release Note

`resource/virtual_machine` - Fix issue where PCI passthrough devices not applied during initial cloning.

### References

Closes #1137