### PR TITLE
feat: Add `d/vsphere_compute_cluster_host_group`

### DIFF
--- a/vsphere/data_source_vsphere_compute_cluster_host_group.go
+++ b/vsphere/data_source_vsphere_compute_cluster_host_group.go
@@ -43,12 +43,15 @@ func dataSourceVSphereComputeClusterHostGroupRead(d *schema.ResourceData, meta i
 		return fmt.Errorf("cannot read cluster properties: %s", err)
 	}
 
-	hostSystemIDs := make([]string, 0)
-	for _, host := range props.Host {
-		hostSystemIDs = append(hostSystemIDs, host.Reference().Value)
+	hostSystemIDs := make([]string, len(props.Host))
+	for i, host := range props.Host {
+		hostSystemIDs[i] = host.Reference().Value
 	}
 
 	d.SetId(name)
-	_ = d.Set("host_system_ids", hostSystemIDs)
+	if err := d.Set("host_system_ids", hostSystemIDs); err != nil {
+		return fmt.Errorf("cannot set host_system_ids: %s", err)
+	}
+
 	return nil
 }

--- a/vsphere/data_source_vsphere_compute_cluster_host_group.go
+++ b/vsphere/data_source_vsphere_compute_cluster_host_group.go
@@ -1,0 +1,54 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource"
+)
+
+func dataSourceVSphereComputeClusterHostGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereComputeClusterHostGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the host group in the cluster.",
+			},
+			"compute_cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The managed object ID of the cluster.",
+			},
+			"host_system_ids": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "The managed object IDs of the hosts.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceVSphereComputeClusterHostGroupRead(d *schema.ResourceData, meta interface{}) error {
+	cluster, name, err := resourceVSphereComputeClusterHostGroupObjects(d, meta)
+	if err != nil {
+		return fmt.Errorf("cannot locate resource: %s", err)
+	}
+
+	props, err := clustercomputeresource.Properties(cluster)
+	if err != nil {
+		return fmt.Errorf("cannot read cluster properties: %s", err)
+	}
+
+	hostSystemIDs := make([]string, 0)
+	for _, host := range props.Host {
+		hostSystemIDs = append(hostSystemIDs, host.Reference().Value)
+	}
+
+	d.SetId(name)
+	_ = d.Set("host_system_ids", hostSystemIDs)
+	return nil
+}

--- a/vsphere/data_source_vsphere_compute_cluster_host_group_test.go
+++ b/vsphere/data_source_vsphere_compute_cluster_host_group_test.go
@@ -1,0 +1,69 @@
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
+)
+
+func TestAccDataSourceVSphereComputeClusterHostGroup_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+			testAccResourceVSphereComputeClusterHostGroupPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereComputeClusterHostGroupConfig(2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_compute_cluster_host_group.test", "host_system_ids",
+						"vsphere_compute_cluster_host_group.cluster_host_group", "host_system_ids",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVSphereComputeClusterHostGroupConfig(count int) string {
+	return fmt.Sprintf(`
+variable hosts {
+  default = [ %q, %q ]
+}
+
+%s 
+
+data "vsphere_host" "hosts" {
+  count         = %d
+  name          = var.hosts[count.index]
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+
+resource "vsphere_compute_cluster_host_group" "cluster_host_group" {
+  name               = "terraform-test-cluster-group"
+  compute_cluster_id = data.vsphere_compute_cluster.rootcompute_cluster1.id
+  host_system_ids    = data.vsphere_host.hosts.*.id
+}
+
+data "vsphere_compute_cluster_host_group" "test" {
+  name = "terraform-test-cluster-group"
+  compute_cluster_id = data.vsphere_compute_cluster.rootcompute_cluster1.id
+}
+`,
+		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
+		os.Getenv("TF_VAR_VSPHERE_ESXI2"),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigDataRootDS1(),
+			testhelper.ConfigDataRootVMNet(),
+		),
+		count)
+}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -142,6 +142,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"vsphere_compute_cluster":            dataSourceVSphereComputeCluster(),
+			"vsphere_compute_cluster_host_group": dataSourceVSphereComputeClusterHostGroup(),
 			"vsphere_content_library":            dataSourceVSphereContentLibrary(),
 			"vsphere_content_library_item":       dataSourceVSphereContentLibraryItem(),
 			"vsphere_custom_attribute":           dataSourceVSphereCustomAttribute(),

--- a/vsphere/resource_vsphere_compute_cluster_host_group.go
+++ b/vsphere/resource_vsphere_compute_cluster_host_group.go
@@ -33,7 +33,7 @@ func resourceVSphereComputeClusterHostGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The unique name of the virtual machine group in the cluster.",
+				Description: "The unique name of the host group in the cluster.",
 			},
 			"compute_cluster_id": {
 				Type:        schema.TypeString,

--- a/website/docs/d/compute_cluster_host_group.html.markdown
+++ b/website/docs/d/compute_cluster_host_group.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_compute_cluster_host_group"
+sidebar_current: "docs-vsphere-data-source-compute-cluster-host-group"
+description: |-
+  Provides a vSphere cluster host group data source. Returns attributes of a vSphere cluster host group.
+---
+
+# vsphere\_compute\_cluster\_host\_group
+
+The `vsphere_compute_cluster_host_group` data source can be used to discover
+the IDs ESXi hosts in a host group and return host group attributes to other
+resources.
+
+## Example Usage
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = var.vsphere_datacenter
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = var.vsphere_cluster
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+data "vsphere_compute_cluster_host_group" "host_group1" {
+  name               = "host_group1"
+  compute_cluster_id = data.vsphere_compute_cluster.cluster.id
+}
+
+resource "vsphere_compute_cluster_vm_host_rule" "host_rule1" {
+  compute_cluster_id       = data.vsphere_compute_cluster.cluster.id
+  name                     = "terraform-host-rule1"
+  vm_group_name            = "vm_group1"
+  affinity_host_group_name = data.vsphere_compute_cluster_host_group.host_group1.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the host group.
+* `compute_cluster_id` - (Required) The [managed object reference ID][docs-about-morefs]
+  of the compute cluster for the host group.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+
+## Attribute Reference
+
+* `host_system_ids`: The [managed object reference ID][docs-about-morefs] of
+  the ESXi hosts in the host group.


### PR DESCRIPTION
### Description

- Adds a datasource for `vsphere_compute_cluster_host_group`.
- Corrects the description for the `name` attribute in `r/vsphere_compute_cluster_host_group`.

### Release Note

`datasource/compute_cluster_host_group`: New data source can be used to read general attributes of a host group. (GH-xxx)

### References

Closes #1449

### Tests

`main.tf` Example

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

data "vsphere_datacenter" "datacenter" {
  name = var.vsphere_datacenter
}

data "vsphere_compute_cluster" "cluster" {
  name          = var.vsphere_cluster
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

data "vsphere_compute_cluster_host_group" "host_group1" {
  name               = "host_group1"
  compute_cluster_id = data.vsphere_compute_cluster.cluster.id
}

resource "vsphere_compute_cluster_vm_host_rule" "host_rule1" {
  compute_cluster_id       = data.vsphere_compute_cluster.cluster.id
  name                     = "terraform-host-rule1"
  vm_group_name            = "vm_group1"
  affinity_host_group_name = data.vsphere_compute_cluster_host_group.host_group1.name
}

output "name" {
  value = data.vsphere_compute_cluster_host_group.host_group1.name
}

output "host_system_ids" {
  value = data.vsphere_compute_cluster_host_group.host_group1.host_system_ids
}
```

```console
❯ terraform apply -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_compute_cluster_vm_host_rule.host_rule1 will be created
  + resource "vsphere_compute_cluster_vm_host_rule" "host_rule1" {
      + affinity_host_group_name = "host_group1"
      + compute_cluster_id       = "domain-c6045"
      + enabled                  = true
      + id                       = (known after apply)
      + name                     = "terraform-host-rule1"
      + vm_group_name            = "vm_group1"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + host_system_ids = [
      + "host-10",
      + "host-64003",
    ]
  + name            = "host_group1"
vsphere_compute_cluster_vm_host_rule.host_rule1: Creating...
vsphere_compute_cluster_vm_host_rule.host_rule1: Creation complete after 0s [id=domain-c6045:405]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

host_system_ids = toset([
  "host-10",
  "host-64003",
])
name = "host_group1"
```