### PR TITLE
feat: add support for distributed switch v8.0.0

### DIFF
--- a/vsphere/distributed_virtual_switch_helper.go
+++ b/vsphere/distributed_virtual_switch_helper.go
@@ -23,6 +23,7 @@ var dvsVersions = []string{
 	"7.0.0",
 	"7.0.2",
 	"7.0.3",
+	"8.0.0",
 }
 
 // dvsFromUUID gets a DVS object from its UUID.

--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -753,7 +753,7 @@ func schemaDVSCreateSpec() map[string]*schema.Schema {
 		"version": {
 			Type:         schema.TypeString,
 			Computed:     true,
-			Description:  "The version of this virtual switch. Allowed versions are 7.0.3, 7.0.0, 6.6.0, 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
+			Description:  "The version of this virtual switch. Allowed versions are 8.0.0, 7.0.3, 7.0.2, 7.0.0, 6.6.0, 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice(dvsVersions, false),
 		},


### PR DESCRIPTION
### Description

Adds support for vSphere distributed switch 8.0.0, default in vSphere 8.0.

<img width="864" alt="image" src="https://user-images.githubusercontent.com/7771363/195101235-0acb463c-868b-42eb-9042-a9c3468a8fa3.png">

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

### Release Note

```markdown
* `resource/distributed_virtual_switch`: Adds support for vSphere distributed switch version `8.0.0` in vSphere 8.0.
```