### PR TITLE
fix: user and password from environment variables

### DIFF
--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -21,14 +21,14 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"user": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_USER", nil),
 				Description: "The user name for vSphere API operations.",
 			},
 
 			"password": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_PASSWORD", nil),
 				Description: "The user password for vSphere API operations.",
 			},


### PR DESCRIPTION
Currently, documentation mentions that it's possible to use `VSPHERE_USER` and `VSPHERE_PASSWORD` environment variables to provide the credentials to the server.

Unfortunately this doesn't work, as `user` and `password` are marked as required, so environment variable is never looked up.


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Make `user` and `password` optional variables for provider, so these could be filled from environment variables as stated in documentation.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
