### PR TITLE
fix: address `gostaticanalysis/nilerr` error in `content_library_helper.go`

### DIFF
--- a/vsphere/internal/helper/contentlibrary/content_library_helper.go
+++ b/vsphere/internal/helper/contentlibrary/content_library_helper.go
@@ -123,7 +123,7 @@ func ItemFromName(c *rest.Client, l *library.Library, name string) (*library.Ite
 	}
 	items, err := clm.FindLibraryItems(ctx, fi)
 	if err != nil {
-		return nil, nil
+		return nil, provider.Error(name, "ItemFromName", err)
 	}
 	if len(items) < 1 {
 		return nil, fmt.Errorf("Unable to find content library item (%s)", name)


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Addresses `gostaticanalysis/nilerr` error in `content_library_helper.go`'s `ItemFromName` function.

`.golangci.yml`

```yaml
issues:
  max-per-linter: 0
  max-same-issues: 0
linters:
  disable-all: true
  enable:
    - nilerr
run:
  timeout: 10m
  go: 1.18
```

```console
✦ ❯ golangci-lint run
```


Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

