### PR TITLE
 fix(docs): correct typo 

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -133,7 +133,7 @@ will no longer need them.
 * `persist_session` - (Optional) Persist the SOAP and REST client sessions to
   disk. Default: `false`. Can also be specified by the
   `VSPHERE_PERSIST_SESSION` environment variable.
-* `vim_session_path` - (Optional) The direcotry to save the VIM SOAP API
+* `vim_session_path` - (Optional) The directory to save the VIM SOAP API
   session to. Default: `${HOME}/.govmomi/sessions`. Can also be specified by
   the `VSPHERE_VIM_SESSION_PATH` environment variable.
 * `rest_session_path` - The directory to save the REST API session to. 


### PR DESCRIPTION
### Description

There is a typo on the word `direcotry` on the documentation. This PR just fix it to `directory`.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added? : N/A
- [x] Have you run the acceptance tests on this branch? : N/A

### Release Note

```release-note
NONE
```

### References

None