### PR TITLE
fix: `r/vsphere_file` provider crash

### DIFF
--- a/vsphere/resource_vsphere_file.go
+++ b/vsphere/resource_vsphere_file.go
@@ -133,6 +133,11 @@ func resourceVSphereFileCreate(d *schema.ResourceData, meta interface{}) error {
 
 func createDirectory(datastoreFileManager *object.DatastoreFileManager, f *file) error {
 	directoryPathIndex := strings.LastIndex(f.destinationFile, "/")
+	if directoryPathIndex < 0 {
+		// there are no parent directories in the file's name - nothing to create
+		return nil
+	}
+
 	targetPath := f.destinationFile[0:directoryPathIndex]
 	err := datastoreFileManager.FileManager.MakeDirectory(context.TODO(),
 		datastoreFileManager.Datastore.Path(targetPath), datastoreFileManager.Datacenter, true)


### PR DESCRIPTION
### Description

- Updates `resource_vsphere_file.createDirectory` method to check whether the provided file path has any parent folder(s). If there are no folders to be created we return early without invoking `FileManager.MakeDirectory`. This fixes the “_slice bounds out of range_” runtime error which was crashing the provider.
- Fixes the `resource_vsphere_file_test` acceptance tests as they were failing due to incorrect test vmdk files.
- Adds a new TestAccResourceVSphereFile_uploadWithCreateDirectories test to cover the `r/vsphere_file.create_directories` configuration argument.

Testing done:

Performed terraform apply using the following configuration:

```hcl
resource "vsphere_file" "iso" {
  datacenter       = data.vsphere_datacenter.datacenter.name
  datastore        = data.vsphere_datastore.nfs-tf.name
  source_file      = "${path.cwd}/ISO/test.iso"
  destination_file = "test.iso"
  create_directories = true
}
```

And verified that the file was uploaded correctly without any runtime errors.


### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?

Added `TestAccResourceVSphereFile_uploadWithCreateDirectories`

- [X] Have you run the acceptance tests on this branch?

<details><summary>Output from acceptance testing</summary>
<p>

```console
make testacc TESTARGS="-run='TestAccResourceVSphereFile'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccResourceVSphereFile' -timeout 240m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
=== RUN   TestAccResourceVSphereFile_basic
--- PASS: TestAccResourceVSphereFile_basic (62.99s)
=== RUN   TestAccResourceVSphereFile_uploadWithCreateDirectories
--- PASS: TestAccResourceVSphereFile_uploadWithCreateDirectories (91.53s)
=== RUN   TestAccResourceVSphereFile_basicUploadAndCopy
--- PASS: TestAccResourceVSphereFile_basicUploadAndCopy (73.37s)
=== RUN   TestAccResourceVSphereFile_renamePostCreation
--- PASS: TestAccResourceVSphereFile_renamePostCreation (93.87s)
=== RUN   TestAccResourceVSphereFile_uploadAndCopyAndUpdate
--- PASS: TestAccResourceVSphereFile_uploadAndCopyAndUpdate (109.50s)
PASS
```

</p>
</details> 

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

Bug Fix:

`r/vsphere_file`: Fixes a provider crash by updating the `createDirectory` method to check if the provided file path has any parent folder(s). If no folders need to be created `FileManager.MakeDirectory` is not invoked.

### References

Closes https://github.com/hashicorp/terraform-provider-vsphere/issues/1779
