### PR TITLE
feat: Add `moid` attribute in `vsphere_virtual_machine` data source

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -152,13 +152,15 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 	// include the number of cpus, memory, firmware, disks, etc.
 	structure.MergeSchema(s, schemaVirtualMachineConfigSpec())
 
-	// make name/uuid/moid Optional/AtLeastOneOf since UUID lookup is now supported
+	// make name/uuid/moid Optional/AtLeastOneOf
 	s["name"].Required = false
 	s["name"].Optional = true
 	s["name"].AtLeastOneOf = []string{"name", "uuid", "moid"}
+
 	s["uuid"].Required = false
 	s["uuid"].Optional = true
 	s["uuid"].AtLeastOneOf = []string{"name", "uuid", "moid"}
+
 	s["moid"].Required = false
 	s["moid"].Optional = true
 	s["moid"].AtLeastOneOf = []string{"name", "uuid", "moid"}
@@ -201,6 +203,9 @@ func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("error fetching virtual machine: %s", err)
 	}
+
+	// Set the managed object id.
+	d.Set("moid", vm.Reference().Value)
 
 	props, err := virtualmachine.Properties(vm)
 	if err != nil {

--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -152,13 +152,16 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 	// include the number of cpus, memory, firmware, disks, etc.
 	structure.MergeSchema(s, schemaVirtualMachineConfigSpec())
 
-	// make name/uuid Optional/AtLeastOneOf since UUID lookup is now supported
+	// make name/uuid/moid Optional/AtLeastOneOf since UUID lookup is now supported
 	s["name"].Required = false
 	s["name"].Optional = true
-	s["name"].AtLeastOneOf = []string{"name", "uuid"}
+	s["name"].AtLeastOneOf = []string{"name", "uuid", "moid"}
 	s["uuid"].Required = false
 	s["uuid"].Optional = true
-	s["uuid"].AtLeastOneOf = []string{"name", "uuid"}
+	s["uuid"].AtLeastOneOf = []string{"name", "uuid", "moid"}
+	s["moid"].Required = false
+	s["moid"].Optional = true
+	s["moid"].AtLeastOneOf = []string{"name", "uuid", "moid"}
 
 	// Now that the schema has been composed and merged, we can attach our reader and
 	// return the resource back to our host process.
@@ -171,6 +174,7 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client).vimClient
 	uuid := d.Get("uuid").(string)
+	moid := d.Get("moid").(string)
 	name := d.Get("name").(string)
 	var vm *object.VirtualMachine
 	var err error
@@ -178,6 +182,9 @@ func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{
 	if uuid != "" {
 		log.Printf("[DEBUG] Looking for VM or template by UUID %q", uuid)
 		vm, err = virtualmachine.FromUUID(client, uuid)
+	} else if moid != "" {
+		log.Printf("[DEBUG] Looking for VM or template by MOID %q", moid)
+		vm, err = virtualmachine.FromMOID(client, moid)
 	} else {
 		log.Printf("[DEBUG] Looking for VM or template by name/path %q", name)
 		var dc *object.Datacenter

--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -150,6 +150,52 @@ func TestAccDataSourceVSphereVirtualMachine_uuid(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceVSphereVirtualMachine_moid(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+			testAccDataSourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereVirtualMachineConfigMOID(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_virtual_machine.moid",
+						"id",
+						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "memory"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "num_cpus"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "num_cores_per_socket"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "hardware_version"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.unit_number"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.label"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interface_types.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.adapter_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_limit"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_reservation"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_share_level"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_share_count"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.mac_address"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.network_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "moid"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceVSphereVirtualMachinePreCheck(t *testing.T) {
 	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
 		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_virtual_machine data source acceptance tests")
@@ -174,6 +220,28 @@ data "vsphere_virtual_machine" "template" {
 
 data "vsphere_virtual_machine" "uuid" {
   uuid = data.vsphere_virtual_machine.template.uuid
+}
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
+	)
+}
+
+func testAccDataSourceVSphereVirtualMachineConfigMOID() string {
+	return fmt.Sprintf(`
+%s
+
+variable "template" {
+  default = "%s"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = var.template
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+
+data "vsphere_virtual_machine" "moid" {
+  moid = data.vsphere_virtual_machine.template.moid
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -276,11 +276,6 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Computed:    true,
 			Description: "A flag internal to Terraform that indicates that this resource was either imported or came from a earlier major version of this resource. Reset after the first post-import or post-upgrade apply.",
 		},
-		"moid": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The machine object ID from VMware vSphere.",
-		},
 		"power_state": {
 			Type:        schema.TypeString,
 			Computed:    true,

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -338,6 +338,11 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "The UUID of the virtual machine. Also exposed as the ID of the resource.",
 		},
+		"moid": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The machine object ID from VMware vSphere.",
+		},
 		"storage_policy_id": {
 			Type:        schema.TypeString,
 			Optional:    true,


### PR DESCRIPTION
### Description

`data/vsphere_virtual_machine` Add `moid` attribute to support result from `data/vsphere_dynamic`

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- `data/vsphere_virtual_machine` Add `moid` attribute to support result from `data/vsphere_dynamic`
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Closes #1867 
