### PR TITLE
fix: Update `DiskCloneValidateOperation` and `DiskImportOperation`

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -794,14 +794,13 @@ func DiskCloneValidateOperation(d *schema.ResourceDiff, c *govmomi.Client, l obj
 			}
 		}
 
-		// Finally, we don't support non-SCSI (ie: SATA, IDE, NVMe) disks, so kick
-		// back an error if we see one of those.
+		// The provider does not support all controllers, return an error if unsupported.
 		ct, _, _, err := splitDevAddr(r.DevAddr())
 		if err != nil {
 			return fmt.Errorf("%s: error parsing device address after reading disk %q: %s", tr.Addr(), targetPath, err)
 		}
-		if ct != SubresourceControllerTypeSCSI {
-			return fmt.Errorf("%s: unsupported controller type %s for disk %q. Please use a template with SCSI disks only", tr.Addr(), ct, targetPath)
+		if ct != SubresourceControllerTypeSCSI && ct != SubresourceControllerTypeSATA && ct != SubresourceControllerTypeIDE {
+			return fmt.Errorf("%s: unsupported controller type %s for disk %q.", tr.Addr(), ct, targetPath)
 		}
 	}
 	log.Printf("[DEBUG] DiskCloneValidateOperation: All disks in source validated successfully")
@@ -1060,7 +1059,7 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 // DiskImportOperation validates the disk configuration of the virtual
 // machine's VirtualDeviceList to ensure it will be imported properly, and also
 // saves device addresses into state for disks defined in config. Both the
-// imported device list is sorted by the device's unit number on the SCSI bus.
+// imported device list is sorted by the device's unit number on the controller bus.
 func DiskImportOperation(d *schema.ResourceData, l object.VirtualDeviceList) error {
 	log.Printf("[DEBUG] DiskImportOperation: Performing pre-read import and validation of virtual disks")
 	devices := SelectDisks(l, d.Get("scsi_controller_count").(int), d.Get("sata_controller_count").(int), d.Get("ide_controller_count").(int))
@@ -1074,8 +1073,8 @@ func DiskImportOperation(d *schema.ResourceData, l object.VirtualDeviceList) err
 	devices = devSort.Sort
 	log.Printf("[DEBUG] DiskImportOperation: Disk devices order after sort: %s", DeviceListString(devices))
 
-	// Read in the disks. We don't do anything with the results here other than
-	// validate that the disks are SCSI disks. The read operation validates the rest.
+	// Read in the disks and validate.
+	// The provider does not support all controllers, return an error if unsupported.
 	var curSet []interface{}
 	log.Printf("[DEBUG] DiskImportOperation: Validating disk type and saving ")
 	for i, device := range devices {
@@ -1092,8 +1091,8 @@ func DiskImportOperation(d *schema.ResourceData, l object.VirtualDeviceList) err
 		if err != nil {
 			return fmt.Errorf("disk.%d: error parsing device address %s: %s", i, addr, err)
 		}
-		if ct != SubresourceControllerTypeSCSI {
-			return fmt.Errorf("disk.%d: unsupported controller type %s for disk %s. The VM resource supports SCSI disks only", i, ct, addr)
+		if ct != SubresourceControllerTypeSCSI && ct != SubresourceControllerTypeSATA && ct != SubresourceControllerTypeIDE {
+			return fmt.Errorf("disk.%d: unsupported controller type %s for disk %s.", i, ct, addr)
 		}
 		// As one final validation, as we are no longer reading here, validate that
 		// this is a VMDK-backed virtual disk to make sure we aren't importing RDM

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -800,7 +800,7 @@ func DiskCloneValidateOperation(d *schema.ResourceDiff, c *govmomi.Client, l obj
 			return fmt.Errorf("%s: error parsing device address after reading disk %q: %s", tr.Addr(), targetPath, err)
 		}
 		if ct != SubresourceControllerTypeSCSI && ct != SubresourceControllerTypeSATA && ct != SubresourceControllerTypeIDE {
-			return fmt.Errorf("%s: unsupported controller type %s for disk %q.", tr.Addr(), ct, targetPath)
+			return fmt.Errorf("%s: unsupported controller type %s for disk %q", tr.Addr(), ct, targetPath)
 		}
 	}
 	log.Printf("[DEBUG] DiskCloneValidateOperation: All disks in source validated successfully")
@@ -1092,7 +1092,7 @@ func DiskImportOperation(d *schema.ResourceData, l object.VirtualDeviceList) err
 			return fmt.Errorf("disk.%d: error parsing device address %s: %s", i, addr, err)
 		}
 		if ct != SubresourceControllerTypeSCSI && ct != SubresourceControllerTypeSATA && ct != SubresourceControllerTypeIDE {
-			return fmt.Errorf("disk.%d: unsupported controller type %s for disk %s.", i, ct, addr)
+			return fmt.Errorf("disk.%d: unsupported controller type %s for disk %s", i, ct, addr)
 		}
 		// As one final validation, as we are no longer reading here, validate that
 		// this is a VMDK-backed virtual disk to make sure we aren't importing RDM


### PR DESCRIPTION
### Description

Updates the `DiskCloneValidateOperation` and `DiskImportOperation` functions in `virtual_machine_disk_subresource` to add support for SATA and IDE controllers and disks (alongside existing SCSI.)

### Release Note

`resource/virtual_machine`: Fixes ability to clone and import virtual machine resources with SATA and IDE controllers. (GH-1629)

### References

Closes #1189 
Closes #1355

### Testing

**Import**:

`main.tf`

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

data "vsphere_datacenter" "datacenter" {
  name = var.vsphere_datacenter
}

data "vsphere_network" "network" {
  name          = var.vsphere_network
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_compute_cluster" "cluster" {
  name          = var.vsphere_cluster
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_resource_pool" "pool" {
  name          = format("%s%s", data.vsphere_compute_cluster.cluster.name, "/Resources")
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_datastore" "datastore" {
  name          = var.vsphere_datastore
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_host" "host" {
  name          = var.vsphere_host
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_virtual_machine" "template" {
  name          = var.vsphere_template
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

resource "vsphere_virtual_machine" "vm" {
  folder                  = "workloads"
  name                    = var.vm_name
  num_cpus                = var.vm_cpus
  memory                  = var.vm_memory
  firmware                = var.vm_firmware
  efi_secure_boot_enabled = var.vm_efi_secure_boot_enabled
  host_system_id          = data.vsphere_host.host.id
  guest_id                = var.vm_guest_id
  datastore_id            = data.vsphere_datastore.datastore.id
  resource_pool_id        = data.vsphere_resource_pool.pool.id
  scsi_controller_count   = 1
  scsi_type               = var.vm_scsi_type
  sata_controller_count   = 1
  network_interface {
    network_id = data.vsphere_network.network.id
  }
  disk {
    label            = "disk0"
    size             = var.vm_disk_size
    eagerly_scrub    = false
    thin_provisioned = true
    unit_number      = 0
    controller_type  = "sata"
    keep_on_remove   = true
  }

  cdrom {
    client_device = true
  }

  # clone {
  #   template_uuid = data.vsphere_virtual_machine.template.id
  #   customize {
  #     linux_options {
  #       host_name = var.vm_hostname
  #       domain    = var.vm_domain
  #     }
  #     network_interface {
  #     }
  #   }
  # }

  lifecycle {
    ignore_changes = []
  }
}
```

```console
❯ terraform import vsphere_virtual_machine.vm /m01-dc01/vm/workloads/centos-sata
vsphere_virtual_machine.vm: Importing from ID "/m01-dc01/vm/workloads/centos-sata"...
vsphere_virtual_machine.vm: Import prepared!
  Prepared vsphere_virtual_machine for import
vsphere_virtual_machine.vm: Refreshing state... [id=42028355-b9cf-0813-57a5-177836b0c9fd]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.


❯ terraform plan
vsphere_virtual_machine.vm: Refreshing state... [id=42028355-b9cf-0813-57a5-177836b0c9fd]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no
changes are needed.
```

**Clone**:

`main.tf`

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

data "vsphere_datacenter" "datacenter" {
  name = var.vsphere_datacenter
}

data "vsphere_network" "network" {
  name          = var.vsphere_network
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_compute_cluster" "cluster" {
  name          = var.vsphere_cluster
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_resource_pool" "pool" {
  name          = format("%s%s", data.vsphere_compute_cluster.cluster.name, "/Resources")
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_datastore" "datastore" {
  name          = var.vsphere_datastore
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_host" "host" {
  name          = var.vsphere_host
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_virtual_machine" "template" {
  name          = var.vsphere_template
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

resource "vsphere_virtual_machine" "vm" {
  folder                  = "workloads"
  name                    = var.vm_name
  num_cpus                = var.vm_cpus
  memory                  = var.vm_memory
  firmware                = var.vm_firmware
  efi_secure_boot_enabled = var.vm_efi_secure_boot_enabled
  host_system_id          = data.vsphere_host.host.id
  guest_id                = var.vm_guest_id
  datastore_id            = data.vsphere_datastore.datastore.id
  resource_pool_id        = data.vsphere_resource_pool.pool.id
  scsi_controller_count   = 1
  scsi_type               = var.vm_scsi_type
  sata_controller_count   = 1
  network_interface {
    network_id = data.vsphere_network.network.id
  }
  disk {
    label            = "disk0"
    size             = var.vm_disk_size
    eagerly_scrub    = false
    thin_provisioned = true
    unit_number      = 0
    controller_type  = "sata"
    keep_on_remove   = true
  }

  cdrom {
    client_device = true
  }

  clone {
    template_uuid = data.vsphere_virtual_machine.template.id
    customize {
      linux_options {
        host_name = var.vm_hostname
        domain    = var.vm_domain
      }
      network_interface {
      }
    }
  }

  lifecycle {
    ignore_changes = []
  }
}
```

```clone
❯ terraform apply -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_virtual_machine.vm will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = (known after apply)
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-11"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = true
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "efi"
      + folder                                  = "workloads"
      + force_power_off                         = true
      + guest_id                                = "centos8_64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = "host-10"
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 2048
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "centos-sata"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 1
      + power_state                             = (known after apply)
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-6046"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 1
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tools_upgrade_policy                    = "manual"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + cdrom {
          + client_device  = true
          + device_address = (known after apply)
          + key            = (known after apply)
        }

      + clone {
          + template_uuid = "42024809-74f5-a91e-03c5-806fc50c3319"
          + timeout       = 30

          + customize {
              + timeout = 10

              + linux_options {
                  + domain       = "rainpole.io"
                  + host_name    = "centos-sata"
                  + hw_clock_utc = true
                }

              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "sata"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = true
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 16
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-16"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
vsphere_virtual_machine.vm: Creating...
vsphere_virtual_machine.vm: Still creating... [10s elapsed]
vsphere_virtual_machine.vm: Still creating... [20s elapsed]
vsphere_virtual_machine.vm: Still creating... [30s elapsed]
vsphere_virtual_machine.vm: Still creating... [40s elapsed]
vsphere_virtual_machine.vm: Still creating... [50s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m0s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m10s elapsed]
vsphere_virtual_machine.vm: Still creating... [1m20s elapsed]
vsphere_virtual_machine.vm: Creation complete after 1m25s [id=4202b8f5-a1a3-4850-8ad4-6f0710996630]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.


❯ terraform state show vsphere_virtual_machine.vm
# vsphere_virtual_machine.vm:
resource "vsphere_virtual_machine" "vm" {
    boot_delay                              = 0
    boot_retry_delay                        = 10000
    boot_retry_enabled                      = false
    change_version                          = "2022-03-21T20:29:26.991056Z"
    cpu_hot_add_enabled                     = false
    cpu_hot_remove_enabled                  = false
    cpu_limit                               = -1
    cpu_performance_counters_enabled        = false
    cpu_reservation                         = 0
    cpu_share_count                         = 1000
    cpu_share_level                         = "normal"
    datastore_id                            = "datastore-11"
    default_ip_address                      = "172.16.14.166"
    efi_secure_boot_enabled                 = true
    enable_disk_uuid                        = false
    enable_logging                          = false
    ept_rvi_mode                            = "automatic"
    firmware                                = "efi"
    folder                                  = "workloads"
    force_power_off                         = true
    guest_id                                = "centos8_64Guest"
    guest_ip_addresses                      = [
        "172.16.14.166",
        "fe80::250:56ff:fe82:d2fb",
    ]
    hardware_version                        = 19
    host_system_id                          = "host-10"
    hv_mode                                 = "hvAuto"
    id                                      = "4202b8f5-a1a3-4850-8ad4-6f0710996630"
    ide_controller_count                    = 2
    latency_sensitivity                     = "normal"
    memory                                  = 2048
    memory_hot_add_enabled                  = false
    memory_limit                            = -1
    memory_reservation                      = 0
    memory_share_count                      = 20480
    memory_share_level                      = "normal"
    migrate_wait_timeout                    = 30
    moid                                    = "vm-63011"
    name                                    = "centos-sata"
    nested_hv_enabled                       = false
    num_cores_per_socket                    = 1
    num_cpus                                = 1
    power_state                             = "on"
    poweron_timeout                         = 300
    reboot_required                         = false
    resource_pool_id                        = "resgroup-6046"
    run_tools_scripts_after_power_on        = true
    run_tools_scripts_after_resume          = true
    run_tools_scripts_before_guest_reboot   = false
    run_tools_scripts_before_guest_shutdown = true
    run_tools_scripts_before_guest_standby  = true
    sata_controller_count                   = 1
    scsi_bus_sharing                        = "noSharing"
    scsi_controller_count                   = 1
    scsi_type                               = "pvscsi"
    shutdown_wait_timeout                   = 3
    swap_placement_policy                   = "inherit"
    sync_time_with_host                     = false
    sync_time_with_host_periodically        = false
    tools_upgrade_policy                    = "manual"
    uuid                                    = "4202b8f5-a1a3-4850-8ad4-6f0710996630"
    vapp_transport                          = []
    vbs_enabled                             = false
    vmware_tools_status                     = "guestToolsRunning"
    vmx_path                                = "centos-sata_2/centos-sata.vmx"
    vvtd_enabled                            = false
    wait_for_guest_ip_timeout               = 0
    wait_for_guest_net_routable             = true
    wait_for_guest_net_timeout              = 5

    cdrom {
        client_device  = true
        device_address = "ide:0:0"
        key            = 3000
    }

    clone {
        linked_clone  = false
        template_uuid = "42024809-74f5-a91e-03c5-806fc50c3319"
        timeout       = 30

        customize {
            timeout = 10

            linux_options {
                domain       = "rainpole.io"
                host_name    = "centos-sata"
                hw_clock_utc = true
            }

            network_interface {}
        }
    }

    disk {
        attach           = false
        controller_type  = "sata"
        datastore_id     = "datastore-11"
        device_address   = "sata:0:0"
        disk_mode        = "persistent"
        disk_sharing     = "sharingNone"
        eagerly_scrub    = false
        io_limit         = -1
        io_reservation   = 0
        io_share_count   = 1000
        io_share_level   = "normal"
        keep_on_remove   = true
        key              = 16000
        label            = "disk0"
        path             = "centos-sata_2/centos-sata.vmdk"
        size             = 16
        thin_provisioned = true
        unit_number      = 0
        uuid             = "6000C297-4ac4-ebf4-27a0-00987f600f0e"
        write_through    = false
    }

    network_interface {
        adapter_type          = "vmxnet3"
        bandwidth_limit       = -1
        bandwidth_reservation = 0
        bandwidth_share_count = 50
        bandwidth_share_level = "normal"
        device_address        = "pci:0:7"
        key                   = 4000
        mac_address           = "00:50:56:82:d2:fb"
        network_id            = "network-16"
        use_static_mac        = false
    }
}
```
