### PR TITLE
[#1448] fix: Error parsing string as enum type for sdrs_advanced_option on r/datastore_cluster

### DIFF
--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -867,6 +867,9 @@ func expandStorageDrsOptionSpec(d *schema.ResourceData) []types.StorageDrsOption
 	m := d.Get("sdrs_advanced_options").(map[string]interface{})
 	for k, v := range m {
 		opts = append(opts, types.StorageDrsOptionSpec{
+                        ArrayUpdateSpec: types.ArrayUpdateSpec{
+                                         Operation: types.ArrayUpdateOperationAdd,
+                        },
 			Option: &types.OptionValue{
 				Key:   k,
 				Value: types.AnyType(v),


### PR DESCRIPTION
### Description

fix: Error parsing string as enum type for sdrs_advanced_option on r/datastore_cluster
Triage details and fix validation could be found in issue link.

### References
https://github.com/hashicorp/terraform-provider-vsphere/issues/1448

