### PR TITLE
Fix spelling mistake on vsphere documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -84,7 +84,7 @@ resource "vsphere_virtual_machine" "vm" {
 }
 ```
 
-Refere to the provider documenation for information on all of the resources
+Refer to the provider documentation for information on all of the resources
 and data sources supported by this provider. Each includes a detailed
 description of the purpose and how to use it.
 


### PR DESCRIPTION
### Description

Fix spelling in vsphere provider documentation. 

### Acceptance tests

None added


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
