### PR TITLE
fix: vnic tests

### DIFF
--- a/acctests/README.md
+++ b/acctests/README.md
@@ -63,9 +63,9 @@ $ source devrc
 This set of environment variables and setup should allow you to run most of the acceptance tests, current failing ones or ones skipped due to missing or misconfigured environment variables will be addressed ASAP (unfortunately there had been a large amount of technical debt built up around testing).
 
 ### Please Note
-As for writing a few manual steps had to be taken to privately network the nested ESXis and add them to vSphere.
+As for writing a few manual steps had to be taken to privately network the nested ESXis and add them to vSphere. You will need to let the first apply fail, then perform the steps and re-apply.
 
-1. Delete vmk1 and manually recreate it attached to the new vSwitch (which runs on vmnic1)
+1. Delete vmk1 and manually recreate it attached to the new vSwitch (which runs on vmnic1), give it an IP on the private subnet
 2. Visit the physical ESXi web UI (likely the vCenter IP - 1) and power off the vcsa VM
 3. Attach vmnet to the vcsa VM
 4. Power on the vcsa VM

--- a/acctests/vsphere/for-acceptance-tests.tf
+++ b/acctests/vsphere/for-acceptance-tests.tf
@@ -29,11 +29,11 @@ resource "vsphere_resource_pool" "pool" {
 }
 
 resource "vsphere_nas_datastore" "ds" {
-  name = var.VSPHERE_NFS_DS_NAME
+  name            = var.VSPHERE_NFS_DS_NAME
   host_system_ids = [vsphere_host.host1.id] // TODO: needs to be networked privately for nested ESXIs to connect to it
-  type         = "NFS"
-  remote_hosts = [var.VSPHERE_NAS_HOST]
-  remote_path  = "/nfs"
+  type            = "NFS"
+  remote_hosts    = [var.VSPHERE_NAS_HOST]
+  remote_path     = "/nfs"
 }
 
 resource "vsphere_virtual_machine" "template" {

--- a/acctests/vsphere/nested-esxi-template.tf
+++ b/acctests/vsphere/nested-esxi-template.tf
@@ -27,7 +27,7 @@ resource "vsphere_vmfs_datastore" "nested-esxi" {
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
-  name           = "terraform-test" #
+  name           = "terraform-test"
   host_system_id = vsphere_host.host1.id
 
   network_adapters = [var.VSPHERE_ESXI_TRUNK_NIC]
@@ -62,5 +62,6 @@ data "vsphere_ovf_vm_template" "nested-esxi" {
   remote_ovf_url    = "https://download3.vmware.com/software/vmw-tools/nested-esxi/Nested_ESXi7.0u3_Appliance_Template_v1.ova"
   ovf_network_map = {
     "${vsphere_host_port_group.pg.name}" = data.vsphere_network.pg.id
+    "VM Network" = data.vsphere_network.pg.id # second NIC for testing
   }
 }

--- a/acctests/vsphere/nested-esxi-template.tf
+++ b/acctests/vsphere/nested-esxi-template.tf
@@ -62,6 +62,6 @@ data "vsphere_ovf_vm_template" "nested-esxi" {
   remote_ovf_url    = "https://download3.vmware.com/software/vmw-tools/nested-esxi/Nested_ESXi7.0u3_Appliance_Template_v1.ova"
   ovf_network_map = {
     "${vsphere_host_port_group.pg.name}" = data.vsphere_network.pg.id
-    "VM Network" = data.vsphere_network.pg.id # second NIC for testing
+    "VM Network"                         = data.vsphere_network.pg.id # second NIC for testing
   }
 }


### PR DESCRIPTION
### Description
Fix VNIC tests to work with new nested ESXi model. This is so I can review/add tests to #1855 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccResourceVSphereVNic_'
=== RUN   TestAccResourceVSphereVNic_dvs_default
--- PASS: TestAccResourceVSphereVNic_dvs_default (196.88s)
=== RUN   TestAccResourceVSphereVNic_dvs_vmotion
--- PASS: TestAccResourceVSphereVNic_dvs_vmotion (196.36s)
=== RUN   TestAccResourceVSphereVNic_hvs_default
--- PASS: TestAccResourceVSphereVNic_hvs_default (33.19s)
=== RUN   TestAccResourceVSphereVNic_hvs_vmotion
--- PASS: TestAccResourceVSphereVNic_hvs_vmotion (32.19s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/vsphere_vnic: Fix vnic tests GH-1887
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
