### PR TITLE
fix: import of `r/vsphere_virtual_disk` imports the wrong `vmdk_path`

### DIFF
--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -1,8 +1,10 @@
 package vsphere
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"errors"
@@ -484,7 +486,21 @@ func searchForDirectory(client *govmomi.Client, datacenter string, datastore str
 
 func resourceVSphereVirtualDiskImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*Client).vimClient
-	p := d.Id()
+	var data map[string]string
+	if err := json.Unmarshal([]byte(d.Id()), &data); err != nil {
+		return nil, err
+	}
+	createDirectories, ok := data["create_directories"]
+	if ok {
+		createDirectoriesBool, _ := strconv.ParseBool(createDirectories)
+		log.Printf("[INFO] Set create_directories during import: %v", createDirectoriesBool)
+		_ = d.Set("create_directories", createDirectoriesBool)
+	}
+
+	p, ok := data["virtual_disk_path"]
+	if !ok {
+		return nil, errors.New("missing virtual_disk_path in input data")
+	}
 	if !strings.HasPrefix(p, "/") {
 		return nil, errors.New("ID must start with a trailing slash")
 	}
@@ -512,10 +528,12 @@ func resourceVSphereVirtualDiskImport(d *schema.ResourceData, meta interface{}) 
 		return nil, fmt.Errorf("Invalid datastore path '%s'", di.Name)
 	}
 
+	//addrParts[2] is in form: [<datastore>]path/to/vmdk
+	vmdkPath := strings.Split(addrParts[2], "]")[1]
 	_ = d.Set("datacenter", dc.Name())
 	_ = d.Set("datastore", dp.Datastore)
-	_ = d.Set("vmdk_path", dp.Path)
-	d.SetId(dp.Path)
+	_ = d.Set("vmdk_path", vmdkPath)
+	d.SetId(vmdkPath)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -88,10 +88,11 @@ via supplying the full datastore path to the virtual disk. An example is below:
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 ```
-terraform import vsphere_virtual_disk.virtual_disk "/dc-01/[datastore-01] foo/bar.vmdk"
+terraform import vsphere_virtual_disk.virtual_disk \
+  '{"virtual_disk_path": "/dc-01/[datastore-01]foo/bar.vmdk", \ "create_directories": "true"}'
 ```
 
 The above would import the virtual disk located at `foo/bar.vmdk` in the `datastore-01`
-datastore of the `dc-01` datacenter.
+datastore of the `dc-01` datacenter with `create_directories` set as `true`.
 
 ~> **NOTE:** Import is not supported if using the **deprecated** `adapter_type` field.


### PR DESCRIPTION
### Description

Fix: Import of `r/vsphere_virtual_disk` imports the wrong `vmdk_path`.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from local testing:

```console
$rm terraform.tfstate
$terraform import vsphere_virtual_disk.vmdk '{"virtual_disk_path": "/DataCenter/[vsanDatastore]namespace_test/secondary.vmdk", "create_directories": "true"}'
...
vsphere_virtual_disk.vmdk: Importing from ID "{\"virtual_disk_path\": \"/DataCenter/[vsanDatastore]namespace_test/secondary.vmdk\", \"create_directories\": \"true\"}"...
2022-09-26T19:23:44.709-0700 [INFO]  provider.terraform-provider-vsphere: 2022/09/26 19:23:44 [INFO] Set create_directories during import: true: timestamp=2022-09-26T19:23:44.709-0700   <----newly added log info, field is successfully set during import
2022-09-26T19:23:45.164-0700 [INFO]  provider.terraform-provider-vsphere: 2022/09/26 19:23:45 [DEBUG] DatastorePathFromString: success: true, path: "[vsanDatastore] 795e3263-e238-26e7-a8c6-02008e76a48b/secondary.vmdk": timestamp=2022-09-26T19:23:45.164-0700
vsphere_virtual_disk.vmdk: Import prepared!
  Prepared vsphere_virtual_disk for import
vsphere_virtual_disk.vmdk: Refreshing state... [id=namespace_test/secondary.vmdk]
....
Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

$cat terraform.tfstate
{
  "version": 4,
  "terraform_version": "1.2.1",
  "serial": 1,
  "lineage": "54097c80-aeff-a51b-a5d2-7c91fca8daa5",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "vsphere_virtual_disk",
      "name": "vmdk",
      "provider": "provider[\"terraform-example.com/provider/vsphere\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "adapter_type": "lsiLogic",
            "create_directories": true,  <--- set to true after import
            "datacenter": "DataCenter",
            "datastore": "vsanDatastore",
            "id": "namespace_test/secondary.vmdk",  <--- change to readable name, same as former tfstate file
            "size": 500,
            "type": "thin",
            "vmdk_path": "namespace_test/secondary.vmdk". <--- change to readable name, same as former tfstate file
          },
          "sensitive_attributes": [],
          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
        }
      ]
    }
  ]
}
$terraform plan
....
2022-09-26T19:24:07.894-0700 [DEBUG] no planned changes, skipping apply graph check
2022-09-26T19:24:07.894-0700 [INFO]  backend/local: plan operation completed

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```
Local test without `create_directories` field was also done. Import won't be blocked, and the issue is expected to be reproed. 

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```
resource/virtual_disk: Update import usage
```
### References

Closes #1482

