### PR TITLE
feat: Support looking up VM by UUID

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -149,6 +149,14 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 	// include the number of cpus, memory, firmware, disks, etc.
 	structure.MergeSchema(s, schemaVirtualMachineConfigSpec())
 
+	// make name/uuid Optional/AtLeastOneOf since UUID lookup is now supported
+	s["name"].Required = false
+	s["name"].Optional = true
+	s["name"].AtLeastOneOf = []string{"name", "uuid"}
+	s["uuid"].Required = false
+	s["uuid"].Optional = true
+	s["uuid"].AtLeastOneOf = []string{"name", "uuid"}
+
 	// Now that the schema has been composed and merged, we can attach our reader and
 	// return the resource back to our host process.
 	return &schema.Resource{
@@ -159,22 +167,31 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 
 func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client).vimClient
-
+	uuid := d.Get("uuid").(string)
 	name := d.Get("name").(string)
-	log.Printf("[DEBUG] Looking for VM or template by name/path %q", name)
-	var dc *object.Datacenter
-	if dcID, ok := d.GetOk("datacenter_id"); ok {
-		var err error
-		dc, err = datacenterFromID(client, dcID.(string))
-		if err != nil {
-			return fmt.Errorf("cannot locate datacenter: %s", err)
+	var vm *object.VirtualMachine
+	var err error
+
+	if uuid != "" {
+		log.Printf("[DEBUG] Looking for VM or template by UUID %q", uuid)
+		vm, err = virtualmachine.FromUUID(client, uuid)
+	} else {
+		log.Printf("[DEBUG] Looking for VM or template by name/path %q", name)
+		var dc *object.Datacenter
+		if dcID, ok := d.GetOk("datacenter_id"); ok {
+			dc, err = datacenterFromID(client, dcID.(string))
+			if err != nil {
+				return fmt.Errorf("cannot locate datacenter: %s", err)
+			}
+			log.Printf("[DEBUG] Datacenter for VM/template search: %s", dc.InventoryPath)
 		}
-		log.Printf("[DEBUG] Datacenter for VM/template search: %s", dc.InventoryPath)
+		vm, err = virtualmachine.FromPath(client, name, dc)
 	}
-	vm, err := virtualmachine.FromPath(client, name, dc)
+
 	if err != nil {
 		return fmt.Errorf("error fetching virtual machine: %s", err)
 	}
+
 	props, err := virtualmachine.Properties(vm)
 	if err != nil {
 		return fmt.Errorf("error fetching virtual machine properties: %s", err)

--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -101,6 +101,52 @@ func TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath(t *testi
 	})
 }
 
+func TestAccDataSourceVSphereVirtualMachine_uuid(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+			testAccDataSourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereVirtualMachineConfigUUID(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_virtual_machine.uuid",
+						"id",
+						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "memory"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "num_cpus"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "num_cores_per_socket"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "hardware_version"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.unit_number"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.label"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interface_types.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.adapter_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_limit"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_reservation"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_share_level"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_share_count"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.mac_address"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.network_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "uuid"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceVSphereVirtualMachinePreCheck(t *testing.T) {
 	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
 		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_virtual_machine data source acceptance tests")
@@ -108,6 +154,28 @@ func testAccDataSourceVSphereVirtualMachinePreCheck(t *testing.T) {
 	if os.Getenv("TF_VAR_VSPHERE_TEMPLATE") == "" {
 		t.Skip("set TF_VAR_VSPHERE_TEMPLATE to run vsphere_virtual_machine data source acceptance tests")
 	}
+}
+
+func testAccDataSourceVSphereVirtualMachineConfigUUID() string {
+	return fmt.Sprintf(`
+%s
+
+variable "template" {
+  default = "%s"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = var.template
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+
+data "vsphere_virtual_machine" "uuid" {
+  uuid = data.vsphere_virtual_machine.template.uuid
+}
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
+	)
 }
 
 func testAccDataSourceVSphereVirtualMachineConfig() string {

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -54,8 +54,11 @@ data "vsphere_virtual_machine" "development_template" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual machine. This can be a name or
-  the full path relative to the datacenter.
+* `name` - (Optional) The name of the virtual machine. This can be a name or
+  the full path relative to the datacenter. This is required if a UUID lookup
+  is not performed.
+* `uuid` - (Optional) Specify this field for a UUID lookup, `name` and `datacenter_id`
+  are not required if this is specified.
 * `datacenter_id` - (Optional) The [managed object reference
   ID][docs-about-morefs] of the datacenter the virtual machine is located in.
   This can be omitted if the search path used in `name` is an absolute path.


### PR DESCRIPTION
### Description

Support lookup by UUID on the VM datasource.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜ make testacc TESTARGS='-run=TestAccDataSourceVSphereVirtualMachine_' GOFLAGS="-count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceVSphereVirtualMachine_ -timeout 240m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
=== RUN   TestAccDataSourceVSphereVirtualMachine_basic
--- PASS: TestAccDataSourceVSphereVirtualMachine_basic (32.52s)
=== RUN   TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath
--- PASS: TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath (30.32s)
=== RUN   TestAccDataSourceVSphereVirtualMachine_uuid
--- PASS: TestAccDataSourceVSphereVirtualMachine_uuid (34.00s)
PASS
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
d/virtual_machine: support lookup by `uuid`
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Closes #1612 
