### PR TITLE
.github/workflows: Use actions/setup-go go-version-file input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,6 @@ permissions:
   contents: write
 
 jobs:
-  go-version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.go-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: go-version
-        run: echo "::set-output name=version::$(cat ./.go-version)"
   release-notes:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +24,7 @@ jobs:
           retention-days: 1
   terraform-provider-release:
     name: 'Terraform Provider Release'
-    needs: [go-version, release-notes]
+    needs: [release-notes]
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'
@@ -46,7 +38,7 @@ jobs:
       hc-releases-host-prod: '${{ secrets.HC_RELEASES_HOST_PROD }}'
     with:
       release-notes: true
-      setup-go-version: '${{ needs.go-version.outputs.version }}'
+      setup-go-version-file: '.go-version'
       # Product Version (e.g. v1.2.3 or github.ref_name)
       product-version: '${{ github.ref_name }}'
         

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -15,15 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Read go-version
-        id: go-version
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./.go-version
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.content }}
+          go-version-file: '.go-version'
       - name: Go mod verify
         run: go mod verify
       - name: Run unit tests


### PR DESCRIPTION
Reference: https://github.com/actions/setup-go/releases/tag/v3.1.0
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v2.2.0
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/blob/7e53d9adb57f05cb16c227ef0bfd030060fae82e/.github/workflows/hashicorp.yml#L26-L29

In hashicorp/ghaction-terraform-provider-release, its passed through via the `setup-go-version-file` input.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
