### PR TITLE
Add CODEOWNERS file in root of repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @hashicorp/terraform-ecosystem-strategic


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

As part of standardising repos in HashiCorp, this PR adds a CODEOWNERS file.

Guidance is to reference teams instead of individuals, so the file starts with our team but it can be updated in future as needed.

### Acceptance tests

N/A

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
