### PR TITLE
fix: address `gofmt` errors observed in `golangci-lint`

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -67,11 +67,11 @@ type Client struct {
 // Read call to determine if tags are supported on this connection, and if they
 // are, read them from the object and save them in the resource:
 //
-//   if tm, _ := meta.(*VSphereClient).TagsManager(); tm != nil {
-//     if err := readTagsForResource(restClient, obj, d); err != nil {
-//       return err
-//     }
-//   }
+//	if tm, _ := meta.(*VSphereClient).TagsManager(); tm != nil {
+//	  if err := readTagsForResource(restClient, obj, d); err != nil {
+//	    return err
+//	  }
+//	}
 func (c *Client) TagsManager() (*tags.Manager, error) {
 	if err := viapi.ValidateVirtualCenter(c.vimClient); err != nil {
 		return nil, err

--- a/vsphere/data_source_vsphere_datacenter.go
+++ b/vsphere/data_source_vsphere_datacenter.go
@@ -12,9 +12,9 @@ func dataSourceVSphereDatacenter() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type: schema.TypeString,
+				Type:        schema.TypeString,
 				Description: "The name of the datacenter. This can be a name or path.	Can be omitted if there is only one datacenter in your inventory.",
-				Optional: true,
+				Optional:    true,
 			},
 		},
 	}

--- a/vsphere/data_source_vsphere_datacenter.go
+++ b/vsphere/data_source_vsphere_datacenter.go
@@ -13,7 +13,7 @@ func dataSourceVSphereDatacenter() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The name of the datacenter. This can be a name or path.	Can be omitted if there is only one datacenter in your inventory.",
+				Description: "The name of the datacenter. This can be a name or path. Can be omitted if there is only one datacenter in your inventory.",
 				Optional:    true,
 			},
 		},

--- a/vsphere/data_source_vsphere_host.go
+++ b/vsphere/data_source_vsphere_host.go
@@ -13,9 +13,9 @@ func dataSourceVSphereHost() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:        schema.TypeString,
+				Type: schema.TypeString,
 				Description: "The name of the host. This can be a name or path.	If not provided, the default host is used.",
-				Optional:    true,
+				Optional: true,
 			},
 			"datacenter_id": {
 				Type:        schema.TypeString,

--- a/vsphere/data_source_vsphere_host.go
+++ b/vsphere/data_source_vsphere_host.go
@@ -13,9 +13,9 @@ func dataSourceVSphereHost() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type: schema.TypeString,
+				Type:        schema.TypeString,
 				Description: "The name of the host. This can be a name or path.	If not provided, the default host is used.",
-				Optional: true,
+				Optional:    true,
 			},
 			"datacenter_id": {
 				Type:        schema.TypeString,

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -847,7 +847,7 @@ func testGetComputeCluster(s *terraform.State, resourceName string, resourceType
 	return clustercomputeresource.FromID(vars.client, vars.resourceID)
 }
 
-//get cluster and vsanclient
+// get cluster and vsanclient
 func testGetVsanClientCluster(s *terraform.State, resourceName string, resourceType string) (*object.ClusterComputeResource, *vsan.Client, error) {
 	vars, err := testClientVariablesForResource(s, fmt.Sprintf("%s.%s", resourceType, resourceName))
 	if err != nil {

--- a/vsphere/internal/helper/customattribute/custom_attributes_helper.go
+++ b/vsphere/internal/helper/customattribute/custom_attributes_helper.go
@@ -22,7 +22,7 @@ import (
 // When adding custom attributes to a resource schema, the easiest way to do
 // that (for now) will be to use the following line:
 //
-//   customattribute.ConfigKey: customattribute.ConfigSchema(),
+//	customattribute.ConfigKey: customattribute.ConfigSchema(),
 //
 // This will ensure that the correct key and schema is used across all
 // resources.

--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -494,13 +494,13 @@ func LogCond(c bool, t, f interface{}) interface{} {
 // attrs is a map[string]interface{} that follows a pattern in the example
 // below:
 //
-//   err := SetBatch(d, map[string]interface{}{
-//  	"foo": obj.Foo,
-//  	"bar": obj.Bar,
-//   })
-//   if err != nil {
-//  	return err
-//   }
+//	 err := SetBatch(d, map[string]interface{}{
+//		"foo": obj.Foo,
+//		"bar": obj.Bar,
+//	 })
+//	 if err != nil {
+//		return err
+//	 }
 //
 // For best results, supplied values should be or have concrete values that map
 // to the correct values for the respective type in helper/schema. This is

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -74,7 +74,7 @@ this issue, please use a tag name unique within your vCenter system.
 // When adding tags to a resource schema, the easiest way to do that (for now)
 // will be to use the following line:
 //
-//   vSphereTagAttributeKey: tagsSchema(),
+//	vSphereTagAttributeKey: tagsSchema(),
 //
 // This will ensure that the correct key and schema is used across all resources.
 const vSphereTagAttributeKey = "tags"


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Addresses the `gofmt` errors observed in `golangci-lint`.

`.golangci.yml`

```yaml
issues:
  max-per-linter: 0
  max-same-issues: 0
linters:
  disable-all: true
  enable:
    - gofmt
run:
  timeout: 10m
  go: 1.18
```

```console
✦ ❯ golangci-lint run
```

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

