### PR TITLE
feat: add support for import of `r/vsphere_role`

### DIFF
--- a/vsphere/data_source_vsphere_role_test.go
+++ b/vsphere/data_source_vsphere_role_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+const NoAccessRoleDescription = "No access"
+const NoAccessRoleName = "NoAccess"
+const NoAccessRoleId = "-5"
+
 func TestAccDataSourceVSphereRole_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -47,6 +51,24 @@ func TestAccDataSourceVSphereRole_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceVSphereRole_systemRoleData(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereRoleSystemRoleConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vsphere_role.role1", "name", NoAccessRoleName),
+					resource.TestCheckResourceAttr("data.vsphere_role.role1", "id", NoAccessRoleId),
+					resource.TestCheckResourceAttr("data.vsphere_role.role1", "role_privileges.#", "0")),
+			},
+		},
+	})
+}
+
 func testAccDataSourceVSphereRoleConfig() string {
 	return fmt.Sprintf(`
 resource "vsphere_role" test-role {
@@ -62,5 +84,15 @@ data "vsphere_role" "role1" {
 		Privilege2,
 		Privilege3,
 		Privilege4,
+	)
+}
+
+func testAccDataSourceVSphereRoleSystemRoleConfig() string {
+	return fmt.Sprintf(`
+data "vsphere_role" "role1" {
+  label = "%s"
+}
+`,
+		NoAccessRoleDescription,
 	)
 }

--- a/vsphere/resource_vsphere_role.go
+++ b/vsphere/resource_vsphere_role.go
@@ -43,7 +43,7 @@ func resourceVsphereRole() *schema.Resource {
 		Delete: resourceRoleDelete,
 		Schema: sch,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			State: resourceRoleImport,
 		},
 	}
 }
@@ -67,6 +67,19 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
+	return roleById(d, false, meta)
+}
+
+func resourceRoleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	err := roleById(d, true, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func roleById(d *schema.ResourceData, excludeSystem bool, meta interface{}) error {
 	log.Printf("[DEBUG] Reading vm role with id %s", d.Id())
 	client := meta.(*Client).vimClient
 	authorizationManager := object.NewAuthorizationManager(client.Client)
@@ -81,6 +94,10 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error while reading the role list %s", err)
 	}
 	role := roleList.ById(roleID)
+	if role != nil && excludeSystem && role.System {
+		return fmt.Errorf("error specified role with id %s is a system role. System roles are not supported for this operation", d.Id())
+	}
+
 	if role == nil {
 		log.Printf(" [DEBUG] Role %s doesn't exist", d.Get("name"))
 		d.SetId("")

--- a/vsphere/resource_vsphere_role.go
+++ b/vsphere/resource_vsphere_role.go
@@ -42,6 +42,9 @@ func resourceVsphereRole() *schema.Resource {
 		Update: resourceRoleUpdate,
 		Delete: resourceRoleDelete,
 		Schema: sch,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 

--- a/vsphere/resource_vsphere_role_test.go
+++ b/vsphere/resource_vsphere_role_test.go
@@ -124,7 +124,7 @@ func TestAccResourceVsphereRole_importSystemRoleShouldError(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateId:     NoAccessRoleId,
-				ExpectError:       regexp.MustCompile(fmt.Sprintf("error system role id %s specified. System roles are not supported", NoAccessRoleId)),
+				ExpectError:       regexp.MustCompile(fmt.Sprintf("error specified role with id %s is a system role. System roles are not supported for this operation", NoAccessRoleId)),
 			},
 		},
 	})

--- a/website/docs/r/vsphere_role.html.markdown
+++ b/website/docs/r/vsphere_role.html.markdown
@@ -38,3 +38,15 @@ The following arguments are supported:
 * `name` - (Required) The name of the role.
 * `role_privileges` - (Optional) The privileges to be associated with this role.
 
+## Importing
+
+An existing role can be imported into this resource by supplying the role id. An example is below:
+
+```hcl
+terraform import vsphere_role.role1 -709298051
+```
+~> **NOTE:** System roles can't be imported because they can't be modified or deleted.
+Use [`vsphere_role` data source][ref-vsphere-role-data-source]
+to read information about system roles.
+
+[ref-vsphere-role-data-source]: /docs/providers/vsphere/d/vsphere_role.html


### PR DESCRIPTION
### Description

Adds support for import of `r/vsphere_role`. 

Not: vSphere system roles are blocked from import as these can not be modified or deleted; however, each can be returned in `d/vsphere_role`.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccResourceVsphereRole"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVsphereRole -timeout 240m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
=== RUN   TestAccResourceVsphereRole_createRole
--- PASS: TestAccResourceVsphereRole_createRole (12.47s)
=== RUN   TestAccResourceVsphereRole_addPrivilege
--- PASS: TestAccResourceVsphereRole_addPrivilege (7.54s)
=== RUN   TestAccResourceVsphereRole_removePrivilege
--- PASS: TestAccResourceVsphereRole_removePrivilege (7.55s)
PASS

```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

Enhancement:

Adds support for import of `r/vsphere_role`.  [GH-1822](https://github.com/hashicorp/terraform-provider-vsphere/pull/1822)

### References
Closes [#1735 ](https://github.com/hashicorp/terraform-provider-vsphere/issues/1735)
