### PR TITLE
feat: Set timeout for `v/virtual_machine` reconfigure task

### DIFF
--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -430,7 +430,7 @@ func testRenameVMFirstDisk(s *terraform.State, resourceName string, new string) 
 	spec := types.VirtualMachineConfigSpec{
 		DeviceChange: dcSpec,
 	}
-	return virtualmachine.Reconfigure(vm, spec)
+	return virtualmachine.Reconfigure(vm, spec, defaultAPITimeout)
 }
 
 // testDeleteVMDisk deletes a VMDK file from the virtual machine directory. It

--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -826,15 +826,15 @@ func MoveToFolder(client *govmomi.Client, vm *object.VirtualMachine, relative st
 
 // Reconfigure wraps the Reconfigure task and the subsequent waiting for
 // the task to complete.
-func Reconfigure(vm *object.VirtualMachine, spec types.VirtualMachineConfigSpec) error {
+func Reconfigure(vm *object.VirtualMachine, spec types.VirtualMachineConfigSpec, timeout time.Duration) error {
 	log.Printf("[DEBUG] Reconfiguring virtual machine %q", vm.InventoryPath)
-	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	task, err := vm.Reconfigure(ctx, spec)
 	if err != nil {
 		return err
 	}
-	tctx, tcancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	tctx, tcancel := context.WithTimeout(context.Background(), timeout)
 	defer tcancel()
 	return task.Wait(tctx)
 }

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -581,6 +581,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] %s: Performing update", resourceVSphereVirtualMachineIDString(d))
 	client := meta.(*Client).vimClient
+	timeout := meta.(*Client).timeout
 	tagsClient, err := tagsManagerIfDefined(d, meta)
 	if err != nil {
 		return err
@@ -751,7 +752,7 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 		if _, ok := d.GetOk("datastore_cluster_id"); ok {
 			err = resourceVSphereVirtualMachineUpdateReconfigureWithSDRS(d, meta, vm, spec)
 		} else {
-			err = virtualmachine.Reconfigure(vm, spec)
+			err = virtualmachine.Reconfigure(vm, spec, timeout)
 		}
 		if err != nil {
 			return err
@@ -832,9 +833,10 @@ func resourceVSphereVirtualMachineUpdateReconfigureWithSDRS(
 ) error {
 	// Check to see if we have any disk creation operations first, as sending an
 	// update through SDRS without any disk creation operations will fail.
+	timeout := meta.(*Client).timeout
 	if !storagepod.HasDiskCreationOperations(spec.DeviceChange) {
 		log.Printf("[DEBUG] No disk operations for reconfiguration of VM %q, deferring to standard API", vm.InventoryPath)
-		return virtualmachine.Reconfigure(vm, spec)
+		return virtualmachine.Reconfigure(vm, spec, timeout)
 	}
 
 	client := meta.(*Client).vimClient
@@ -858,6 +860,7 @@ func resourceVSphereVirtualMachineUpdateReconfigureWithSDRS(
 func resourceVSphereVirtualMachineDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] %s: Performing delete", resourceVSphereVirtualMachineIDString(d))
 	client := meta.(*Client).vimClient
+	timeout := meta.(*Client).timeout
 	id := d.Id()
 	vm, err := virtualmachine.FromUUID(client, id)
 	if err != nil {
@@ -885,7 +888,7 @@ func resourceVSphereVirtualMachineDelete(d *schema.ResourceData, meta interface{
 	}
 	// Only run the reconfigure operation if there's actually disks in the spec.
 	if len(spec.DeviceChange) > 0 {
-		if err := virtualmachine.Reconfigure(vm, spec); err != nil {
+		if err := virtualmachine.Reconfigure(vm, spec, timeout); err != nil {
 			return fmt.Errorf("error detaching virtual disks: %s", err)
 		}
 	}
@@ -1346,6 +1349,7 @@ func resourceVSphereVirtualMachineCreateBareStandard(
 // Deploy vm from ovf/ova template
 func resourceVsphereMachineDeployOvfAndOva(d *schema.ResourceData, meta interface{}) (*object.VirtualMachine, error) {
 	client := meta.(*Client).vimClient
+	timeout := meta.(*Client).timeout
 
 	ovfParams := NewOvfHelperParamsFromVMResource(d)
 	ovfHelper, err := ovfdeploy.NewOvfHelper(client, ovfParams)
@@ -1395,7 +1399,7 @@ func resourceVsphereMachineDeployOvfAndOva(d *schema.ResourceData, meta interfac
 		vmConfigSpec := types.VirtualMachineConfigSpec{
 			VAppConfig: vappConfig,
 		}
-		err = virtualmachine.Reconfigure(vm, vmConfigSpec)
+		err = virtualmachine.Reconfigure(vm, vmConfigSpec, timeout)
 		if err != nil {
 			return nil, fmt.Errorf("error while applying vapp config %s", err)
 		}
@@ -1610,7 +1614,8 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] %s: Final device change cfgSpec: %s", resourceVSphereVirtualMachineIDString(d), virtualdevice.DeviceChangeString(cfgSpec.DeviceChange))
 
 	// Perform updates
-	err = virtualmachine.Reconfigure(vm, cfgSpec)
+	timeout := meta.(*Client).timeout
+	err = virtualmachine.Reconfigure(vm, cfgSpec, timeout)
 	if err != nil {
 		return resourceVSphereVirtualMachineRollbackCreate(
 			d,


### PR DESCRIPTION
### Description

Sometimes reconfiguration tasks take a long time. And if they last more than 5 minutes, then the tasks fail. Because the limit is set as a constant as seen below.

https://github.com/hashicorp/terraform-provider-vsphere/blob/30f37d268d790f7ced3cf6b2d80bfaf693327251/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go#L827-L840

This pull request adds a timeout setting for `r/virtual_machine` reconfiguration tasks.

### Release Note

`resource/virtual_machine`: Virtual machine reconfiguration tasks will use the provider `api_timeout` setting. (GH-1645)

### References

Closes #1646
Closes #1662