### PR TITLE
feat: Add support for vSAN performance service configuration

### DIFF
--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -465,10 +465,14 @@ details, see the referenced link in the above paragraph.
 * `vsan_dedup_enabled` - (Optional) Enables vSAN deduplication on the cluster.
   Cannot be independently set to true. When vSAN deduplication is enabled, vSAN
   compression is automatically enabled.
-* `vsan_compression_enabled` - (Optional) Enables vSAN compression on the cluster.
-* `vsan_performance_enabled` - (Optional) Enables vSAN performance service on the cluster. When vSAN is enabled, performance service will be enabled by default if it is not explicitly configured.
-* `vsan_verbose_mode_enabled` - (Optional) Enables verbose mode for vSAN performance service on the cluster.
-* `vsan_network_diagnostic_mode_enabled` - (Optional) Enables network diagnostic mode for vSAN performance service on the cluster.
+* `vsan_compression_enabled` - (Optional) Enables vSAN compression on the
+  cluster.
+* `vsan_performance_enabled` - (Optional) Enables vSAN performance service on
+  the cluster. Default: `true`.
+* `vsan_verbose_mode_enabled` - (Optional) Enables verbose mode for vSAN
+  performance service on the cluster.
+* `vsan_network_diagnostic_mode_enabled` - (Optional) Enables network
+  diagnostic mode for vSAN performance service on the cluster.
 * `vsan_disk_group` - (Optional) Represents the configuration of a host disk
   group in the cluster.
   * `cache` - The canonical name of the disk to use for vSAN cache.

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -466,6 +466,9 @@ details, see the referenced link in the above paragraph.
   Cannot be independently set to true. When vSAN deduplication is enabled, vSAN
   compression is automatically enabled.
 * `vsan_compression_enabled` - (Optional) Enables vSAN compression on the cluster.
+* `vsan_performance_enabled` - (Optional) Enables vSAN performance service on the cluster. When vSAN is enabled, performance service will be enabled by default if it is not explicitly configured.
+* `vsan_verbose_mode_enabled` - (Optional) Enables verbose mode for vSAN performance service on the cluster.
+* `vsan_network_diagnostic_mode_enabled` - (Optional) Enables network diagnostic mode for vSAN performance service on the cluster.
 * `vsan_disk_group` - (Optional) Represents the configuration of a host disk
   group in the cluster.
   * `cache` - The canonical name of the disk to use for vSAN cache.
@@ -488,6 +491,9 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   vsan_enabled = true
   vsan_dedup_enabled = true
   vsan_compression_enabled = true
+  vsan_performance_enabled = true
+  vsan_verbose_mode_enabled = true
+  vsan_network_diagnostic_mode_enabled = true
   vsan_disk_group {
     cache = data.vsphere_vmfs_disks.cache_disks[0]
     storage = data.vsphere_vmfs_disks.storage_disks


### PR DESCRIPTION
### Description

This change enables the configuration for the vSAN performance service via the .tf file. The three parameters supported are to enable/disable vSAN performance service, the support for verbose mode, and network diagnostics mode. In this change, we will also support the enablement for vSAN performance by default with vSAN performance which aligns with the behavior of the vSAN enablement UI.

The related documentation and API command line are also updated in this change.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make testacc TESTARGS='-run=TestAccResourceVSphereComputeCluster_vsanPerfEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVSphereComputeCluster_vsanPerfEnabled -timeout 240m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
=== RUN   TestAccResourceVSphereComputeCluster_vsanPerfEnabled
--- PASS: TestAccResourceVSphereComputeCluster_vsanPerfEnabled (96.96s)
PASS
...
```
Also, we ran manual tests for the code change and it has passed --

```
$terraform apply
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 0s [id=datacenter-3]
data.vsphere_host.hosts[2]: Reading...
data.vsphere_host.hosts[0]: Reading...
data.vsphere_host.hosts[1]: Reading...
data.vsphere_host.hosts[0]: Read complete after 0s [id=host-17]
data.vsphere_host.hosts[1]: Read complete after 0s [id=host-11]
data.vsphere_host.hosts[2]: Read complete after 0s [id=host-14]
vsphere_compute_cluster.cluster: Refreshing state... [id=domain-c19]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # vsphere_compute_cluster.cluster will be updated in-place
  ~ resource "vsphere_compute_cluster" "cluster" {
        id                                                    = "domain-c19"
        name                                                  = "test"
        tags                                                  = []
      ~ vsan_enabled                                          = false -> true
      + vsan_network_diagnostic_mode_enabled                  = true
      ~ vsan_performance_enabled                              = false -> true
      ~ vsan_verbose_mode_enabled                             = false -> true
        # (48 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

vsphere_compute_cluster.cluster: Modifying... [id=domain-c19]
vsphere_compute_cluster.cluster: Still modifying... [id=domain-c19, 10s elapsed]
vsphere_compute_cluster.cluster: Still modifying... [id=domain-c19, 20s elapsed]
vsphere_compute_cluster.cluster: Still modifying... [id=domain-c19, 30s elapsed]
vsphere_compute_cluster.cluster: Modifications complete after 32s [id=domain-c19]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->


```release-note
`resource/compute_cluster`: Add support for configuring vSAN performance service.
```
### References

Closes: https://github.com/hashicorp/terraform-provider-vsphere/issues/1727.