### PR TITLE
fix: address `io/ioutil` depreciation

### DIFF
--- a/vsphere/config_test.go
+++ b/vsphere/config_test.go
@@ -116,11 +116,11 @@ func testAccClientCheckStatNoExist(t *testing.T, p string) {
 func TestAccClient_persistence(t *testing.T) {
 	testAccClientPreCheck(t)
 
-	vimSessionDir, err := os.CreateTemp("", "tf-vsphere-test-vimsessiondir")
+	vimSessionDir, err := os.MkdirTemp("", "tf-vsphere-test-vimsessiondir")
 	if err != nil {
 		t.Fatalf("error creating VIM session temp directory: %s", err)
 	}
-	restSessionDir, err := os.CreateTemp("", "tf-vsphere-test-restsessiondir")
+	restSessionDir, err := os.MkdirTemp("", "tf-vsphere-test-restsessiondir")
 	if err != nil {
 		t.Fatalf("error creating REST session temp directory: %s", err)
 	}
@@ -152,11 +152,11 @@ func TestAccClient_persistence(t *testing.T) {
 func TestAccClient_noPersistence(t *testing.T) {
 	testAccClientPreCheck(t)
 
-	vimSessionDir, err := os.CreateTemp("", "tf-vsphere-test-vimsessiondir")
+	vimSessionDir, err := os.MkdirTemp("", "tf-vsphere-test-vimsessiondir")
 	if err != nil {
 		t.Fatalf("error creating VIM session temp directory: %s", err)
 	}
-	restSessionDir, err := os.CreateTemp("", "tf-vsphere-test-restsessiondir")
+	restSessionDir, err := os.MkdirTemp("", "tf-vsphere-test-restsessiondir")
 	if err != nil {
 		t.Fatalf("error creating REST session temp directory: %s", err)
 	}

--- a/vsphere/config_test.go
+++ b/vsphere/config_test.go
@@ -1,7 +1,6 @@
 package vsphere
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -94,7 +93,7 @@ func testAccClientGenerateData(t *testing.T, c *Config) string {
 		t.Fatalf("error computing VIM session file: %s", err)
 	}
 
-	vimData, err := ioutil.ReadFile(vimSessionFile)
+	vimData, err := os.ReadFile(vimSessionFile)
 	if err != nil {
 		t.Fatalf("error reading VIM session file: %s", err)
 	}
@@ -117,11 +116,11 @@ func testAccClientCheckStatNoExist(t *testing.T, p string) {
 func TestAccClient_persistence(t *testing.T) {
 	testAccClientPreCheck(t)
 
-	vimSessionDir, err := ioutil.TempDir("", "tf-vsphere-test-vimsessiondir")
+	vimSessionDir, err := os.CreateTemp("", "tf-vsphere-test-vimsessiondir")
 	if err != nil {
 		t.Fatalf("error creating VIM session temp directory: %s", err)
 	}
-	restSessionDir, err := ioutil.TempDir("", "tf-vsphere-test-restsessiondir")
+	restSessionDir, err := os.CreateTemp("", "tf-vsphere-test-restsessiondir")
 	if err != nil {
 		t.Fatalf("error creating REST session temp directory: %s", err)
 	}
@@ -153,11 +152,11 @@ func TestAccClient_persistence(t *testing.T) {
 func TestAccClient_noPersistence(t *testing.T) {
 	testAccClientPreCheck(t)
 
-	vimSessionDir, err := ioutil.TempDir("", "tf-vsphere-test-vimsessiondir")
+	vimSessionDir, err := os.CreateTemp("", "tf-vsphere-test-vimsessiondir")
 	if err != nil {
 		t.Fatalf("error creating VIM session temp directory: %s", err)
 	}
-	restSessionDir, err := ioutil.TempDir("", "tf-vsphere-test-restsessiondir")
+	restSessionDir, err := os.CreateTemp("", "tf-vsphere-test-restsessiondir")
 	if err != nil {
 		t.Fatalf("error creating REST session temp directory: %s", err)
 	}

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -265,7 +264,7 @@ func GetOvfDescriptor(filePath string, deployOva bool, fromLocal bool, allowUnve
 	ovfDescriptor := ""
 	if !deployOva {
 		if fromLocal {
-			fileBuffer, err := ioutil.ReadFile(filePath)
+			fileBuffer, err := os.ReadFile(filePath)
 			if err != nil {
 				return "", err
 			}
@@ -281,7 +280,7 @@ func GetOvfDescriptor(filePath string, deployOva bool, fromLocal bool, allowUnve
 			}(resp.Body)
 
 			if resp.StatusCode == http.StatusOK {
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return "", err
 				}
@@ -335,7 +334,7 @@ func getOvfDescriptorFromOva(ovaFile io.Reader) (string, error) {
 			return "", err
 		}
 		if strings.HasSuffix(fileHdr.Name, ".ovf") {
-			content, _ := ioutil.ReadAll(ovaReader)
+			content, _ := io.ReadAll(ovaReader)
 			ovfDescriptor := string(content)
 			return ovfDescriptor, nil
 		}

--- a/vsphere/resource_vsphere_file_test.go
+++ b/vsphere/resource_vsphere_file_test.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -22,7 +21,7 @@ parentCID=ffffffff
 createType="twoGbMaxExtentSparse"
 `)
 	testVmdkFile := "/tmp/tf_test.vmdk"
-	err := ioutil.WriteFile(testVmdkFile, testVmdkFileData, 0600)
+	err := os.WriteFile(testVmdkFile, testVmdkFileData, 0600)
 	if err != nil {
 		t.Errorf("error %s", err)
 		return
@@ -77,7 +76,7 @@ func TestAccResourceVSphereFile_basicUploadAndCopy(t *testing.T) {
 	sourceFileCopy := "${vsphere_file." + uploadResourceName + ".destination_file}"
 	destinationFileCopy := "tf_file_test_copy.vmdk"
 
-	err := ioutil.WriteFile(sourceFile, testVmdkFileData, 0600)
+	err := os.WriteFile(sourceFile, testVmdkFileData, 0600)
 	if err != nil {
 		t.Errorf("error %s", err)
 		return
@@ -124,7 +123,7 @@ func TestAccResourceVSphereFile_basicUploadAndCopy(t *testing.T) {
 func TestAccResourceVSphereFile_renamePostCreation(t *testing.T) {
 	testVmdkFileData := []byte("# Disk DescriptorFile\n")
 	testVmdkFile := "/tmp/tf_test.vmdk"
-	err := ioutil.WriteFile(testVmdkFile, testVmdkFileData, 0600)
+	err := os.WriteFile(testVmdkFile, testVmdkFileData, 0600)
 	if err != nil {
 		t.Errorf("error %s", err)
 		return
@@ -197,7 +196,7 @@ func TestAccResourceVSphereFile_uploadAndCopyAndUpdate(t *testing.T) {
 	destinationFileCopy := "tf_file_test_copy.vmdk"
 	destinationFileMoved := "tf_test_file_moved.vmdk"
 
-	err := ioutil.WriteFile(sourceFile, testVmdkFileData, 0600)
+	err := os.WriteFile(sourceFile, testVmdkFileData, 0600)
 	if err != nil {
 		t.Errorf("error %s", err)
 		return


### PR DESCRIPTION
### Description

`io/ioutil` is deprecated as of Go v1.16. This provider uses v1.18.

This pull request:

- Converts from `io/ioutil` to the use of the `io` package and updates then `ioutil.ReadAll...` to `io.ReadAll...`.

- Converts from `io/ioutil` to the use of the `os` package and updates `ioutil.TempDir...` to `os.MkdirTemp...`.

- Convert  from `io/ioutil` to the use of the `os` package and updates `ioutil.WriteFile..` to `os.WriteFilel...`.

The following messages would be observed by `golangci-lint`:

```console
vsphere/internal/helper/ovfdeploy/ovf_helper.go:10:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
 "io/ioutil"
 ^

vsphere/config_test.go:4:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
 "io/ioutil"
 ^

vsphere/resource_vsphere_file_test.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
 "io/ioutil"
 ^
```

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

- https://github.com/golang/go/issues/40025
- https://github.com/golang/go/issues/44311
