### PR TITLE
chore: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: "/"
+  ignore:
+  - dependency-name: "golang.org/x/tools"
+  - dependency-name: "google.golang.org/grpc"
   schedule:
     interval: daily
   open-pull-requests-limit: 5


### PR DESCRIPTION
### Description

Enables dependabot for the following `package-ecosystem`:
- `gomod`: Update Go dependencies.
- `github-actions`: Update GitHub Actions dependencies.

Upon merge into `main`, dependabot will begin to generate pull requests for updates to these `package-ecosystem` items.

> **Note**
>
> The following are ignored for `gomod` similar to the [`terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws/blob/main/.github/dependabot.yml) configuration for indirect.
> - `golang.org/x/tools`
> - `google.golang.org/grpc`


Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

**Ryan Johnson**
Senior Staff Solutions Architect | Product Engineering @ VMware, Inc.
