### PR TITLE
fix: Prevent unsupported traffic classes to be set and cause crash

### DIFF
--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -642,6 +642,11 @@ func expandSliceOfDvsHostInfrastructureTrafficResource(d *schema.ResourceData) [
 // flattenSliceOfDvsHostInfrastructureTrafficResource reads in the supplied network I/O control allocation entries supplied via a respective DVSConfigInfo field and sets the appropriate keys in the supplied ResourceData.
 func flattenSliceOfDvsHostInfrastructureTrafficResource(d *schema.ResourceData, s []types.DvsHostInfrastructureTrafficResource) error {
 	for _, v := range s {
+		if !stringInSlice(v.Key, infrastructureTrafficClassValues) {
+			// this would imply there are new classes introduced by the vCenter
+			// API but not yet supported by govmomi/provider
+			continue
+		}
 		if err := flattenDvsHostInfrastructureTrafficResource(d, v, v.Key); err != nil {
 			return err
 		}

--- a/vsphere/util.go
+++ b/vsphere/util.go
@@ -1,0 +1,10 @@
+package vsphere
+
+func stringInSlice(s string, list []string) bool {
+	for _, i := range list {
+		if i == s {
+			return true
+		}
+	}
+	return false
+}

--- a/website/docs/r/distributed_virtual_switch.html.markdown
+++ b/website/docs/r/distributed_virtual_switch.html.markdown
@@ -237,7 +237,7 @@ pools, if their use is so desired.
 
 #### Network I/O control traffic classes
 
-There are currently 9 traffic classes that can be used for network I/O
+There are currently 10 traffic classes that can be used for network I/O
 control - they are below.
 
 Each of these classes has 4 options that can be tuned that are discussed in the
@@ -254,6 +254,7 @@ next section.
 <tr><td>Virtual Machine Traffic</td><td>`virtualmachine`</td></tr>
 <tr><td>vMotion Traffic</td><td>`vmotion`</td></tr>
 <tr><td>VSAN Traffic</td><td>`vsan`</td></tr>
+<tr><td>Backup NFC</td><td>`backupnfc`</td></tr>
 </table>
 
 #### Traffic class resource options


### PR DESCRIPTION
### Description

It would appear newer versions of vCenter responds back with traffic classes
even if those classes aren't accounted in the version of govmomi the provider has.
Need to upgrade govmomi to support new `nvmetcp` class that was causing a crash.

### Acceptance tests
- [x] Have you run the acceptance tests on this branch?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/dvs`: Prevent setting unsupported traffic classes.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
