### PR TITLE
Generate VMFS disk IDs for tests

### DIFF
--- a/scripts/packet/devrc.tpl
+++ b/scripts/packet/devrc.tpl
@@ -13,9 +13,9 @@ export TF_VAR_VSPHERE_ESXI1=${esxi_host_1}
 export TF_VAR_VSPHERE_ESXI2=${esxi_host_2}
 export VSPHERE_SERVER=${vsphere_host}
 
-export TF_VAR_VSPHERE_VMFS_REGEXP='naa.6000c29[2b]'
-export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0="naa.6000c29b4b217432a854822b1bc40502"
-export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK1="naa.6000c29f3dbf773c6c25cb830dfc201b"
+export TF_VAR_VSPHERE_VMFS_REGEXP='naa.'
+export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0=${vmfs_disk_0}
+export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK1=${vmfs_disk_1}
 
 export VSPHERE_USER="administrator@vcenter.vspheretest.internal"
 export VSPHERE_PASSWORD="Password123!"

--- a/scripts/packet/main.tf.phase2
+++ b/scripts/packet/main.tf.phase2
@@ -246,13 +246,20 @@ resource "vsphere_host" "host2" {
   thumbprint = data.vsphere_host_thumbprint.esxi2.id
 }
 
+data "vsphere_vmfs_disks" "available" {
+  host_system_id = vsphere_host.host1.id
+  rescan         = true
+  filter         = "naa."
+}
+
 resource "local_file" "devrc" {
   sensitive_content = templatefile("${path.cwd}/devrc.tpl", {
     nas_host    = metal_device.storage1.network.0.address
     esxi_host_1 = metal_device.esxi1.network.0.address
     esxi_host_2 = metal_device.esxi2.network.0.address
     vsphere_host = cidrhost("${metal_device.esxi1.network.0.address}/${metal_device.esxi1.network.0.cidr}",3)
-
+    vmfs_disk_0 = data.vsphere_vmfs_disks.available.disks[0]
+    vmfs_disk_1 = data.vsphere_vmfs_disks.available.disks[1]
   })
   filename = "./devrc"
 }

--- a/scripts/packet/main.tf.phase3
+++ b/scripts/packet/main.tf.phase3
@@ -309,13 +309,20 @@ resource "vsphere_virtual_machine" "pxe" {
   }
 }
 
+data "vsphere_vmfs_disks" "available" {
+  host_system_id = vsphere_host.host1.id
+  rescan         = true
+  filter         = "naa."
+}
+
 resource "local_file" "devrc" {
   sensitive_content = templatefile("${path.cwd}/devrc.tpl", {
     nas_host    = metal_device.storage1.network.0.address
     esxi_host_1 = metal_device.esxi1.network.0.address
     esxi_host_2 = metal_device.esxi2.network.0.address
     vsphere_host = cidrhost("${metal_device.esxi1.network.0.address}/${metal_device.esxi1.network.0.cidr}",3)
-
+    vmfs_disk_0 = data.vsphere_vmfs_disks.available.disks[0]
+    vmfs_disk_1 = data.vsphere_vmfs_disks.available.disks[1]
   })
   filename = "./devrc"
 }

--- a/scripts/packet/versions.tf
+++ b/scripts/packet/versions.tf
@@ -8,7 +8,6 @@ terraform {
     }
     vsphere = {
       source = "hashicorp/vsphere"
-      version = "2.0.2"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
The VMFS datastore tests weren't broken but was previously hardcoded, all of them pass with the right values set.
