### PR TITLE
fix: revert sha1 linting update

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -2,7 +2,7 @@ package vsphere
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -322,7 +322,7 @@ func (c *Config) sessionFile() (string, error) {
 	// Key session file off of full URI and insecure setting.
 	// Hash key to get a predictable, canonical format.
 	key := fmt.Sprintf("%s#insecure=%t", u.String(), c.InsecureFlag)
-	name := fmt.Sprintf("%040x", sha256.Sum256([]byte(key)))
+	name := fmt.Sprintf("%040x", sha1.Sum([]byte(key)))
 	return name, nil
 }
 


### PR DESCRIPTION
### Description

Reverts the update in #1416 back to SHA1.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

Reverts a linting update from #1416 back to SHA1. SHA1 is used by `vmware/govmomi` for the session file. This will allow session reuse from `govc`.

### References

Closes #1807
