### PR TITLE
docs: update `r/vsphere_host`

### DIFF
--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
   be added to. This should not be set if `cluster` is set.
 * `cluster` - (Optional) The ID of the Compute Cluster this host should
   be added to. This should not be set if `datacenter` is set. Conflicts with:
-  `cluster`.
+  `cluster_managed`.
 * `cluster_managed` - (Optional) Can be set to `true` if compute cluster
   membership will be managed through the `compute_cluster` resource rather
   than the`host` resource. Conflicts with: `cluster`.


### PR DESCRIPTION
### Description

Updates the argument reference for `cluster` to correctly note that it conflicts with `cluster_managed`.

### References

Ref: #1850