### PR TITLE
enhance: Allow `standby_nics` as optional attribute

### DIFF
--- a/vsphere/resource_vsphere_host_virtual_switch.go
+++ b/vsphere/resource_vsphere_host_virtual_switch.go
@@ -29,7 +29,7 @@ func resourceVSphereHostVirtualSwitch() *schema.Resource {
 	// Transform any necessary fields in the schema that need to be updated
 	// specifically for this resource.
 	s["active_nics"].Required = true
-	s["standby_nics"].Required = true
+	s["standby_nics"].Optional = true
 
 	s["teaming_policy"].Default = hostNetworkPolicyNicTeamingPolicyModeLoadbalanceSrcID
 	s["check_beacon"].Default = false

--- a/vsphere/resource_vsphere_host_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_host_virtual_switch_test.go
@@ -294,7 +294,6 @@ resource "vsphere_host_virtual_switch" "switch" {
   network_adapters = ["${var.host_nic0}"]
 
   active_nics  = ["${var.host_nic0}"]
-  standby_nics = []
 }
 `, os.Getenv("TF_VAR_VSPHERE_HOST_NIC0"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -130,7 +130,7 @@ probing (configured with [`check_beacon`](#check_beacon)).
 
 * `active_nics` - (Required) The list of active network adapters used for load
   balancing.
-* `standby_nics` - (Required) The list of standby network adapters used for
+* `standby_nics` - (Optional) The list of standby network adapters used for
   failover.
 * `check_beacon` - (Optional) Enable beacon probing - this requires that the
   [`beacon_interval`](#beacon_interval) option has been set in the bridge


### PR DESCRIPTION
### Description

Allow `standby_nics` on `r/vsphere_host_virtual_switch` to be an optional attribute so the `standby_nics = []` does not need to be defined when no standby NICs are required/available.

### Release Note

`resource/host_virtual_switch`: Allow `standby_nics` on `r/vsphere_host_virtual_switch` to be an optional attribute so the `standby_nics = []` does not need to be defined when no standby NICs are required/available.

### References

Closes: #1690 

### Manual Tests

Current Method:

```hcl
terraform {
  required_providers {
    vsphere = {
      source  = "local/hashicorp/vsphere"
      version = ">= 2.3.0"
    }
  }
  required_version = ">= 1.2.5"
}

provider "vsphere" {
  vsphere_server       = "m01-vc01.rainpole.io"
  user                 = "administrator@vsphere.local"
  password             = "VMware1!"
  allow_unverified_ssl = true
}

data "vsphere_datacenter" "datacenter" {
  name = "dc-01"
}

data "vsphere_host" "host" {
  name          = "n-esxi01.rainpole.io"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

resource "vsphere_host_virtual_switch" "gh-1690" {
  name = "gh-1690"
  host_system_id = data.vsphere_host.host.id
  network_adapters = ["vmnic1","vmnic2","vmnic3"]
  active_nics  =  ["vmnic1"]
  standby_nics = []
}
```

```console
❯ terraform apply -auto-approve
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 1s [id=datacenter-99086]
data.vsphere_host.host: Reading...
data.vsphere_host.host: Read complete after 0s [id=host-100004]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_host_virtual_switch.gh-1690 will be created
  + resource "vsphere_host_virtual_switch" "gh-1690" {
      + active_nics              = [
          + "vmnic2",
        ]
      + allow_forged_transmits   = true
      + allow_mac_changes        = true
      + allow_promiscuous        = false
      + beacon_interval          = 1
      + check_beacon             = false
      + failback                 = true
      + host_system_id           = "host-100004"
      + id                       = (known after apply)
      + link_discovery_operation = "listen"
      + link_discovery_protocol  = "cdp"
      + mtu                      = 1500
      + name                     = "gh-1690"
      + network_adapters         = [
          + "vmnic1",
          + "vmnic2",
          + "vmnic3",
        ]
      + notify_switches          = true
      + number_of_ports          = 128
      + shaping_enabled          = false
      + standby_nics             = []
      + teaming_policy           = "loadbalance_srcid"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
vsphere_host_virtual_switch.gh-1690: Creating...
vsphere_host_virtual_switch.gh-1690: Creation complete after 0s [id=tf-HostVirtualSwitch:host-100004:gh-1690]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Results as expected.

New methods w/ `standby_nic` optional.

```hcl
terraform {
  required_providers {
    vsphere = {
      source  = "local/hashicorp/vsphere"
      version = ">= 2.3.0"
    }
  }
  required_version = ">= 1.2.5"
}

provider "vsphere" {
  vsphere_server       = "m01-vc01.rainpole.io"
  user                 = "administrator@vsphere.local"
  password             = "VMware1!"
  allow_unverified_ssl = true
}

data "vsphere_datacenter" "datacenter" {
  name = "dc-01"
}

data "vsphere_host" "host" {
  name          = "n-esxi01.rainpole.io"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}

resource "vsphere_host_virtual_switch" "gh-1690" {
  name = "gh-1690"
  host_system_id = data.vsphere_host.host.id
  network_adapters = ["vmnic1","vmnic2","vmnic3"]
  active_nics  =  ["vmnic1"]
}
```

```console
❯ terraform apply -auto-approve
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 1s [id=datacenter-99086]
data.vsphere_host.host: Reading...
data.vsphere_host.host: Read complete after 0s [id=host-100004]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_host_virtual_switch.gh-1690 will be created
  + resource "vsphere_host_virtual_switch" "gh-1690" {
      + active_nics              = [
          + "vmnic1",
        ]
      + allow_forged_transmits   = true
      + allow_mac_changes        = true
      + allow_promiscuous        = false
      + beacon_interval          = 1
      + check_beacon             = false
      + failback                 = true
      + host_system_id           = "host-100004"
      + id                       = (known after apply)
      + link_discovery_operation = "listen"
      + link_discovery_protocol  = "cdp"
      + mtu                      = 1500
      + name                     = "gh-1690"
      + network_adapters         = [
          + "vmnic1",
          + "vmnic2",
          + "vmnic3",
        ]
      + notify_switches          = true
      + number_of_ports          = 128
      + shaping_enabled          = false
      + teaming_policy           = "loadbalance_srcid"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
vsphere_host_virtual_switch.gh-1690: Creating...
vsphere_host_virtual_switch.gh-1690: Creation complete after 1s [id=tf-HostVirtualSwitch:host-100004:gh-1690]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Results as expected.

**Ryan Johnson**
Senior Staff Solutions Architect | Product Engineering @ VMware, Inc.