### PR TITLE
feat: add support for vSAN unmap

### DIFF
--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -521,6 +521,12 @@ func resourceVSphereComputeCluster() *schema.Resource {
 				Computed:    true,
 				Description: "Whether the vSAN network diagnostic mode is enabled for the cluster.",
 			},
+			"vsan_unmap_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether the vSAN unmap service is enabled for the cluster.",
+			},
 			"vsan_disk_group": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1335,6 +1341,14 @@ func expandVsanPerfConfig(d *schema.ResourceData) (*vsantypes.VsanPerfsvcConfig,
 	return conf, nil
 }
 
+func expandVsanUnmapConfig(d *schema.ResourceData) *vsantypes.VsanUnmapConfig {
+	unmap_enabled := d.Get("vsan_unmap_enabled").(bool)
+
+	conf := &vsantypes.VsanUnmapConfig{}
+	conf.Enable = unmap_enabled
+	return conf
+}
+
 func resourceVSphereComputeClusterApplyVsanConfig(d *schema.ResourceData, meta interface{}, cluster *object.ClusterComputeResource) error {
 	vsan_enabled := d.Get("vsan_enabled").(bool)
 	if !vsan_enabled {
@@ -1349,6 +1363,8 @@ func resourceVSphereComputeClusterApplyVsanConfig(d *schema.ResourceData, meta i
 		return err
 	}
 	conf.PerfsvcConfig = perf_config
+
+	conf.UnmapConfig = expandVsanUnmapConfig(d)
 
 	conf.DataEfficiencyConfig = &vsantypes.VsanDataEfficiencyConfig{}
 	conf.DataEfficiencyConfig.DedupEnabled = dedup_enabled

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -265,7 +265,7 @@ func TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled(t *t
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereComputeClusterCheckExists(true),
 					testAccResourceVSphereComputeClusterCheckVsanEnabled(false),
-					testAccResourceVSphereComputeClusterCheckUnmapEnabled(true),
+					testAccResourceVSphereComputeClusterCheckUnmapEnabled(false),
 				),
 			},
 		},

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -473,6 +473,7 @@ details, see the referenced link in the above paragraph.
   performance service on the cluster.
 * `vsan_network_diagnostic_mode_enabled` - (Optional) Enables network
   diagnostic mode for vSAN performance service on the cluster.
+* `vsan_unmap_enabled` - (Optional) Enables vSAN unmap on the cluster.
 * `vsan_disk_group` - (Optional) Represents the configuration of a host disk
   group in the cluster.
   * `cache` - The canonical name of the disk to use for vSAN cache.
@@ -498,6 +499,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   vsan_performance_enabled = true
   vsan_verbose_mode_enabled = true
   vsan_network_diagnostic_mode_enabled = true
+  vsan_unmap_enabled = true
   vsan_disk_group {
     cache = data.vsphere_vmfs_disks.cache_disks[0]
     storage = data.vsphere_vmfs_disks.storage_disks


### PR DESCRIPTION
### Description

This change adds the feature to support the vSAN unmap feature. In this code change, the vsan_unmap_enabled field is introduced, which maps to the vSAN enable state. By enabling the feature, vSAN can recognize the Trim/Unmap command from GuestOS and reclaim the storage space that is mapped to a deleted vSAN object. The introduction for the unmap feature is recorded here: https://core.vmware.com/resource/vsan-space-efficiency-technologies.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled -timeout 240m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
=== RUN   TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled
--- PASS: TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled (246.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	246.483s
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi	0.031s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk	0.023s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice	0.010s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow	[no test files]


$ make testacc TESTARGS="-run=TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled" 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled -timeout 240m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
=== RUN   TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled
--- PASS: TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled (90.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	90.355s
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi	0.033s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk	0.010s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice	0.011s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow	[no test files]
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```release-note
resource/compute_cluster: Add support for vSAN unmap
```
### References

https://github.com/hashicorp/terraform-provider-vsphere/issues/1744
