### PR TITLE
docs: update `r/host_port_group` docs

### DIFF
--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -4,38 +4,38 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host_port_group"
 sidebar_current: "docs-vsphere-resource-networking-host-port-group"
 description: |-
-  Provides a vSphere Host Port Group Resource. This can be used to configure port groups direct on an ESXi host.
+  Provides a vSphere port group resource to manage port groups on ESXi hosts.
 ---
 
 # vsphere\_host\_port\_group
 
-The `vsphere_host_port_group` resource can be used to manage vSphere standard
-port groups on an ESXi host. These port groups are connected to standard
-virtual switches, which can be managed by the
-[`vsphere_host_virtual_switch`][host-virtual-switch] resource.
+The `vsphere_host_port_group` resource can be used to manage port groups on
+ESXi hosts. These port groups are connected to standard switches, which
+can be managed by the [`vsphere_host_virtual_switch`][host-virtual-switch]
+resource.
 
-For an overview on vSphere networking concepts, see [this page][ref-vsphere-net-concepts].
+For an overview on vSphere networking concepts, see [the product documentation][ref-vsphere-net-concepts].
 
 [host-virtual-switch]: /docs/providers/vsphere/r/host_virtual_switch.html
 [ref-vsphere-net-concepts]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html
 
 ## Example Usages
 
-**Create a virtual switch and bind a port group to it:**
+**Create a Virtual Switch and Bind a Port Group:**
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {
-  name = "dc1"
+  name = "dc-01"
 }
 
-data "vsphere_host" "esxi_host" {
-  name          = "esxi1"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+data "vsphere_host" "host" {
+  name          = "esxi-01.example.com"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
-resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+resource "vsphere_host_virtual_switch" "host_virtual_switch" {
+  name           = "switch-01"
+  host_system_id = data.vsphere_host.host.id
 
   network_adapters = ["vmnic0", "vmnic1"]
 
@@ -44,33 +44,33 @@ resource "vsphere_host_virtual_switch" "switch" {
 }
 
 resource "vsphere_host_port_group" "pg" {
-  name                = "PGTerraformTest"
-  host_system_id      = "${data.vsphere_host.esxi_host.id}"
-  virtual_switch_name = "${vsphere_host_virtual_switch.switch.name}"
+  name                = "portgroup-01"
+  host_system_id      = data.vsphere_host.host.id
+  virtual_switch_name = vsphere_host_virtual_switch.host_virtual_switch.name
 }
 ```
 
-**Create a port group with VLAN set and some overrides:**
+**Create a Port Group with a VLAN and ab Override:**
 
 This example sets the trunk mode VLAN (`4095`, which passes through all tags)
 and sets
 [`allow_promiscuous`](/docs/providers/vsphere/r/host_virtual_switch.html#allow_promiscuous)
-to ensure that all traffic is seen on the port. The latter setting overrides
-the implicit default of `false` set on the virtual switch.
+to ensure that all traffic is seen on the port. The setting overrides
+the implicit default of `false` set on the standard switch.
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {
-  name = "dc1"
+  name = "dc-01"
 }
 
-data "vsphere_host" "esxi_host" {
-  name          = "esxi1"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+data "vsphere_host" "host" {
+  name          = "esxi-01.example.com"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
-resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+resource "vsphere_host_virtual_switch" "host_virtual_switch" {
+  name           = "switch-01"
+  host_system_id = data.vsphere_host.host.id
 
   network_adapters = ["vmnic0", "vmnic1"]
 
@@ -79,9 +79,9 @@ resource "vsphere_host_virtual_switch" "switch" {
 }
 
 resource "vsphere_host_port_group" "pg" {
-  name                = "PGTerraformTest"
-  host_system_id      = "${data.vsphere_host.esxi_host.id}"
-  virtual_switch_name = "${vsphere_host_virtual_switch.switch.name}"
+  name                = "portgroup-01"
+  host_system_id      = data.vsphere_host.host.id
+  virtual_switch_name = vsphere_host_virtual_switch.host_virtual_switch.name
 
   vlan_id = 4095
 
@@ -114,7 +114,7 @@ section][host-vswitch-policy-options].  Any policy option that is not set is
 **inherited** from the virtual switch, its options propagating to the port
 group.
 
-See the link for a full list of options that can be set.
+Refer to the link for a full list of options that can be set.
 
 [host-vswitch-policy-options]: /docs/providers/vsphere/r/host_virtual_switch.html#policy-options
 
@@ -122,16 +122,19 @@ See the link for a full list of options that can be set.
 
 The following attributes are exported:
 
-* `id` - An ID unique to Terraform for this port group. The convention is a
-  prefix, the host system ID, and the port group name. An example would be
-  `tf-HostPortGroup:host-10:PGTerraformTest`.
+* `id` - An ID for the port group that is _unique_ to Terraform.
+  The convention is a prefix, the host system ID, and the port group name.
+  For example,`tf-HostPortGroup:host-10:portgroup-01`. Tracking a port group
+  on a standard switch, which can be created with or without a vCenter Server,
+  is different than then a dvPortGroup which is tracked as a managed object ID
+  in vCemter Server versus a key on a host.
 * `computed_policy` - A map with a full set of the [policy
   options][host-vswitch-policy-options] computed from defaults and overrides,
   explaining the effective policy for this port group.
 * `key` - The key for this port group as returned from the vSphere API.
 * `ports` - A list of ports that currently exist and are used on this port group.
 
-## Importing 
+## Importing
 
 An existing host port group can be [imported][docs-import] into this resource
 using the host port group's ID. An example is below:
@@ -139,7 +142,7 @@ using the host port group's ID. An example is below:
 [docs-import]: /docs/import/index.html
 
 ```
-terraform import vsphere_host_port_group.management tf-HostPortGroup:host-123:Management
+terraform import vsphere_host_port_group.management tf-HostPortGroup:host-123:management
 ```
 
-The above would import the `Management` host port group from host with ID `host-123`.
+The above would import the `management` host port group from host with ID `host-123`.


### PR DESCRIPTION
### Description

- Updates `r/host_port_group` documentation with more information regarding the `id` unique to Terraform.
- Updates the content of the `r/host_port_group` documentation for clearer examples and removal of legacy interpolation.

### Release Note

`resource/host_port_group`: Documentation updates. (GH-1671)

### References

Closes #554