### PR TITLE
docs: update `r/vsphere_host` docs

### DIFF
--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 * `force` - (Optional) If set to `true` then it will force the host to be added,
   even if the host is already connected to a different vCenter Server instance.
   Default is `false`.
-* `connected` - (Optional) If set to false then the host will be disconected.
+* `connected` - (Optional) If set to false then the host will be disconnected.
   Default is `false`.
 * `maintenance` - (Optional) Set the management state of the host.
   Default is `false`.

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -22,11 +22,17 @@ data "vsphere_datacenter" "datacenter" {
   name = "dc-01"
 }
 
+data "vsphere_host_thumbprint" "thumbprint" {
+  address = "esx-01.example.com"
+  insecure = true
+}
+
 resource "vsphere_host" "esx-01" {
   hostname = "esx-01.example.com"
   username   = "root"
   password   = "password"
   license    = "00000-00000-00000-00000-00000"
+  thumbprint = data.vsphere_host_thumbprint.thumbprint.id
   datacenter = data.vsphere_datacenter.datacenter.id
 }
 ```
@@ -43,11 +49,17 @@ data "vsphere_compute_cluster" "cluster" {
   datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
+data "vsphere_host_thumbprint" "thumbprint" {
+  address = "esx-01.example.com"
+  insecure = true
+}
+
 resource "vsphere_host" "esx-01" {
   hostname = "esx-01.example.com"
   username = "root"
   password = "password"
   license  = "00000-00000-00000-00000-00000"
+  thumbprint = data.vsphere_host_thumbprint.thumbprint.id
   cluster  = data.vsphere_compute_cluster.cluster.id
 }
 ```
@@ -71,7 +83,8 @@ The following arguments are supported:
   than the`host` resource. Conflicts with: `cluster`.
 * `thumbprint` - (Optional) Host's certificate SHA-1 thumbprint. If not set the
   CA that signed the host's certificate should be trusted. If the CA is not
-  trusted and no thumbprint is set then the operation will fail.
+  trusted and no thumbprint is set then the operation will fail. See data source
+  [`vsphere_host_thumbprint`][docs-host-thumbprint-data-source].
 * `license` - (Optional) The license key that will be applied to the host.
   The license key is expected to be present in vSphere.
 * `force` - (Optional) If set to `true` then it will force the host to be added,
@@ -97,6 +110,8 @@ connections and require vCenter Server.
 
 ~> **NOTE:** Custom attributes are not supported on direct ESXi host
 connections and require vCenter Server.
+
+[docs-host-thumbprint-data-source]: /docs/providers/vsphere/d/host_thumbprint.html
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

This is some documentation updates to the resource `vsphere_host`:

- Add in the Example Usages section using the data source `vsphere_host_thumbprint` to get the Host Thumbprint
- Add a link to the data source `vsphere_host_thumbprint` in the `thumbprint` Argument Reference
- Fix spelling of the word disconnected

I feel adding additional help on getting the thumbprint is important. SSL certs are not often trusted in vSphere, especially at the stage a host is being added to a vCenter. At this point is it not managed by the vSphere Certificate Manager.

Additionally the VMware recommended method of handling certificates is Hybrid mode where the Host certificates are not automatically renewed with a signed certificate.

### Release Node

IMPROVEMENTS:

`resource/vsphere_host`: Documentation updates. (#1675]

### References

[Add ESXi Host to Cluster with Terraform](https://www.vgemba.net/vmware/terraform/terraform-vsphere-host-ssl/)
[New Product Walkthrough – Hybrid vSphere SSL Certificate Replacement](https://blogs.vmware.com/vsphere/2017/01/walkthrough-hybrid-ssl-certificate-replacement.html)
