### PR TITLE
docs: update docs index

### DIFF
--- a/website/docs/d/compute_cluster_host_group.html.markdown
+++ b/website/docs/d/compute_cluster_host_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_host_group"
 sidebar_current: "docs-vsphere-data-source-compute-cluster-host-group"

--- a/website/docs/d/ovf_vm_template.html.markdown
+++ b/website/docs/d/ovf_vm_template.html.markdown
@@ -4,7 +4,7 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_ovf_vm_template"
 sidebar_current: "docs-vsphere-data-source-ovf-vm-template"
 description: |-
-A data source that can be used to extract the configuration of an OVF template.
+  A data source that can be used to extract the configuration of an OVF template.
 ---
 
 # vsphere\_ovf\_vm\_template

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -185,7 +185,7 @@ access to read tags.
 
 The provider will attempt to read event data from vSphere to check for certain
 events, such as, virtual machine customization or power events. Ensure that the
-user account used for Terraform has the privledge to be able to read event data.
+user account used for Terraform has the privilege to be able to read event data.
 
 ### Storage
 
@@ -200,7 +200,7 @@ policies.
 The provider implementation requires the ability to set a default swap
 placement policy on a virtual machine resource. Ensure that the user account
 used for Terraform is provided the Virtual Machine > Change Configuration >
-Change Swapfile Placement (`VirtualMachine.Config.SwapPlacement`) privledge.
+Change Swapfile Placement (`VirtualMachine.Config.SwapPlacement`) privilege.
 
 ## Use of Managed Object References by the Provider
 


### PR DESCRIPTION
### Description

- fix typos on docs index for the term "_privilege_".
- move new data source docs under a subcategory.