### PR TITLE
docs: fix grammatical errors

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,7 +39,7 @@ terraform {
 }
 ```
 
-To specify a particular provider version when installing released providers, see the Terrraform documentation [on provider versioning][terraform-provider-versioning]
+To specify a particular provider version when installing released providers, see the Terraform documentation [on provider versioning][terraform-provider-versioning]
 
 ### Verify Terraform Initialization Using the Terraform Registry
 
@@ -72,7 +72,7 @@ This can be useful in environments that do not allow direct access to the Intern
 
 The following examples use Bash on Linux (x64).
 
-1. On an a Linux operating system with Internet access, download the plugin from GitHub using the shell.
+1. On a Linux operating system with Internet access, download the plugin from GitHub using the shell.
 
     ```console
     RELEASE=x.y.z
@@ -181,7 +181,7 @@ The following examples use PowerShell on Windows (x64).
 
     > **Note**
     >
-    > The directory directory hierarchy that Terraform uses to precisely determine the source of each provider it finds locally.
+    > The directory hierarchy that Terraform uses to precisely determine the source of each provider it finds locally.
     >
     > `$PLUGIN_DIRECTORY/$SOURCEHOSTNAME/$SOURCENAMESPACE/$NAME/$VERSION/$OS_$ARCH/`
 

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -18,7 +18,7 @@ We appreciate direct contributions to the provider codebase. Here's what to expe
 
 3. One of Terraform provider team members will look over your contribution and either approve it or provide comments letting you know if there is anything left to do. We do our best to keep up with the volume of PRs waiting for review, but it will take some time for us to reach your PR based on the tasks we have in our backlog.
 
-4. Once all outstanding comments and checklist items have been addressed, your contribution will be merged! Merged PRs will be included in the next release fof the Terraform providee. The provider team takes care of updating the CHANGELOG as they merge.
+4. Once all outstanding comments and checklist items have been addressed, your contribution will be merged! Merged PRs will be included in the next release of the Terraform provider. The provider team takes care of updating the CHANGELOG as they merge.
 
 5. In some cases, we might decide that a PR should be closed without merging. We'll make sure to provide clear reasoning when this happens.
 

--- a/vsphere/data_source_vsphere_host.go
+++ b/vsphere/data_source_vsphere_host.go
@@ -13,9 +13,9 @@ func dataSourceVSphereHost() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:        schema.TypeString,
+				Type: schema.TypeString,
 				Description: "The name of the host. This can be a name or path.	If not provided, the default host is used.",
-				Optional:    true,
+				Optional: true,
 			},
 			"datacenter_id": {
 				Type:        schema.TypeString,

--- a/vsphere/data_source_vsphere_host.go
+++ b/vsphere/data_source_vsphere_host.go
@@ -13,9 +13,9 @@ func dataSourceVSphereHost() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type: schema.TypeString,
+				Type:        schema.TypeString,
 				Description: "The name of the host. This can be a name or path.	If not provided, the default host is used.",
-				Optional: true,
+				Optional:    true,
 			},
 			"datacenter_id": {
 				Type:        schema.TypeString,

--- a/website/docs/d/folder.html.markdown
+++ b/website/docs/d/folder.html.markdown
@@ -11,8 +11,7 @@ description: |-
 # vsphere\_folder
 
 The `vsphere_folder` data source can be used to get the general attributes of a
-vSphere inventory folder. Paths are absolute and include must include the
-datacenter.  
+vSphere inventory folder. Paths are absolute and must include the datacenter.
 
 ## Example Usage
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Simple fixes on documentation plus a little bit of [reformatting](https://github.com/hashicorp/terraform-provider-vsphere/compare/main...Attacktive:terraform-provider-vsphere:main#diff-8b4bac5499caa6b488a8fa5cc57d0ef5da86e4843cd97fddeca129e2c6e03244R16-R18) which `gofmt` complained about.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceVSphereHost'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceVSphereHost -timeout 240m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
=== RUN   TestAccDataSourceVSphereHost_basic
    data_source_vsphere_host_test.go:63: set TF_VAR_VSPHERE_DATACENTER to run vsphere_host acceptance tests
--- SKIP: TestAccDataSourceVSphereHost_basic (2.35s)
=== RUN   TestAccDataSourceVSphereHost_defaultHost
    data_source_vsphere_host_test.go:63: set TF_VAR_VSPHERE_DATACENTER to run vsphere_host acceptance tests
--- SKIP: TestAccDataSourceVSphereHost_defaultHost (2.06s)
=== RUN   TestAccDataSourceVSphereHostThumbprint_basic
    data_source_vsphere_host_thumbprint_test.go:32: set TF_VAR_VSPHERE_ESXI1 to run vsphere_host_thumbprint acceptance tests
--- SKIP: TestAccDataSourceVSphereHostThumbprint_basic (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere 4.420s
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   0.005s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     0.008s [no tests to run]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  0.004s [no tests to run]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Documentation updates
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
