### PR TITLE
feat: Add support for vSAN data-in-transit encryption and HCI mesh

### DIFF
--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -474,6 +474,17 @@ details, see the referenced link in the above paragraph.
 * `vsan_network_diagnostic_mode_enabled` - (Optional) Enables network
   diagnostic mode for vSAN performance service on the cluster.
 * `vsan_unmap_enabled` - (Optional) Enables vSAN unmap on the cluster.
+* `vsan_remote_datastore_ids` - (Optional) The remote vSAN datastore IDs to be
+  mounted to this cluster. Conflicts with `vsan_dit_encryption_enabled` and
+  `vsan_dit_rekey_interval`, i.e., vSAN HCI mesh feature cannot be enabled with
+  data-in-transit encryption feature at the same time.
+* `vsan_dit_encryption_enabled` - (Optional) Enables vSAN data-in-transit
+  encryption on the cluster. Conflicts with `vsan_remote_datastore_ids`, i.e.,
+  vSAN data-in-transit feature cannot be enabled with the HCI mesh feature
+  at the same time.
+* `vsan_dit_rekey_interval` - (Optional) Indicates the rekey interval in
+  minutes for data-in-transit encryption. The valid rekey interval is 30 to
+  10800 (defaults to 1400). Conflicts with `vsan_remote_datastore_ids`.
 * `vsan_disk_group` - (Optional) Represents the configuration of a host disk
   group in the cluster.
   * `cache` - The canonical name of the disk to use for vSAN cache.
@@ -500,6 +511,8 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   vsan_verbose_mode_enabled = true
   vsan_network_diagnostic_mode_enabled = true
   vsan_unmap_enabled = true
+  vsan_dit_encryption_enabled = true
+  vsan_dit_rekey_interval = 1800
   vsan_disk_group {
     cache = data.vsphere_vmfs_disks.cache_disks[0]
     storage = data.vsphere_vmfs_disks.storage_disks


### PR DESCRIPTION
### Description

This change is to add the vSAN DIT (data-in-transit encryption) and HCI mesh support. The configuration parameters include the following parameters.

* vSAN Data-in-Transit Encryption. The following parameters are added to support this scenario.
  * `vsan_dit_encryption_enabled` to indicate the state for the data-in-transit encryption state.
  * `vsan_dit_rekey_interval` to indicate the rekey intervals for the data-in-transit encryption.
* HCI mesh - the remote datastore IDs and the host IDs.
  *  `vsan_remote_datastore_ids` to indicate the remote vSAN datastore IDs to be mounted to this cluster.

With the above two feature support, the users should be able to configure the vSAN data-in-transit encryption and HCI mesh feature at the same level of support as the vSphere UI.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```console
[worker@sc2-10-186-35-197 terraform-provider-vsphere-main]$ make testacc TESTARGS="-run=TestAccResourceVSphereComputeCluster_vsanRemoteDatastoreMount"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVSphereComputeCluster_vsanRemoteDatastoreMount -timeout 240m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
=== RUN   TestAccResourceVSphereComputeCluster_vsanRemoteDatastoreMount
Datastore datastore-17
actual: 1Datastoredatastore-17--- PASS: TestAccResourceVSphereComputeCluster_vsanRemoteDatastoreMount (271.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	271.524s
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi	0.026s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk	0.023s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice	0.009s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow	[no test files]
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```release-note
Add support for vSAN data-in-transit encryption and HCI mesh.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
Closes #1783