### PR TITLE
chore: Begin overhauling provider acceptance test setup

### DIFF
--- a/acctests/README.md
+++ b/acctests/README.md
@@ -1,5 +1,5 @@
 # Acceptance Tests
-Here is the current process for deploying infrastructure that can be used for running acceptance tests. Currently only supported on Equinix Metal, the metal provider is currently set for EOL in July 2023, a new official process for running tests will need to be developed.
+Acceptance testing is undergoing technical debt and streamlining. The current process recommends hosting on Equinix Metal, but the foundation of testing will hopefully evolve around nested ESXi VMs, ideally could be used to scale and parallelize tests.
 
 ## Download
 1. Log in to VMware Customer Connect.
@@ -37,31 +37,49 @@ export TF_VAR_VCSA_DEPLOY_PATH="{extract_location}/vcsa-cli-installer/mac/vcsa-d
 ```
 
 ## Provision Equinix Infrastructure
-Terraform needs to be run in two stages. First, to provision the Equinix infrastructure and second to create the shared resources upon which most acceptance tests rely.
+Terraform needs to be run in two stages. First, to provision the Equinix infrastructure and second to create the shared vSphere resources upon which most acceptance tests rely.
 
 ```
 $ cd acctests/equinix
 $ terraform init
 $ terraform apply
 ```
-This process will take a significant amount of time, as a lot of data is being uploaded to servers. The process likely completed successfully but errored with something like
-```
-Error 422: still bonded 
-```
-You should be able to just reapply
-```
-$ terraform apply
-```
+This process will take a significant amount of time, as a lot of data is being uploaded to servers.
 
-## Run Terraform Phase 2
+## Provision vSphere
 A file with several environment variables called `devrc` must be created within `acctests/equinix` path. You must source that file and then switch to the `acctests/vsphere` path.
+
 ```
 $ source devrc
 $ cd ../vsphere
 $ terraform init
 $ terraform apply
 ```
-Now all the infrastructure should be created, if you planned on running the cluster tests with vSAN, make sure to enable vSAN on the VMkernal adapters on the management network for ESXI hosts 3 and 4. This can be done through the vSphere client or PowerCLI.  An additional `devrc` file should have been created in the `acctests/vsphere` path. Source this file and you should have all the necessary environment variables for running tests.
+This will create a few resources expected in testing, as well as set a few default values for testing hardcoded in devrc.tpl. The set of variables were exported to another devrc, source that now.
 ```
 $ source devrc
 ```
+
+This set of environment variables and setup should allow you to run most of the acceptance tests, current failing ones or ones skipped due to missing or misconfigured environment variables will be addressed ASAP (unfortunately there had been a large amount of technical debt built up around testing).
+
+### Please Note
+As for writing a few manual steps had to be taken to privately network the nested ESXis and add them to vSphere.
+
+1. Delete vmk1 and manually recreate it attached to the new vSwitch (which runs on vmnic1)
+2. Visit the physical ESXi web UI (likely the vCenter IP - 1) and power off the vcsa VM
+3. Attach vmnet to the vcsa VM
+4. Power on the vcsa VM
+5. Visit the vCenter IP again, but this time port :5480
+6. In the networking tab give it a valid IP on the private subnet the ESXi VMs run on
+7. In vCenter manually create a snapshot of the template VM (this should be easy to capture in config going forward)
+
+## Running tests
+Tests can be ran via regexp pattern, generally advisable to run them individually or by resource type. It's common practice to have resource tests contain an underscore in their name to make the whole suite of tests for the resource run.
+
+```
+$ make testacc TESTARGS="-run=TestAccResourceVSphereVirtualMachine_ -count=1"
+```
+
+`count=1` is just a Golang trick to bust the testcache.
+
+Some tests may leave a few resources behind causing a subsequent test in the suite to complain about a name already existing, generally you can just manually delete it from the vSphere UI to get the next test to run.

--- a/acctests/equinix/devrc.tpl
+++ b/acctests/equinix/devrc.tpl
@@ -1,20 +1,10 @@
-export TF_VAR_VSPHERE_REST_SESSION_PATH=$HOME/.govmomi/rest_sessions
-export TF_VAR_VSPHERE_VIM_SESSION_PATH=$HOME/.govmomi/sessions
-
 export TF_VAR_VSPHERE_NAS_HOST=${nas_host}
 export TF_VAR_VSPHERE_ESXI1=${esxi_host_1}
 export TF_VAR_VSPHERE_ESXI1_PW='${esxi_host_1_pw}'
-export TF_VAR_VSPHERE_ESXI2=${esxi_host_2}
-export TF_VAR_VSPHERE_ESXI2_PW='${esxi_host_2_pw}'
-export TF_VAR_VSPHERE_ESXI3=${esxi_host_3}
-export TF_VAR_VSPHERE_ESXI3_PW='${esxi_host_3_pw}'
-export TF_VAR_VSPHERE_ESXI4=${esxi_host_4}
-export TF_VAR_VSPHERE_ESXI4_PW='${esxi_host_4_pw}'
 export VSPHERE_SERVER=${vsphere_host}
+export TF_VAR_VSPHERE_PRIVATE_NETWORK='${private_network}'
 
-export TF_VAR_VSPHERE_VMFS_REGEXP='naa.'
-
-export VSPHERE_USER="administrator@vcenter.vspheretest.internal"
+export VSPHERE_USER="administrator@vcenter.test.local"
 export VSPHERE_PASSWORD="Password123!"
 export VSPHERE_ALLOW_UNVERIFIED_SSL=true
 
@@ -22,38 +12,3 @@ export TF_VAR_VSPHERE_SERVER=$VSPHERE_SERVER
 export TF_VAR_VSPHERE_USER=$VSPHERE_USER
 export TF_VAR_VSPHERE_PASSWORD=$VSPHERE_PASSWORD
 export TF_VAR_VSPHERE_ALLOW_UNVERIFIED_SSL=$VSPHERE_ALLOW_UNVERIFIED_SSL
-export TF_VAR_VSPHERE_ESXI_TRUNK_NIC=vmnic1
-export TF_VAR_VSPHERE_DATACENTER=hashidc
-export TF_VAR_VSPHERE_CLUSTER=c1
-export TF_VAR_VSPHERE_NFS_DS_NAME=nfs
-export TF_VAR_VSPHERE_NFS_DS_NAME1=nfs-vol1
-export TF_VAR_VSPHERE_NFS_DS_NAME2=nfs-vol2
-export TF_VAR_VSPHERE_DVS_NAME=terraform-test-dvs
-export TF_VAR_VSPHERE_PG_NAME='vmnet'
-export TF_VAR_VSPHERE_RESOURCE_POOL=hashi-resource-pool
-export TF_VAR_VSPHERE_NFS_PATH=/nfs
-export TF_VAR_VSPHERE_NFS_PATH1=/nfs/ds1
-export TF_VAR_VSPHERE_NFS_PATH2=/nfs/ds2
-export TF_VAR_VSPHERE_ISO_DATASTORE=nfs
-export TF_VAR_VSPHERE_ISO_FILE=fake.iso
-export TF_VAR_VSPHERE_TEMPLATE=tfvsphere_template
-export TF_VAR_VSPHERE_INIT_TYPE=thin
-export TF_VAR_VSPHERE_ADAPTER_TYPE=lsiLogic
-export TF_VAR_VSPHERE_DC_FOLDER=dc-folder
-export TF_VAR_VSPHERE_DS_FOLDER=ds
-export TF_VAR_VSPHERE_PERSIST_SESSION=true
-export TF_VAR_VSPHERE_CLONED_VM_DISK_SIZE=20
-export TF_VAR_VSPHERE_TEST_OVA="https://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ova"
-export TF_VAR_VSPHERE_TEST_OVF="https://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ovf"
-export TF_VAR_VSPHERE_CONTENT_LIBRARY_FILES="https://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ovf"
-
-export TF_VAR_VSPHERE_HOST_NIC0=vmnic0
-export TF_VAR_VSPHERE_HOST_NIC1=vmnic1
-
-
-export TF_VAR_VSPHERE_VSWITCH_UPPER_VERSION="7.0.0"
-export TF_VAR_VSPHERE_VSWITCH_LOWER_VERSION="6.5.0"
-export TF_VAR_VSPHERE_DS_VMFS_NAME='ds-001'
-export TF_VAR_VSPHERE_VM_V1_PATH='pxe-server'
-export TF_VAR_VSPHERE_FOLDER_V0_PATH='Discovered virtual machine'
-export TF_VAR_VSPHERE_ENTITY_PERMISSION_USER_GROUP="root"

--- a/acctests/equinix/main.tf
+++ b/acctests/equinix/main.tf
@@ -31,12 +31,12 @@ variable "LAB_PREFIX" {
   default = ""
 }
 
-provider "metal" {
+provider "equinix" {
   auth_token = var.PACKET_AUTH
 }
 
-resource "metal_device" "esxi1" {
-  hostname         = "${var.LAB_PREFIX}esxi1.vspheretest.internal"
+resource "equinix_metal_device" "esxi1" {
+  hostname         = "${var.LAB_PREFIX}e.test.local"
   plan             = var.ESXI_PLAN
   metro            = var.PACKET_FACILITY
   operating_system = var.ESXI_VERSION
@@ -44,55 +44,32 @@ resource "metal_device" "esxi1" {
   project_id       = var.PACKET_PROJECT
 }
 
-resource "metal_device_network_type" "esxi1" {
-  device_id = metal_device.esxi1.id
+resource "equinix_metal_device_network_type" "esxi1" {
+  device_id = equinix_metal_device.esxi1.id
   type      = "hybrid"
 }
 
-resource "metal_device" "esxi2" {
-  hostname         = "${var.LAB_PREFIX}esxi2.vspheretest.internal"
-  plan             = var.ESXI_PLAN
-  metro            = var.PACKET_FACILITY
-  operating_system = var.ESXI_VERSION
-  billing_cycle    = "hourly"
-  project_id       = var.PACKET_PROJECT
+resource "equinix_metal_vlan" "vmvlan" {
+  metro      = var.PACKET_FACILITY
+  project_id = var.PACKET_PROJECT
 }
 
-resource "metal_device_network_type" "esxi2" {
-  device_id = metal_device.esxi2.id
-  type      = "hybrid"
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [equinix_metal_device_network_type.esxi1]
+
+  create_duration = "120s"
 }
 
-resource "metal_device" "esxi3" {
-  hostname         = "${var.LAB_PREFIX}esxi3.vspheretest.internal"
-  plan             = var.ESXI_PLAN
-  metro            = var.PACKET_FACILITY
-  operating_system = var.ESXI_VERSION
-  billing_cycle    = "hourly"
-  project_id       = var.PACKET_PROJECT
+resource "equinix_metal_port_vlan_attachment" "esxi1" {
+  depends_on = [time_sleep.wait_120_seconds]
+
+  device_id = equinix_metal_device.esxi1.id
+  port_name = "eth1"
+  vlan_vnid = equinix_metal_vlan.vmvlan.vxlan
 }
 
-resource "metal_device_network_type" "esxi3" {
-  device_id = metal_device.esxi3.id
-  type      = "hybrid"
-}
-
-resource "metal_device" "esxi4" {
-  hostname         = "${var.LAB_PREFIX}esxi4.vspheretest.internal"
-  plan             = var.ESXI_PLAN
-  metro            = var.PACKET_FACILITY
-  operating_system = var.ESXI_VERSION
-  billing_cycle    = "hourly"
-  project_id       = var.PACKET_PROJECT
-}
-
-resource "metal_device_network_type" "esxi4" {
-  device_id = metal_device.esxi4.id
-  type      = "hybrid"
-}
-
-resource "metal_device" "storage1" {
-  hostname         = "${var.LAB_PREFIX}storage1.vspheretest.internal"
+resource "equinix_metal_device" "storage1" {
+  hostname         = "${var.LAB_PREFIX}storage1.test.local"
   plan             = var.STORAGE_PLAN
   metro            = var.PACKET_FACILITY
   operating_system = "ubuntu_20_04"
@@ -100,7 +77,7 @@ resource "metal_device" "storage1" {
   project_id       = var.PACKET_PROJECT
   provisioner "remote-exec" {
     inline = [
-      "mkdir -p /nfs/ds1 /nfs/ds2 /nfs/ds2 /nfs/ds3",
+      "mkdir -p /nfs/ds1 /nfs/ds2 /nfs/ds3",
       "apt-get update",
       "apt-get install nfs-common nfs-kernel-server -y",
       "echo \"/nfs *(rw,no_root_squash)\" > /etc/exports",
@@ -110,73 +87,35 @@ resource "metal_device" "storage1" {
       "exportfs -a",
     ]
     connection {
-      host        = metal_device.storage1.network.0.address
+      host        = equinix_metal_device.storage1.network.0.address
       private_key = file(var.PRIV_KEY)
     }
   }
 }
 
-resource "metal_vlan" "vmvlan" {
-  metro      = var.PACKET_FACILITY
-  project_id = var.PACKET_PROJECT
-}
-
-resource "metal_port_vlan_attachment" "vmvlan_esxi1" {
-  device_id = metal_device.esxi1.id
-  port_name = "eth1"
-  vlan_vnid = metal_vlan.vmvlan.vxlan
-}
-
-resource "metal_port_vlan_attachment" "vmvlan_esxi2" {
-  device_id = metal_device.esxi2.id
-  port_name = "eth1"
-  vlan_vnid = metal_vlan.vmvlan.vxlan
-}
-
-resource "metal_port_vlan_attachment" "vmvlan_esxi3" {
-  device_id = metal_device.esxi3.id
-  port_name = "eth1"
-  vlan_vnid = metal_vlan.vmvlan.vxlan
-}
-
-resource "metal_port_vlan_attachment" "vmvlan_esxi4" {
-  device_id = metal_device.esxi4.id
-  port_name = "eth1"
-  vlan_vnid = metal_vlan.vmvlan.vxlan
-}
-
 resource "local_file" "vcsa_template" {
   content = templatefile("${path.cwd}/vcsa_deploy.json", {
-    hostname       = metal_device.esxi1.network.0.address
-    password       = metal_device.esxi1.root_password
-    ip_address     = cidrhost("${metal_device.esxi1.network.0.address}/${metal_device.esxi1.network.0.cidr}", 3)
-    ip_prefix      = metal_device.esxi1.network.0.cidr
-    gateway        = cidrhost("${metal_device.esxi1.network.0.address}/${metal_device.esxi1.network.0.cidr}", 1)
-    vcenter_fqdn   = "vcenter.vspheretest.internal"
+    hostname       = equinix_metal_device.esxi1.network.0.address
+    password       = equinix_metal_device.esxi1.root_password
+    ip_address     = cidrhost("${equinix_metal_device.esxi1.network.0.address}/${equinix_metal_device.esxi1.network.0.cidr}", 3)
+    ip_prefix      = equinix_metal_device.esxi1.network.0.cidr
+    gateway        = cidrhost("${equinix_metal_device.esxi1.network.0.address}/${equinix_metal_device.esxi1.network.0.cidr}", 1)
+    vcenter_fqdn   = "vcenter.test.local"
     admin_password = "Password123!"
   })
   filename = "./tmp/vcsa.json"
   provisioner "local-exec" {
-    command = "sleep 290; echo five more; sleep 290; TERM=xterm-256color ${var.VCSA_DEPLOY_PATH} install --accept-eula --acknowledge-ceip --no-ssl-certificate-verification --verbose --skip-ovftool-verification $(pwd)/tmp/vcsa.json"
+    command = "sleep 300; TERM=xterm-256color ${var.VCSA_DEPLOY_PATH} install --accept-eula --acknowledge-ceip --no-ssl-certificate-verification --verbose --skip-ovftool-verification $(pwd)/tmp/vcsa.json"
   }
 }
 
-output "ip" {
-  value = cidrhost("${metal_device.esxi1.network.0.address}/${metal_device.esxi1.network.0.cidr}", 3)
-}
-
-resource "local_file" "devrc" {
-  sensitive_content = templatefile("./devrc.tpl", {
-    nas_host       = metal_device.storage1.network.0.address
-    esxi_host_1    = metal_device.esxi1.network.0.address
-    esxi_host_1_pw = metal_device.esxi1.root_password
-    esxi_host_2    = metal_device.esxi2.network.0.address
-    esxi_host_2_pw = metal_device.esxi2.root_password
-    esxi_host_3    = metal_device.esxi3.network.0.address
-    esxi_host_3_pw = metal_device.esxi3.root_password
-    esxi_host_4    = metal_device.esxi4.network.0.address
-    esxi_host_4_pw = metal_device.esxi4.root_password
-    vsphere_host   = cidrhost("${metal_device.esxi1.network.0.address}/${metal_device.esxi1.network.0.cidr}", 3)
+resource "local_sensitive_file" "devrc" {
+  content = templatefile("./devrc.tpl", {
+    nas_host        = equinix_metal_device.storage1.network.0.address
+    esxi_host_1     = equinix_metal_device.esxi1.network.0.address
+    esxi_host_1_pw  = equinix_metal_device.esxi1.root_password
+    vsphere_host    = cidrhost("${equinix_metal_device.esxi1.network.0.address}/${equinix_metal_device.esxi1.network.0.cidr}", 3)
+    private_network = "${equinix_metal_device.esxi1.network.2.address}/${equinix_metal_device.esxi1.network.2.cidr}"
   })
   filename = "./devrc"
 }

--- a/acctests/equinix/vcsa_deploy.json
+++ b/acctests/equinix/vcsa_deploy.json
@@ -1,6 +1,6 @@
 {
     "__version": "2.13.0",
-    "__comments": "Sample template to deploy a vCenter Server Appliance with an embedded Platform Services Controller on an ESXi host.",
+    "__comments": "Sample template to deploy a vCenter Server Appliance with an embedded Platform Services Controller on an ESXi host. TODO: add a private IP/network to VCSA on deploy.",
     "new_vcsa": {
         "esxi": {
             "hostname": "${hostname}",

--- a/acctests/equinix/versions.tf
+++ b/acctests/equinix/versions.tf
@@ -6,8 +6,11 @@ terraform {
     local = {
       source = "hashicorp/local"
     }
-    metal = {
-      source = "equinix/metal"
+    equinix = {
+      source = "equinix/equinix"
+    }
+    time = {
+      source = "hashicorp/time"
     }
   }
   required_version = ">= 0.13"

--- a/acctests/vsphere/deploy-nested-esxi.tf
+++ b/acctests/vsphere/deploy-nested-esxi.tf
@@ -1,0 +1,129 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "NESTED_COUNT" {
+  default = 3
+}
+
+variable "VSPHERE_PRIVATE_NETWORK" {}
+
+variable "PRIV_KEY" {}
+
+resource "vsphere_virtual_machine" "nested-esxi" {
+  count = var.NESTED_COUNT
+
+  name                 = "${data.vsphere_ovf_vm_template.nested-esxi.name}-${count.index + 1}"
+  datacenter_id        = vsphere_datacenter.dc.moid
+  datastore_id         = data.vsphere_ovf_vm_template.nested-esxi.datastore_id
+  host_system_id       = data.vsphere_ovf_vm_template.nested-esxi.host_system_id
+  resource_pool_id     = data.vsphere_ovf_vm_template.nested-esxi.resource_pool_id
+  num_cpus             = data.vsphere_ovf_vm_template.nested-esxi.num_cpus
+  num_cores_per_socket = data.vsphere_ovf_vm_template.nested-esxi.num_cores_per_socket
+  memory               = data.vsphere_ovf_vm_template.nested-esxi.memory
+  guest_id             = data.vsphere_ovf_vm_template.nested-esxi.guest_id
+  firmware             = data.vsphere_ovf_vm_template.nested-esxi.firmware
+  scsi_type            = data.vsphere_ovf_vm_template.nested-esxi.scsi_type
+  nested_hv_enabled    = data.vsphere_ovf_vm_template.nested-esxi.nested_hv_enabled
+  dynamic "network_interface" {
+    for_each = data.vsphere_ovf_vm_template.nested-esxi.ovf_network_map
+    content {
+      network_id = network_interface.value
+    }
+  }
+  wait_for_guest_net_timeout = 0
+  wait_for_guest_ip_timeout  = 0
+
+  ovf_deploy {
+    allow_unverified_ssl_cert = false
+    remote_ovf_url            = data.vsphere_ovf_vm_template.nested-esxi.remote_ovf_url
+    ip_protocol               = "IPV4"
+    ip_allocation_policy      = "STATIC_MANUAL"
+    disk_provisioning         = data.vsphere_ovf_vm_template.nested-esxi.disk_provisioning
+    ovf_network_map           = data.vsphere_ovf_vm_template.nested-esxi.ovf_network_map
+  }
+
+  vapp {
+    properties = {
+      "guestinfo.hostname"   = "nested-${count.index + 1}.test.local",
+      "guestinfo.ipaddress"  = cidrhost(var.VSPHERE_PRIVATE_NETWORK, count.index + 3),
+      "guestinfo.netmask"    = "255.255.255.248",
+      "guestinfo.gateway"    = cidrhost(var.VSPHERE_PRIVATE_NETWORK, 1),
+      "guestinfo.dns"        = cidrhost(var.VSPHERE_PRIVATE_NETWORK, 1),
+      "guestinfo.domain"     = "test.local",
+      "guestinfo.ntp"        = cidrhost(var.VSPHERE_PRIVATE_NETWORK, 1),
+      "guestinfo.ssh"        = "True",
+      "guestinfo.password"   = "VMware1!",
+      "guestinfo.createvmfs" = "False",
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      annotation,
+      disk[0].io_share_count,
+      disk[1].io_share_count,
+      disk[2].io_share_count,
+      vapp[0].properties,
+    ]
+  }
+}
+
+// TODO: figure out why builtin network waiter not working
+resource "time_sleep" "wait_180_seconds" {
+  depends_on = [vsphere_virtual_machine.nested-esxi]
+  triggers = {
+    change_in_hostcount = length(vsphere_virtual_machine.nested-esxi)
+  }
+  create_duration = "180s"
+}
+
+locals {
+  hosts = join(" ", [for h in vsphere_virtual_machine.nested-esxi : h.vapp[0].properties["guestinfo.ipaddress"]])
+}
+
+resource "null_resource" "retrieve_thumbprints" {
+  depends_on = [time_sleep.wait_180_seconds]
+
+  triggers = {
+    hosts = local.hosts
+  }
+
+  # this script will ssh into the physical ESXI, and then use openssl to retrieve the thumbprints via the private IPs
+  provisioner "local-exec" {
+    command = <<-EOT
+      ssh -o StrictHostKeyChecking=no -i "${var.PRIV_KEY}" "root@${var.VSPHERE_ESXI1}" <<-'SSHCOMMANDS' > thumbprints.txt
+        #!/bin/sh
+        esxcli network firewall ruleset set -e true -r httpClient
+        hosts="${local.hosts}"
+        for host in $hosts; do
+          echo | openssl s_client -connect $host:443 -servername $host -showcerts 2>/dev/null | openssl x509 -noout -fingerprint -sha1 | awk -F'=' '{print $2}'
+        done
+      SSHCOMMANDS
+    EOT
+  }
+}
+
+# load the thumbprints from the file
+data "external" "thumbprints" {
+  depends_on = [null_resource.retrieve_thumbprints]
+
+  program = ["sh", "-c", "jq -R -s '{thumbprints: .}' ${path.module}/thumbprints.txt"]
+}
+
+locals {
+  thumbprints = split("\n", data.external.thumbprints.result["thumbprints"])
+}
+
+resource "vsphere_host" "nested-esxi" {
+  depends_on = [null_resource.retrieve_thumbprints]
+
+  count = var.NESTED_COUNT
+
+  hostname   = vsphere_virtual_machine.nested-esxi[count.index].vapp[0].properties["guestinfo.ipaddress"]
+  username   = "root"
+  password   = "VMware1!"
+  license    = vsphere_license.license.license_key
+  force      = true
+  cluster    = vsphere_compute_cluster.compute_cluster.id
+  thumbprint = local.thumbprints[count.index]
+}

--- a/acctests/vsphere/devrc.tpl
+++ b/acctests/vsphere/devrc.tpl
@@ -1,2 +1,37 @@
+export VSPHERE_REST_SESSION_PATH=$HOME/.govmomi/rest_sessions
+export VSPHERE_VIM_SESSION_PATH=$HOME/.govmomi/sessions
+export VSPHERE_PERSIST_SESSION=true
+
+export TF_VAR_VSPHERE_ESXI2=${esxi_host_2}
+export TF_VAR_VSPHERE_ESXI3=${esxi_host_3}
+export TF_VAR_VSPHERE_ESXI4=${esxi_host_4}
+export TF_VAR_VSPHERE_DATACENTER=${datacenter}
+export TF_VAR_VSPHERE_CLUSTER=${cluster}
+export TF_VAR_VSPHERE_PG_NAME=${port_group}
 export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0=${vmfs_disk_0}
 export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK1=${vmfs_disk_1}
+export TF_VAR_VSPHERE_VMFS_REGEXP=${vmfs_regexp}
+export TF_VAR_VSPHERE_RESOURCE_POOL=${resource_pool}
+export TF_VAR_VSPHERE_NFS_DS_NAME=${nfs_ds_name}
+export TF_VAR_VSPHERE_TEMPLATE=${template}
+export TF_VAR_VSPHERE_TEST_OVF=${test_ovf}
+export TF_VAR_VSPHERE_VM_V1_PATH=${vm_name}
+export TF_VAR_VSPHERE_ESXI_TRUNK_NIC=${trunk_nic}
+
+export TF_VAR_VSPHERE_NFS_DS_NAME2=nfs-vol2
+export TF_VAR_VSPHERE_NFS_PATH=/nfs
+export TF_VAR_VSPHERE_NFS_PATH2=/nfs/ds2
+export TF_VAR_VSPHERE_ISO_DATASTORE=nfs
+export TF_VAR_VSPHERE_ISO_FILE=fake.iso
+export TF_VAR_VSPHERE_DC_FOLDER=dc-folder
+export TF_VAR_VSPHERE_DS_FOLDER=ds
+export TF_VAR_VSPHERE_CLONED_VM_DISK_SIZE=20
+export TF_VAR_VSPHERE_TEST_OVA="https://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ova"
+export TF_VAR_VSPHERE_CONTENT_LIBRARY_FILES="http://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ovf"
+export TF_VAR_VSPHERE_HOST_NIC0=vmnic0
+export TF_VAR_VSPHERE_HOST_NIC1=vmnic1
+export TF_VAR_VSPHERE_VSWITCH_UPPER_VERSION="7.0.0"
+export TF_VAR_VSPHERE_VSWITCH_LOWER_VERSION="6.5.0"
+export TF_VAR_VSPHERE_DS_VMFS_NAME='ds-001'
+export TF_VAR_VSPHERE_FOLDER_V0_PATH='Discovered virtual machine'
+export TF_VAR_VSPHERE_ENTITY_PERMISSION_USER_GROUP="root"

--- a/acctests/vsphere/for-acceptance-tests.tf
+++ b/acctests/vsphere/for-acceptance-tests.tf
@@ -1,0 +1,90 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "VSPHERE_RESOURCE_POOL" {
+  default = "hashi-resource-pool"
+}
+
+variable "VSPHERE_NFS_DS_NAME" {
+  default = "nfs"
+}
+
+variable "VSPHERE_NAS_HOST" {}
+
+variable "VSPHERE_TEMPLATE" {
+  default = "tfvsphere_template"
+}
+
+variable "VSPHERE_TEST_OVF" {
+  default = "https://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ovf"
+}
+
+variable "VSPHERE_VM_V1_PATH" {
+  default = "pxe-server"
+}
+
+resource "vsphere_resource_pool" "pool" {
+  name                    = var.VSPHERE_RESOURCE_POOL
+  parent_resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
+}
+
+resource "vsphere_nas_datastore" "ds" {
+  name = var.VSPHERE_NFS_DS_NAME
+  host_system_ids = [vsphere_host.host1.id] // TODO: needs to be networked privately for nested ESXIs to connect to it
+  type         = "NFS"
+  remote_hosts = [var.VSPHERE_NAS_HOST]
+  remote_path  = "/nfs"
+}
+
+resource "vsphere_virtual_machine" "template" {
+  name             = var.VSPHERE_TEMPLATE
+  resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
+  datastore_id     = vsphere_nas_datastore.ds.id
+  datacenter_id    = vsphere_datacenter.dc.moid
+  host_system_id   = vsphere_host.host1.id
+
+  wait_for_guest_net_timeout = -1
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinuxGuest"
+
+  network_interface {
+    network_id = data.vsphere_network.pg.id
+  }
+
+  ovf_deploy {
+    remote_ovf_url = var.VSPHERE_TEST_OVF
+    ovf_network_map = {
+      "${vsphere_host_port_group.pg.name}" = data.vsphere_network.pg.id
+    }
+  }
+}
+
+resource "vsphere_virtual_machine" "pxe" {
+  name             = var.VSPHERE_VM_V1_PATH
+  resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
+  datastore_id     = vsphere_nas_datastore.ds.id
+
+  wait_for_guest_net_timeout = -1
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinuxGuest"
+
+  network_interface {
+    network_id = data.vsphere_network.pg.id
+  }
+  clone {
+    template_uuid = vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label = "disk0"
+    size  = 20
+  }
+
+  cdrom {
+    client_device = true
+  }
+}

--- a/acctests/vsphere/main.tf
+++ b/acctests/vsphere/main.tf
@@ -5,23 +5,13 @@ variable "VSPHERE_LICENSE" {
   sensitive = true
 }
 
-variable "VSPHERE_DATACENTER" {}
+variable "VSPHERE_DATACENTER" {
+  default = "hashidc"
+}
 
-variable "VSPHERE_CLUSTER" {}
-
-variable "VSPHERE_ESXI_TRUNK_NIC" {}
-
-variable "VSPHERE_RESOURCE_POOL" {}
-
-variable "VSPHERE_DVS_NAME" {}
-
-variable "VSPHERE_NFS_DS_NAME" {}
-
-variable "VSPHERE_PG_NAME" {}
-
-variable "VSPHERE_TEMPLATE" {}
-
-variable "VSPHERE_NAS_HOST" {}
+variable "VSPHERE_CLUSTER" {
+  default = "c1"
+}
 
 variable "VSPHERE_ESXI1" {}
 
@@ -29,109 +19,16 @@ variable "VSPHERE_ESXI1_PW" {
   sensitive = true
 }
 
-variable "VSPHERE_ESXI2" {}
-
-variable "VSPHERE_ESXI2_PW" {
-  sensitive = true
-}
-
-variable "VSPHERE_ESXI3" {}
-
-variable "VSPHERE_ESXI3_PW" {
-  sensitive = true
-}
-
-variable "VSPHERE_ESXI4" {}
-
-variable "VSPHERE_ESXI4_PW" {
-  sensitive = true
-}
-
-data "vsphere_network" "vmnet" {
-  datacenter_id = vsphere_datacenter.dc.moid
-  name          = "VM Network"
-  depends_on = [
-    vsphere_distributed_port_group.pg,
-    vsphere_distributed_virtual_switch.dvs
-  ]
-}
-
-resource "vsphere_resource_pool" "pool" {
-  name                    = var.VSPHERE_RESOURCE_POOL
-  parent_resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
-}
-
-resource "vsphere_nas_datastore" "ds" {
-  name            = var.VSPHERE_NFS_DS_NAME
-  host_system_ids = [vsphere_host.host1.id, vsphere_host.host2.id, vsphere_host.host3.id, vsphere_host.host4.id]
-  type            = "NFS"
-  remote_hosts    = [var.VSPHERE_NAS_HOST]
-  remote_path     = "/nfs"
-}
-
-resource "vsphere_distributed_virtual_switch" "dvs" {
-  name          = var.VSPHERE_DVS_NAME
-  datacenter_id = vsphere_datacenter.dc.moid
-
-  uplinks         = ["uplink1", "uplink2"]
-  active_uplinks  = ["uplink1"]
-  standby_uplinks = ["uplink2"]
-
-  host {
-    host_system_id = vsphere_host.host1.id
-    devices        = [var.VSPHERE_ESXI_TRUNK_NIC]
-  }
-
-  host {
-    host_system_id = vsphere_host.host2.id
-    devices        = [var.VSPHERE_ESXI_TRUNK_NIC]
-  }
-
-  host {
-    host_system_id = vsphere_host.host3.id
-    devices        = [var.VSPHERE_ESXI_TRUNK_NIC]
-  }
-
-  host {
-    host_system_id = vsphere_host.host4.id
-    devices        = [var.VSPHERE_ESXI_TRUNK_NIC]
-  }
-
-  version = "7.0.0"
-}
-
-resource "vsphere_distributed_port_group" "pg" {
-  name                            = var.VSPHERE_PG_NAME
-  distributed_virtual_switch_uuid = vsphere_distributed_virtual_switch.dvs.id
-
-  //vlan_id = var.VSPHERE_PXE_VLAN
-}
-
-
 resource "vsphere_datacenter" "dc" {
   name = var.VSPHERE_DATACENTER
 }
+
 resource "vsphere_license" "license" {
   license_key = var.VSPHERE_LICENSE
 }
 
 data "vsphere_host_thumbprint" "esxi1" {
   address  = var.VSPHERE_ESXI1
-  insecure = true
-}
-
-data "vsphere_host_thumbprint" "esxi2" {
-  address  = var.VSPHERE_ESXI2
-  insecure = true
-}
-
-data "vsphere_host_thumbprint" "esxi3" {
-  address  = var.VSPHERE_ESXI3
-  insecure = true
-}
-
-data "vsphere_host_thumbprint" "esxi4" {
-  address  = var.VSPHERE_ESXI4
   insecure = true
 }
 
@@ -153,121 +50,4 @@ resource "vsphere_host" "host1" {
   force      = true
   cluster    = vsphere_compute_cluster.compute_cluster.id
   thumbprint = data.vsphere_host_thumbprint.esxi1.id
-}
-
-resource "vsphere_host" "host2" {
-  hostname   = var.VSPHERE_ESXI2
-  username   = "root"
-  password   = var.VSPHERE_ESXI2_PW
-  license    = vsphere_license.license.license_key
-  force      = true
-  cluster    = vsphere_compute_cluster.compute_cluster.id
-  thumbprint = data.vsphere_host_thumbprint.esxi2.id
-}
-
-# Manually enable vsan on this host in the vsphere UI
-# Enable vsan in VMKernal Adapters on the management network
-resource "vsphere_host" "host3" {
-  hostname   = var.VSPHERE_ESXI3
-  username   = "root"
-  password   = var.VSPHERE_ESXI3_PW
-  license    = vsphere_license.license.license_key
-  force      = true
-  datacenter = vsphere_datacenter.dc.moid
-  thumbprint = data.vsphere_host_thumbprint.esxi3.id
-}
-
-# Manually enable vSAN on this host in the vSphere UI
-# Enable vSAN traffic type in VMKernal adapter on the management network
-resource "vsphere_host" "host4" {
-  hostname   = var.VSPHERE_ESXI4
-  username   = "root"
-  password   = var.VSPHERE_ESXI4_PW
-  license    = vsphere_license.license.license_key
-  force      = true
-  datacenter = vsphere_datacenter.dc.moid
-  thumbprint = data.vsphere_host_thumbprint.esxi4.id
-}
-
-resource "vsphere_virtual_machine" "template" {
-  name             = var.VSPHERE_TEMPLATE
-  resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds.id
-  datacenter_id    = vsphere_datacenter.dc.moid
-  host_system_id   = vsphere_host.host2.id
-
-  wait_for_guest_net_timeout = -1
-
-  num_cpus = 2
-  memory   = 2048
-  guest_id = "other3xLinuxGuest"
-
-  network_interface {
-    network_id = vsphere_distributed_port_group.pg.id
-  }
-
-  ovf_deploy {
-    remote_ovf_url = "https://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ovf"
-    ovf_network_map = {
-      "terraform-test-pg" = vsphere_distributed_port_group.pg.id
-    }
-  }
-}
-
-resource "vsphere_virtual_machine" "pxe" {
-  name             = "pxe-server"
-  resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds.id
-
-  wait_for_guest_net_timeout = -1
-
-  num_cpus = 2
-  memory   = 2048
-  guest_id = "other3xLinuxGuest"
-
-  network_interface {
-    network_id = data.vsphere_network.vmnet.id
-  }
-  network_interface {
-    network_id = vsphere_distributed_port_group.pg.id
-  }
-  clone {
-    template_uuid = vsphere_virtual_machine.template.id
-  }
-
-  disk {
-    label = "disk0"
-    size  = 20
-  }
-
-  cdrom {
-    client_device = true
-  }
-}
-
-data "vsphere_vmfs_disks" "available" {
-  host_system_id = vsphere_host.host1.id
-  rescan         = true
-  filter         = "naa."
-}
-
-resource "local_file" "devrc" {
-  content = templatefile("./devrc.tpl", {
-    vmfs_disk_0 = data.vsphere_vmfs_disks.available.disks[0]
-    vmfs_disk_1 = data.vsphere_vmfs_disks.available.disks[1]
-  })
-  filename = "./devrc"
-}
-
-resource "vsphere_content_library" "nested-library" {
-  name            = "nested esxi content library"
-  storage_backing = [vsphere_nas_datastore.ds.id]
-  description     = "https://www.virtuallyghetto.com/2015/04/subscribe-to-vghetto-nested-esxi-template-content-library-in-vsphere-6-0.html"
-}
-
-resource "vsphere_content_library_item" "n-esxi" {
-  name        = "nested esxi vm"
-  description = "nested esxi template"
-  library_id  = vsphere_content_library.nested-library.id
-  file_url    = "https://s3-us-west-1.amazonaws.com/vghetto-content-library/Nested-ESXi-VM-Template/Nested-ESXi-VM-Template.ovf"
 }

--- a/acctests/vsphere/nested-esxi-template.tf
+++ b/acctests/vsphere/nested-esxi-template.tf
@@ -1,0 +1,66 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "VSPHERE_ESXI_TRUNK_NIC" {
+  default = "vmnic1"
+}
+
+variable "VSPHERE_PG_NAME" {
+  default = "vmnet"
+}
+
+variable "VSPHERE_VMFS_REGEXP" {
+  default = "naa."
+}
+
+data "vsphere_vmfs_disks" "available" {
+  host_system_id = vsphere_host.host1.id
+  rescan         = true
+  filter         = var.VSPHERE_VMFS_REGEXP
+}
+
+# TODO: use datastore1 instead for nested esxi VMs
+resource "vsphere_vmfs_datastore" "nested-esxi" {
+  name           = "nested-esxi"
+  host_system_id = vsphere_host.host1.id
+  disks          = data.vsphere_vmfs_disks.available.disks
+}
+
+resource "vsphere_host_virtual_switch" "switch" {
+  name           = "terraform-test" #
+  host_system_id = vsphere_host.host1.id
+
+  network_adapters = [var.VSPHERE_ESXI_TRUNK_NIC]
+
+  active_nics = [var.VSPHERE_ESXI_TRUNK_NIC]
+}
+
+resource "vsphere_host_port_group" "pg" {
+  name                = var.VSPHERE_PG_NAME
+  host_system_id      = vsphere_host.host1.id
+  virtual_switch_name = vsphere_host_virtual_switch.switch.name
+
+  allow_promiscuous      = true
+  allow_mac_changes      = true
+  allow_forged_transmits = true
+}
+
+// TODO: why can't the id exported from vsphere_host_port_group be used directly?
+data "vsphere_network" "pg" {
+  depends_on = [vsphere_host_port_group.pg, vsphere_host_virtual_switch.switch]
+
+  name          = vsphere_host_port_group.pg.name
+  datacenter_id = vsphere_datacenter.dc.moid
+}
+
+data "vsphere_ovf_vm_template" "nested-esxi" {
+  name              = "Nested-ESXi-7.0"
+  disk_provisioning = "thin"
+  resource_pool_id  = vsphere_compute_cluster.compute_cluster.resource_pool_id
+  datastore_id      = vsphere_vmfs_datastore.nested-esxi.id
+  host_system_id    = vsphere_host.host1.id
+  remote_ovf_url    = "https://download3.vmware.com/software/vmw-tools/nested-esxi/Nested_ESXi7.0u3_Appliance_Template_v1.ova"
+  ovf_network_map = {
+    "${vsphere_host_port_group.pg.name}" = data.vsphere_network.pg.id
+  }
+}

--- a/acctests/vsphere/output.tf
+++ b/acctests/vsphere/output.tf
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "local_sensitive_file" "devrc" {
+  content = templatefile("./devrc.tpl", {
+    esxi_host_2   = vsphere_host.nested-esxi[0].hostname
+    esxi_host_3   = vsphere_host.nested-esxi[1].hostname
+    esxi_host_4   = vsphere_host.nested-esxi[2].hostname
+    datacenter    = vsphere_datacenter.dc.name
+    cluster       = vsphere_compute_cluster.compute_cluster.name
+    port_group    = vsphere_host_port_group.pg.name
+    vmfs_disk_0   = data.vsphere_vmfs_disks.available.disks[0]
+    vmfs_disk_1   = data.vsphere_vmfs_disks.available.disks[1]
+    vmfs_regexp   = data.vsphere_vmfs_disks.available.filter
+    resource_pool = vsphere_resource_pool.pool.name
+    nfs_ds_name   = vsphere_nas_datastore.ds.name
+    template      = vsphere_virtual_machine.template.name
+    test_ovf      = vsphere_virtual_machine.template.ovf_deploy[0].remote_ovf_url
+    vm_name       = vsphere_virtual_machine.pxe.name
+    trunk_nic     = vsphere_host_virtual_switch.switch.network_adapters[0]
+  })
+  filename = "./devrc"
+}

--- a/acctests/vsphere/versions.tf
+++ b/acctests/vsphere/versions.tf
@@ -9,6 +9,15 @@ terraform {
     vsphere = {
       source = "hashicorp/vsphere"
     }
+    time = {
+      source = "hashicorp/time"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    external = {
+      source = "hashicorp/external"
+    }
   }
   required_version = ">= 0.13"
 }

--- a/vsphere/data_source_vsphere_content_library_item_test.go
+++ b/vsphere/data_source_vsphere_content_library_item_test.go
@@ -36,33 +36,23 @@ func TestAccDataSourceVSphereContentLibraryItem_basic(t *testing.T) {
 }
 
 func testAccDataSourceVSphereContentLibraryItemPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_CONTENT_LIBRARY") == "" {
-		t.Skip("set TF_VAR_VSPHERE_CONTENT_LIBRARY to run vsphere_content_library acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_CONTENT_LIBRARY_ITEM") == "" {
-		t.Skip("set TF_VAR_VSPHERE_CONTENT_LIBRARY_ITEM to run vsphere_content_library_item acceptance tests")
+	if os.Getenv("TF_VAR_VSPHERE_CONTENT_LIBRARY_FILES") == "" {
+		t.Skip("set TF_VAR_VSPHERE_CONTENT_LIBRARY_FILES to run vsphere_content_library acceptance tests")
 	}
 }
 
 func testAccDataSourceVSphereContentLibraryItemConfig() string {
 	return fmt.Sprintf(`
-variable "datacenter" {
+%s
+
+variable "file" {
   type    = string
-  default = "%s"
-}
-
-variable "file_list" {
-  type    = list(string)
-  default = %s 
-}
-
-data "vsphere_datacenter" "dc" {
-  name = data.vsphere_datacenter.rootdc1.name
+  default = "%s" 
 }
 
 data "vsphere_datastore" "ds" {
   datacenter_id = data.vsphere_datacenter.rootdc1.id
-  name = var.datastore
+  name          = vsphere_nas_datastore.ds1.name
 }
 
 resource "vsphere_content_library" "library" {
@@ -76,12 +66,13 @@ resource "vsphere_content_library_item" "item" {
   description = "Ubuntu Description"
   library_id  = vsphere_content_library.library.id
   type        = "ovf"
-  file_url    = var.file_list
+  file_url    = var.file
 }
 
 data "vsphere_content_library_item" "item" {
   name       = vsphere_content_library_item.item.name
   library_id = vsphere_content_library.library.id
+  type       = "ovf"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/data_source_vsphere_content_library_test.go
+++ b/vsphere/data_source_vsphere_content_library_test.go
@@ -56,6 +56,6 @@ data "vsphere_content_library" "library" {
 }
 
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }

--- a/vsphere/data_source_vsphere_host_thumbprint_test.go
+++ b/vsphere/data_source_vsphere_host_thumbprint_test.go
@@ -39,7 +39,8 @@ func testAccDataSourceVSphereHostThumbprintPreCheck(t *testing.T) {
 func testAccDataSourceVSphereHostThumbprintConfig() string {
 	return fmt.Sprintf(`
 data "vsphere_host_thumbprint" "thumb" {
-  address = "%s"
+  address  = "%s"
+  insecure = true
 }`,
 		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
 	)

--- a/vsphere/data_source_vsphere_resource_pool_test.go
+++ b/vsphere/data_source_vsphere_resource_pool_test.go
@@ -89,10 +89,6 @@ func TestAccDataSourceVSphereResourcePool_emptyNameOnVCenterShouldError(t *testi
 				ExpectError: regexp.MustCompile("name cannot be empty when using vCenter"),
 				PlanOnly:    true,
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
-			},
 		},
 	})
 }

--- a/vsphere/internal/helper/testhelper/testing.go
+++ b/vsphere/internal/helper/testhelper/testing.go
@@ -161,7 +161,7 @@ func ConfigResDS1() string {
 	return fmt.Sprintf(`
 resource "vsphere_nas_datastore" "ds1" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
   type            = "NFS"
   remote_hosts    = ["%s"]
   remote_path     = "%s"

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -561,11 +561,13 @@ func resourceVSphereComputeCluster() *schema.Resource {
 				Description: "A list of disk UUIDs to add to the vSAN cluster.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						// use 4gb disk from ova in the future for acctests
 						"cache": {
 							Type:        schema.TypeString,
 							Description: "Cache disk.",
 							Optional:    true,
 						},
+						// use 8gb disk from ova in the future for acctests
 						"storage": {
 							Type:        schema.TypeSet,
 							Description: "List of storage disks.",

--- a/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule_test.go
@@ -335,7 +335,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name                 = "testacc-nas"
-  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids      = [data.vsphere_host.roothost1.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -374,7 +374,7 @@ resource "vsphere_datastore_cluster_vm_anti_affinity_rule" "cluster_vm_anti_affi
   enabled              = %t
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigDataRootVMNet()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigDataRootVMNet()),
 		count,
 		os.Getenv("TF_VAR_VSPHERE_NAS_HOST"),
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),

--- a/vsphere/resource_vsphere_host_port_group_test.go
+++ b/vsphere/resource_vsphere_host_port_group_test.go
@@ -194,7 +194,7 @@ data "vsphere_host" "esxi_host" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
+  name           = "vSwitchTerraformTest2"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
   network_adapters = ["${var.host_nic0}"]
@@ -230,7 +230,7 @@ data "vsphere_host" "esxi_host" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
+  name           = "vSwitchTerraformTest2"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
   network_adapters  = ["${var.host_nic0}", "${var.host_nic1}"]

--- a/vsphere/resource_vsphere_host_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_host_virtual_switch_test.go
@@ -114,10 +114,6 @@ func TestAccResourceVSphereHostVirtualSwitch_badActiveNICList(t *testing.T) {
 				ExpectError: regexp.MustCompile(fmt.Sprintf("active NIC entry %q not present in network_adapters list", os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"))),
 				PlanOnly:    true,
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
-			},
 		},
 	})
 }
@@ -136,10 +132,6 @@ func TestAccResourceVSphereHostVirtualSwitch_badStandbyNICList(t *testing.T) {
 				Config:      testAccResourceVSphereHostVirtualSwitchConfigBadStandby(),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("standby NIC entry %q not present in network_adapters list", os.Getenv("TF_VAR_VSPHERE_HOST_NIC1"))),
 				PlanOnly:    true,
-			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
@@ -263,7 +255,7 @@ data "vsphere_host" "esxi_host" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
+  name           = "vSwitchTerraformTest2"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
   network_adapters = [var.host_nic0, var.host_nic1]
@@ -291,7 +283,7 @@ data "vsphere_host" "esxi_host" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
+  name           = "vSwitchTerraformTest2"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
   network_adapters = ["${var.host_nic0}"]
@@ -317,7 +309,7 @@ data "vsphere_host" "esxi_host" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
+  name           = "vSwitchTerraformTest2"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
   network_adapters = []
@@ -344,7 +336,7 @@ data "vsphere_host" "esxi_host" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
+  name           = "vSwitchTerraformTest2"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
   network_adapters = []
@@ -371,7 +363,7 @@ data "vsphere_host" "esxi_host" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "vSwitchTerraformTest"
+  name           = "vSwitchTerraformTest2"
   host_system_id = "${data.vsphere_host.esxi_host.id}"
 
   network_adapters = []

--- a/vsphere/resource_vsphere_nas_datastore_test.go
+++ b/vsphere/resource_vsphere_nas_datastore_test.go
@@ -444,7 +444,7 @@ variable "nfs_path" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
 
   type         = "NFS"
   remote_hosts = ["${var.nfs_host}"]
@@ -455,7 +455,6 @@ resource "vsphere_nas_datastore" "datastore" {
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
 			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
 		),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"))
 }
@@ -507,7 +506,7 @@ variable "nfs_path" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s-renamed"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
 
   type         = "NFS"
   remote_hosts = ["${var.nfs_host}"]
@@ -516,8 +515,7 @@ resource "vsphere_nas_datastore" "datastore" {
 `, os.Getenv("TF_VAR_VSPHERE_NAS_HOST"), os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"))
 }
 
@@ -548,7 +546,7 @@ resource "vsphere_folder" "folder" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
   folder          = vsphere_folder.folder.path
 
   type         = "NFS"
@@ -560,8 +558,7 @@ resource "vsphere_nas_datastore" "datastore" {
 		os.Getenv("TF_VAR_VSPHERE_DS_FOLDER"),
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"))
 }
 
@@ -595,7 +592,7 @@ resource "vsphere_tag" "testacc-tag" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
 
   type         = "NFS"
   remote_hosts = ["${var.nfs_host}"]
@@ -607,8 +604,7 @@ resource "vsphere_nas_datastore" "datastore" {
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"))
 }
 
@@ -655,7 +651,7 @@ resource "vsphere_tag" "testacc-tags-alt" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
 
   type         = "NFS"
   remote_hosts = ["${var.nfs_host}"]
@@ -667,8 +663,7 @@ resource "vsphere_nas_datastore" "datastore" {
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"))
 }
 
@@ -699,7 +694,7 @@ locals {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
 
   type         = "NFS"
   remote_hosts = ["${var.nfs_host}"]
@@ -709,8 +704,7 @@ resource "vsphere_nas_datastore" "datastore" {
 }
 `, os.Getenv("TF_VAR_VSPHERE_NAS_HOST"), os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"))
 }
 
@@ -747,7 +741,7 @@ locals {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
 
   type         = "NFS"
   remote_hosts = ["${var.nfs_host}"]
@@ -758,8 +752,7 @@ resource "vsphere_nas_datastore" "datastore" {
 `, os.Getenv("TF_VAR_VSPHERE_NAS_HOST"), os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"),
 	)
 }
@@ -790,7 +783,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "%s"
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids = [data.vsphere_host.roothost1.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -802,7 +795,6 @@ resource "vsphere_nas_datastore" "datastore" {
 		os.Getenv("TF_VAR_VSPHERE_DS_FOLDER"),
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 		os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME2"))
 }

--- a/vsphere/resource_vsphere_storage_drs_vm_override_test.go
+++ b/vsphere/resource_vsphere_storage_drs_vm_override_test.go
@@ -217,7 +217,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name                 = "%s"
-  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids      = [data.vsphere_host.roothost1.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -255,7 +255,6 @@ resource "vsphere_storage_drs_vm_override" "drs_vm_override" {
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
 			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
 			testhelper.ConfigDataRootComputeCluster1(),
 			testhelper.ConfigResResourcePool1(),
 			testhelper.ConfigDataRootPortGroup1()),
@@ -285,7 +284,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore" {
   name                 = "testacc-nas"
-  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids      = [data.vsphere_host.roothost1.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -326,7 +325,6 @@ resource "vsphere_storage_drs_vm_override" "drs_vm_override" {
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
 			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
 			testhelper.ConfigDataRootComputeCluster1(),
 			testhelper.ConfigResResourcePool1(),
 			testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_vapp_container_test.go
+++ b/vsphere/resource_vsphere_vapp_container_test.go
@@ -474,7 +474,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore1" {
   name                 = "terraform-datastore-test1"
-  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids      = [data.vsphere_host.roothost1.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -525,7 +525,6 @@ resource "vsphere_virtual_machine" "vm" {
 			testhelper.ConfigDataRootPortGroup1(),
 			testhelper.ConfigDataRootComputeCluster1(),
 			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
 			testhelper.ConfigDataRootDS1()),
 
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
@@ -553,7 +552,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore1" {
   name                 = "terraform-datastore-test1"
-  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids      = [data.vsphere_host.roothost1.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -602,8 +601,7 @@ resource "vsphere_virtual_machine" "vm" {
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(),
 			testhelper.ConfigDataRootComputeCluster1(),
 			testhelper.ConfigDataRootPortGroup1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2()),
+			testhelper.ConfigDataRootHost1()),
 
 		os.Getenv("TF_VAR_VSPHERE_NFS_PATH2"),
 		os.Getenv("TF_VAR_VSPHERE_NAS_HOST"),
@@ -639,7 +637,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
 
 resource "vsphere_nas_datastore" "datastore1" {
   name                 = "terraform-datastore-test1"
-  host_system_ids      = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  host_system_ids      = [data.vsphere_host.roothost1.id]
   datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
 
   type         = "NFS"
@@ -694,7 +692,6 @@ resource "vsphere_virtual_machine" "vm" {
 			testhelper.ConfigResDS1(),
 			testhelper.ConfigDataRootDS1(),
 			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
 			testhelper.ConfigDataRootVMNet(),
 			testhelper.ConfigDataRootPortGroup1()),
 
@@ -768,7 +765,6 @@ resource "vsphere_virtual_machine" "vm" {
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
 			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
 			testhelper.ConfigResDS1(),
 			testhelper.ConfigDataRootComputeCluster1(),
 			testhelper.ConfigResResourcePool1(),

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -504,10 +504,6 @@ func TestAccResourceVSphereVirtualMachine_highDiskUnitInsufficientBus(t *testing
 				Config:      testAccResourceVSphereVirtualMachineConfigMultiHighBusInsufficientBus(),
 				ExpectError: regexp.MustCompile("unit_number on disk \"disk1\" too high \\(15\\) - maximum value is 14 with 1 SCSI controller\\(s\\)"),
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
-			},
 		},
 	})
 }
@@ -850,9 +846,6 @@ func TestAccResourceVSphereVirtualMachine_cdromIsoBacking(t *testing.T) {
 					testAccResourceVSphereVirtualMachineCheckIsoCdrom(),
 				),
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-			},
 		},
 	})
 }
@@ -869,9 +862,6 @@ func TestAccResourceVSphereVirtualMachine_cdromConflictingParameters(t *testing.
 			{
 				Config:      testAccResourceVSphereVirtualMachineConfigConflictingCdromParameters(),
 				ExpectError: regexp.MustCompile("Cannot have both client_device parameter and ISO file parameters"),
-			},
-			{
-				Config: testAccResourceVSphereEmpty,
 			},
 		},
 	})
@@ -1163,9 +1153,6 @@ func TestAccResourceVSphereVirtualMachine_vAppContainerAndFolder(t *testing.T) {
 				Config:      testAccResourceVSphereVirtualMachineConfigVAppAndFolder(),
 				ExpectError: regexp.MustCompile("cannot set folder while VM is in a vApp container"),
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-			},
 		},
 	})
 }
@@ -1403,17 +1390,18 @@ func TestAccResourceVSphereVirtualMachine_blockComputedDiskName(t *testing.T) {
 			testAccPreCheck(t)
 			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
-		Providers:    testAccProviders,
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+			},
+		},
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceVSphereVirtualMachineConfigComputedDisk(),
 				ExpectError: regexp.MustCompile("disk label or name must be defined and cannot be computed"),
 				PlanOnly:    true,
-			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
@@ -1432,10 +1420,6 @@ func TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClones(t *testin
 			{
 				Config:      testAccResourceVSphereVirtualMachineVAppPropertiesNonClone(),
 				ExpectError: regexp.MustCompile("vApp properties can only be set on cloned virtual machines"),
-			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
@@ -1485,10 +1469,6 @@ func TestAccResourceVSphereVirtualMachine_blockDiskLabelStartingWithOrphanedPref
 				Config:      testAccResourceVSphereVirtualMachineConfigBadOrphanedLabel(),
 				ExpectError: regexp.MustCompile(regexp.QuoteMeta(`disk label "orphaned_disk_0" cannot start with "orphaned_disk_"`)),
 				PlanOnly:    true,
-			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
@@ -1740,10 +1720,6 @@ func TestAccResourceVSphereVirtualMachine_cloneWithBadTimezone(t *testing.T) {
 				ExpectError: regexp.MustCompile("must be similar to America/Los_Angeles or other Linux/Unix TZ format"),
 				PlanOnly:    true,
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
-			},
 		},
 	})
 }
@@ -1786,10 +1762,6 @@ func TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithLinkedClone(t *tes
 				ExpectError: regexp.MustCompile("must be the exact size of source when using linked_clone"),
 				PlanOnly:    true,
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
-			},
 		},
 	})
 }
@@ -1808,10 +1780,6 @@ func TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithoutLinkedClone(t *
 				Config:      testAccResourceVSphereVirtualMachineConfigBadSizeUnlinked(),
 				ExpectError: regexp.MustCompile("must be at least the same size of source when cloning"),
 				PlanOnly:    true,
-			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
@@ -1834,10 +1802,7 @@ func TestAccResourceVSphereVirtualMachine_cloneIntoEmptyCluster(t *testing.T) {
 				ExpectError: regexp.MustCompile("compute resource .* is missing an Environment Browser\\. Check host, cluster, and vSphere license health of all associated resources and try again"),
 				//PlanOnly:    true,
 			},
-			{
-				Config: testAccResourceVSphereEmpty,
-				Check:  resource.ComposeTestCheckFunc(),
-			}},
+		},
 	})
 }
 
@@ -1961,9 +1926,6 @@ func TestAccResourceVSphereVirtualMachine_hostCheck(t *testing.T) {
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckHost(os.Getenv("TF_VAR_VSPHERE_ESXI1")),
 				),
-			},
-			{
-				Config: testAccResourceVSphereEmpty,
 			},
 			{
 				Config: testAccResourceVSphereVirtualMachineConfigHostCheck(os.Getenv("TF_VAR_VSPHERE_ESXI2")),


### PR DESCRIPTION
## What is happening
The provider will be undergoing a period of technical debt paydown. The primary goal is to have portable and scalable acceptance testing such that community contribution is orders of magnitude easier. This PR is a step in that direction, we want to rely on as little physical infrastructure as possible, with that in mind the test suite will move towards using nested ESXis (which ideally will make no difference to the test cases). The end goal being a full CI pipeline that can run nightly, against different permutations of ESXi/vSphere version combinations, and that can validate PRs autonomously and report back results.

## What does this PR bring
Not much other than an Equinix based config that does not rely on a second physical ESXi host, rather nested ESXi VMs are deployed. The tests in general don't rely too much on multiple hosts. There are some tests that don't pass yet in this setup, and several tests that haven't passed for some time.

## What's next
Likely remediating the failing and skipped tests to pass in the new setup. Then introducing some test coverage tooling to catch parts of the provider that are untested and should be (sometimes features are not testable outside local/hardware based setups, writing acceptance tests is impractical). After that we can invest in some basic automation to at least run `main` nightly to catch regressions, we also need to introduce parallelism to the testsuite.

## Results
Testing is currently performed manually, one resource at a time (in the case of the VM resource, each test was called manually 😱 )

```
346 total, 287 (p)ass, 13 (s)kip, 63 (f)ail
===Results===
TestAccClient_persistence p
TestAccClient_noPersistence p
TestNewConfig p
TestAccDataSourceVSphereComputeClusterHostGroup_basic p
TestAccDataSourceVSphereComputeCluster_basic p
TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter p
TestAccDataSourceVSphereContentLibraryItem_basic p
TestAccDataSourceVSphereContentLibrary_basic p
TestAccDataSourceVSphereCustomAttribute_basic p
TestAccDataSourceVSphereDatacenter_basic p
TestAccDataSourceVSphereDatacenter_defaultDatacenter p
TestAccDataSourceVSphereDatastoreCluster_basic p
TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter p
TestAccDataSourceVSphereDatastore_basic p
TestAccDataSourceVSphereDatastore_noDatacenterAndAbsolutePath p
TestAccDataSourceVSphereDistributedVirtualSwitch_basic p
TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified p
TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup p
TestAccDataSourceVSphereDynamic_regexAndTag p
TestAccDataSourceVSphereDynamic_multiTag p
TestAccDataSourceVSphereDynamic_multiResult p
TestAccDataSourceVSphereDynamic_typeFilter p
TestAccDataSourceVSphereFolder_basic p
TestAccDataSourceVSphereHost_basic p
TestAccDataSourceVSphereHost_defaultHost s
TestAccDataSourceVSphereHostThumbprint_basic p
TestAccDataSourceVSphereLicense_basic p
TestAccDataSourceVSphereNetwork_dvsPortgroup p
TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter p
TestAccDataSourceVSphereNetwork_hostPortgroups p
TestAccDataSourceVSphereResourcePool_basic p
TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath p
TestAccDataSourceVSphereResourcePool_defaultResourcePoolForESXi s
TestAccDataSourceVSphereResourcePool_emptyNameOnVCenterShouldError p
TestAccDataSourceVSphereRole_basic p
TestAccDataSourceVSphereRole_systemRoleData p
TestAccDataSourceVSphereTagCategory_basic p
TestAccDataSourceVSphereTag_basic p
TestAccDataSourceVSphereVAppContainer_basic p
TestAccDataSourceVSphereVAppContainer_path p
TestAccDataSourceVSphereVirtualMachine_basic p
TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath p
TestAccDataSourceVSphereVirtualMachine_uuid p
TestAccDataSourceVSphereVmfsDisks_basic p
TestProvider p
TestAccResourceVSphereComputeClusterHostGroup_basic p
TestAccResourceVSphereComputeClusterHostGroup_update p
TestAccResourceVSphereComputeCluster_basic p
TestAccResourceVSphereComputeCluster_haAdmissionControlPolicyDisabled p
TestAccResourceVSphereComputeCluster_drsHAEnabled p
TestAccResourceVSphereComputeCluster_vsanDedupEnabled p
TestAccResourceVSphereComputeCluster_vsanCompressionEnabled p
TestAccResourceVSphereComputeCluster_vsanPerfEnabled p
TestAccResourceVSphereComputeCluster_vsanPerfVerboseEnabled p
TestAccResourceVSphereComputeCluster_vsanPerfVerboseDiagnosticEnabled p
TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled p
TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled p
TestAccResourceVSphereComputeCluster_vsanDITEncryption p
TestAccResourceVSphereComputeCluster_explicitFailoverHost p
TestAccResourceVSphereComputeCluster_rename p
TestAccResourceVSphereComputeCluster_inFolder p
TestAccResourceVSphereComputeCluster_moveToFolder p
TestAccResourceVSphereComputeCluster_singleTag p
TestAccResourceVSphereComputeCluster_multipleTags p
TestAccResourceVSphereComputeCluster_switchTags p
TestAccResourceVSphereComputeCluster_singleCustomAttribute p
TestAccResourceVSphereComputeCluster_multipleCustomAttribute p
TestAccResourceVSphereComputeCluster_switchCustomAttribute p
TestAccResourceVSphereComputeClusterVMAffinityRule_basic p
TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled p
TestAccResourceVSphereComputeClusterVMAffinityRule_updateCount p
TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic p
TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled p
TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateCount p
TestAccResourceVSphereComputeClusterVMDependencyRule_basic p
TestAccResourceVSphereComputeClusterVMDependencyRule_altGroup p
TestAccResourceVSphereComputeClusterVMDependencyRule_updateEnabled p
TestAccResourceVSphereComputeClusterVMDependencyRule_updateGroup p
TestAccResourceVSphereComputeClusterVMGroup_basic p
TestAccResourceVSphereComputeClusterVMGroup_update p
TestAccResourceVSphereComputeClusterVMHostRule_basic p
TestAccResourceVSphereComputeClusterVMHostRule_antiAffinity p
TestAccResourceVSphereComputeClusterVMHostRule_updateEnabled p
TestAccResourceVSphereComputeClusterVMHostRule_updateAffinity p
TestAccResourceVSphereContentLibraryItem_localOva p
TestAccResourceVSphereContentLibraryItem_remoteOvf p
TestAccResourceVSphereContentLibraryItem_remoteOva p
TestAccResourceVSphereContentLibrary_basic p
TestAccResourceVSphereContentLibrary_subscribed p
TestAccResourceVSphereContentLibrary_authenticated p
TestAccResourceVSphereCustomAttribute_basic p
TestAccResourceVSphereCustomAttribute_withType p
TestAccResourceVSphereCustomAttribute_rename p
TestAccResourceVSphereCustomAttribute_changeType p
TestAccResourceVSphereDatacenter_createOnRootFolder p
TestAccResourceVSphereDatacenter_createOnSubfolder p
TestAccResourceVSphereDatacenter_singleTag p
TestAccResourceVSphereDatacenter_modifyTags p
TestAccResourceVSphereDatacenter_singleCustomAttribute p
TestAccResourceVSphereDatacenter_modifyCustomAttribute p
TestAccResourceVSphereDatastoreCluster_basic p
TestAccResourceVSphereDatastoreCluster_sdrsEnabled p
TestAccResourceVSphereDatastoreCluster_rename p
TestAccResourceVSphereDatastoreCluster_inFolder p
TestAccResourceVSphereDatastoreCluster_moveToFolder p
TestAccResourceVSphereDatastoreCluster_sdrsOverrides p
TestAccResourceVSphereDatastoreCluster_miscTweaks p
TestAccResourceVSphereDatastoreCluster_reservableIops p
TestAccResourceVSphereDatastoreCluster_freeSpace p
TestAccResourceVSphereDatastoreCluster_singleTag p
TestAccResourceVSphereDatastoreCluster_multipleTags p
TestAccResourceVSphereDatastoreCluster_switchTags p
TestAccResourceVSphereDatastoreCluster_singleCustomAttribute p
TestAccResourceVSphereDatastoreCluster_multipleCustomAttribute p
TestAccResourceVSphereDatastoreCluster_switchCustomAttribute p
TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_basic p
TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_updateEnabled p
TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_updateCount p
TestAccResourceVSphereDistributedPortGroup_basic p
TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheck p
TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheckVlanRangeTypeSetEdition p
TestAccResourceVSphereDistributedPortGroup_overrideVlan p
TestAccResourceVSphereDistributedPortGroup_singleTag p
TestAccResourceVSphereDistributedPortGroup_multiTag p
TestAccResourceVSphereDistributedPortGroup_singleCustomAttribute p
TestAccResourceVSphereDistributedPortGroup_multiCustomAttribute p
TestAccResourceVSphereDistributedVirtualSwitch_basic
TestAccResourceVSphereDistributedVirtualSwitch_noHosts
TestAccResourceVSphereDistributedVirtualSwitch_removeNIC
TestAccResourceVSphereDistributedVirtualSwitch_standbyWithExplicitFailoverOrder
TestAccResourceVSphereDistributedVirtualSwitch_basicToStandbyWithFailover
TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion
TestAccResourceVSphereDistributedVirtualSwitch_networkResourceControl
TestAccResourceVSphereDistributedVirtualSwitch_explicitUplinks
TestAccResourceVSphereDistributedVirtualSwitch_modifyUplinks
TestAccResourceVSphereDistributedVirtualSwitch_inFolder p
TestAccResourceVSphereDistributedVirtualSwitch_singleTag p
TestAccResourceVSphereDistributedVirtualSwitch_modifyTags p
TestAccResourceVSphereDistributedVirtualSwitch_netflow p
TestAccResourceVSphereDistributedVirtualSwitch_vlanRanges p
TestAccResourceVSphereDistributedVirtualSwitch_singleCustomAttribute p
TestAccResourceVSphereDistributedVirtualSwitch_multiCustomAttribute p
TestAccResourceVSphereDPMHostOverride_basic p
TestAccResourceVSphereDPMHostOverride_overrides p
TestAccResourceVSphereDPMHostOverride_update p
TestAccResourceVSphereDRSVMOverride_drs p
TestAccResourceVSphereDRSVMOverride_automationLevel p
TestAccResourceVSphereDRSVMOverride_update p
TestAccResourcevsphereEntityPermissions_basic p
TestAccResourceVSphereFile_basic f
TestAccResourceVSphereFile_basicUploadAndCopy f
TestAccResourceVSphereFile_renamePostCreation f
TestAccResourceVSphereFile_uploadAndCopyAndUpdate f
TestAccResourceVSphereFolderMigrateState_basic p
TestAccResourceVSphereFolderMigrateState_empty p
TestAccResourceVSphereFolder_vmFolder p
TestAccResourceVSphereFolder_datastoreFolder p
TestAccResourceVSphereFolder_networkFolder p
TestAccResourceVSphereFolder_hostFolder p
TestAccResourceVSphereFolder_datacenterFolder p
TestAccResourceVSphereFolder_rename p
TestAccResourceVSphereFolder_subfolder p
TestAccResourceVSphereFolder_moveToSubfolder p
TestAccResourceVSphereFolder_tags p
TestAccResourceVSphereFolder_modifyTags p
TestAccResourceVSphereFolder_modifyTagsMultiStage p
TestAccResourceVSphereFolder_customAttributes p
TestAccResourceVSphereFolder_modifyCustomAttributes p
TestAccResourceVSphereFolder_removeAllCustomAttributes p
TestAccResourceVSphereFolder_preventDeleteIfNotEmpty p
TestAccResourceVSphereHAVMOverride_basic p
TestAccResourceVSphereHAVMOverride_complete p
TestAccResourceVSphereHAVMOverride_update p
TestAccResourceVSphereHostPortGroup_basic f
TestAccResourceVSphereHostPortGroup_complexWithOverrides f
TestAccResourceVSphereHostPortGroup_basicToComplex f
TestAccResourceVSphereHost_basic s
TestAccResourceVSphereHost_rootFolder s
TestAccResourceVSphereHost_connection s
TestAccResourceVSphereHost_maintenance s
TestAccResourceVSphereHost_lockdown s
TestAccResourceVSphereHost_lockdown_invalid s
TestAccResourceVSphereHost_emptyLicense s
TestAccResourceVSphereHostVirtualSwitch_basic f
TestAccResourceVSphereHostVirtualSwitch_removeNIC f
TestAccResourceVSphereHostVirtualSwitch_noNICs p
TestAccResourceVSphereHostVirtualSwitch_badActiveNICList p
TestAccResourceVSphereHostVirtualSwitch_badStandbyNICList p
TestAccResourceVSphereHostVirtualSwitch_removeAllNICs f
TestAccResourceVSphereLicense_basic f
TestAccResourceVSphereLicense_invalid p
TestAccResourceVSphereLicense_withLabelsOnVCenter f
TestAccResourceVSphereLicense_withLabelsOnESXiServer s
TestAccResourceVSphereNasDatastore_basic p
TestAccResourceVSphereNasDatastore_multiHost f
TestAccResourceVSphereNasDatastore_basicToMultiHost f
TestAccResourceVSphereNasDatastore_multiHostToBasic f
TestAccResourceVSphereNasDatastore_renameDatastore p
TestAccResourceVSphereNasDatastore_inFolder p
TestAccResourceVSphereNasDatastore_moveToFolder p
TestAccResourceVSphereNasDatastore_inDatastoreCluster p
TestAccResourceVSphereNasDatastore_moveToDatastoreCluster p
TestAccResourceVSphereNasDatastore_singleTag p
TestAccResourceVSphereNasDatastore_modifyTags p
TestAccResourceVSphereNasDatastore_singleCustomAttribute p
TestAccResourceVSphereNasDatastore_multiCustomAttribute p
TestAccResourceVSphereResourcePool_basic p
TestAccResourceVSphereResourcePool_updateRename p
TestAccResourceVSphereResourcePool_updateToCustom p
TestAccResourceVSphereResourcePool_updateToDefaults p
TestAccResourceVSphereResourcePool_esxiHost p
TestAccResourceVSphereResourcePool_updateParent p
TestAccResourceVSphereResourcePool_tags p
TestAccResourceVsphereRole_createRole p
TestAccResourceVsphereRole_addPrivileges p
TestAccResourceVsphereRole_removePrivileges p
TestAccResourceVsphereRole_importSystemRoleShouldError p
TestAccResourceVSphereStorageDrsVMOverride_basic p
TestAccResourceVSphereStorageDrsVMOverride_overrides p
TestAccResourceVSphereStorageDrsVMOverride_update p
TestAccResourceVSphereTagCategory_basic p
TestAccResourceVSphereTagCategory_addType p
TestAccResourceVSphereTagCategory_removeTypeShouldError p
TestAccResourceVSphereTagCategory_invalidTypeShouldError p
TestAccResourceVSphereTagCategory_rename p
TestAccResourceVSphereTagCategory_singleCardinality p
TestAccResourceVSphereTagCategory_multiCardinality p
TestAccResourceVSphereTag_basic p
TestAccResourceVSphereTag_changeName p
TestAccResourceVSphereTag_changeDescription p
TestAccResourceVSphereTag_detachAllTags p
TestAccResourceVSphereVAppContainer_basic p
TestAccResourceVSphereVAppContainer_childImport p
TestAccResourceVSphereVAppContainer_vmBasic p
TestAccResourceVSphereVAppContainer_vmMoveIntoVApp p
TestAccResourceVSphereVAppContainer_vmSDRS p
TestAccResourceVSphereVAppContainer_vmClone f
TestAccResourceVSphereVAppContainer_vmCloneSDRS f
TestAccResourceVSphereVAppContainer_vmMoveIntoVAppSDRS p
TestAccResourceVSphereVAppEntity_basic p
TestAccResourceVSphereVAppEntity_nonDefault p
TestAccResourceVSphereVAppEntity_update p
TestAccResourceVSphereVAppEntity_multi p
TestAccResourceVSphereVAppEntity_multiUpdate p
TestAccResourceVSphereVirtualDisk_basic p
TestAccResourceVSphereVirtualDisk_multi p
TestAccResourceVSphereVirtualDisk_multiWithParent p
TestAccResourceVSphereVirtualDisk_withParent p
TestVSphereVirtualMachine_migrateStateV1 p
TestAccResourceVSphereVirtualMachine_migrateStateV3_fromV2 p
TestAccResourceVSphereVirtualMachine_migrateStateV3FromV1 p
TestAccResourceVSphereVirtualMachine_migrateStateV2 p
TestComputeInstanceMigrateState_empty p
TestAccResourceVSphereVirtualMachineSnapshot_basic s
TestAccResourceVSphereVirtualMachine_basic p
TestAccResourceVSphereVirtualMachine_TestAccResourceVSphereVirtualMachine_hardwareVersionBare p
TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade p
TestAccResourceVSphereVirtualMachine_hardwareVersionInvalidVersion p
TestAccResourceVSphereVirtualMachine_hardwareVersionDowngrade p
TestAccResourceVSphereVirtualMachine_TestAccResourceVSphereVirtualMachine_hardwareVersionClone p
TestAccResourceVSphereVirtualMachineContentLibrary_basic f
TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue p
TestAccResourceVSphereVirtualMachine_highLatencySensitivity f
TestAccResourceVSphereVirtualMachine_ESXiOnly s
TestAccResourceVSphereVirtualMachine_shutdownOK p
TestAccResourceVSphereVirtualMachine_reCreateOnDeletion p
TestAccResourceVSphereVirtualMachine_multiDevice f
TestAccResourceVSphereVirtualMachine_addDevices f
TestAccResourceVSphereVirtualMachine_removeMiddleDevices f
TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit f
TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers f
TestAccResourceVSphereVirtualMachine_highDiskUnitInsufficientBus p
TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController f
TestAccResourceVSphereVirtualMachine_scsiBusSharing p
TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate p
TestAccResourceVSphereVirtualMachine_disksKeepOnRemove p
TestAccResourceVSphereVirtualMachine_cdromClientMapping p
TestAccResourceVSphereVirtualMachine_vAppIsoBasic f
TestAccResourceVSphereVirtualMachine_vAppIsoNoVApp p
TestAccResourceVSphereVirtualMachine_vAppIsoNoCdrom f
TestAccResourceVSphereVirtualMachine_vAppIsoConfigIsoIgnored f
TestAccResourceVSphereVirtualMachine_vAppIsoChangeCdromBacking f
TestAccResourceVSphereVirtualMachine_vAppIsoPoweredOffCdromRead f
TestAccResourceVSphereVirtualMachine_vvtdAndVbs p
TestAccResourceVSphereVirtualMachine_cdromNoParameters p
TestAccResourceVSphereVirtualMachine_cdromIsoBacking f
TestAccResourceVSphereVirtualMachine_cdromConflictingParameters p
TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs p
TestAccResourceVSphereVirtualMachine_upgradeCPUAndRam p
TestAccResourceVSphereVirtualMachine_modifyAnnotation p
TestAccResourceVSphereVirtualMachine_growDisk p
TestAccResourceVSphereVirtualMachine_swapSCSIBus p
TestAccResourceVSphereVirtualMachine_extraConfig p
TestAccResourceVSphereVirtualMachine_extraConfigSwapKeys p
TestAccResourceVSphereVirtualMachine_attachExistingVmdk p
TestAccResourceVSphereVirtualMachine_attachExistingVmdkTaint p
TestAccResourceVSphereVirtualMachine_resourcePoolMove p
TestAccResourceVSphereVirtualMachine_vAppContainerAndFolder p
TestAccResourceVSphereVirtualMachine_vAppContainerMove p
TestAccResourceVSphereVirtualMachine_inFolder p
TestAccResourceVSphereVirtualMachine_moveToFolder p
TestAccResourceVSphereVirtualMachine_staticMAC p
TestAccResourceVSphereVirtualMachine_singleTag p
TestAccResourceVSphereVirtualMachine_multipleTags p
TestAccResourceVSphereVirtualMachine_switchTags p
TestAccResourceVSphereVirtualMachine_renamedDiskInPlaceOfExisting p
TestAccResourceVSphereVirtualMachine_blockComputedDiskName f
TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClones p
TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClonesAfterCreation p
TestAccResourceVSphereVirtualMachine_blockDiskLabelStartingWithOrphanedPrefix p
TestAccResourceVSphereVirtualMachine_createIntoEmptyClusterNoEnvironmentBrowser p
TestAccResourceVSphereVirtualMachine_cloneFromTemplate p
TestAccResourceVSphereVirtualMachine_clonePoweredOn p
TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool f
TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore f
TestAccResourceVSphereVirtualMachine_cloneModifyDiskAndSCSITypeAtSameTime p
TestAccResourceVSphereVirtualMachine_cloneMultiNICFromSingleNICTemplate p
TestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone f
TestAccResourceVSphereVirtualMachine_cloneBlockESXi s
TestAccResourceVSphereVirtualMachine_cloneWithBadTimezone p
TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithLinkedClone p
TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithoutLinkedClone f
TestAccResourceVSphereVirtualMachine_cloneIntoEmptyCluster p
TestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname f
TestAccResourceVSphereVirtualMachine_cpuHotAdd p
TestAccResourceVSphereVirtualMachine_memoryHotAdd p
TestAccResourceVSphereVirtualMachine_dualStackIPv4AndIPv6 f
TestAccResourceVSphereVirtualMachine_hostCheck f
TestAccResourceVSphereVirtualMachine_hostVMotion f
TestAccResourceVSphereVirtualMachine_resourcePoolVMotion p
TestAccResourceVSphereVirtualMachine_storageVMotionGlobalSetting p
TestAccResourceVSphereVirtualMachine_storageVMotionSingleDisk p
TestAccResourceVSphereVirtualMachine_storageVMotionPinDatastore f
TestAccResourceVSphereVirtualMachine_storageVMotionRenamedVirtualMachine f
TestAccResourceVSphereVirtualMachine_storageVMotionLinkedClones f
TestAccResourceVSphereVirtualMachine_storageVMotionBlockExternallyAttachedDisks p
TestAccResourceVSphereVirtualMachine_singleCustomAttribute p
TestAccResourceVSphereVirtualMachine_multiCustomAttribute p
TestAccResourceVSphereVirtualMachine_switchCustomAttribute p
TestAccResourceVSphereVirtualMachine_multipleDisksAtDifferentSCSISlotsImport f
TestAccResourceVSphereVirtualMachine_cloneImport p
TestAccResourceVSphereVirtualMachine_interpolatedDisk p
TestAccResourceVSphereVirtualMachine_deployOvfFromUrl p
TestAccResourceVSphereVirtualMachine_deployOvaFromUrl p
TestAccResourceVMStoragePolicy_basic p
TestAccResourceVSphereVmfsDatastore_basic f
TestAccResourceVSphereVmfsDatastore_multiDisk f
TestAccResourceVSphereVmfsDatastore_discoveryViaDatasource f
TestAccResourceVSphereVmfsDatastore_addDisksThroughUpdate f
TestAccResourceVSphereVmfsDatastore_renameDatastore f
TestAccResourceVSphereVmfsDatastore_withFolder f
TestAccResourceVSphereVmfsDatastore_moveToFolderAfter f
TestAccResourceVSphereVmfsDatastore_withDatastoreCluster f
TestAccResourceVSphereVmfsDatastore_moveToDatastoreClusterAfter f
TestAccResourceVSphereVmfsDatastore_singleTag f
TestAccResourceVSphereVmfsDatastore_modifyTags f
TestAccResourceVSphereVmfsDatastore_badDiskEntry f
TestAccResourceVSphereVmfsDatastore_duplicateDiskEntry f
TestAccResourceVSphereVmfsDatastore_singleCustomAttribute f
TestAccResourceVSphereVmfsDatastore_multiCustomAttribute f
TestAccResourceVSphereVNic_dvs f
TestAccResourceVSphereVNic_dvs_vmotion f
TestAccResourceVSphereVNic_hvs f
TestAccResourceVSphereVNic_hvs_vmotion f
TestParseVersion p
TestCompareVersion p
TestAtLeast p
TestDatastorePathFromString p
TestIsVmdkDatastorePath p
TestDstDataStorePathFromLocalSrc p
TestDiskCapacityInGiB p
TestNicUnitRange p
```