### PR TITLE
chore(gh): pin actions to commit hash

### DIFF
--- a/.github/workflows/issue_greeting.yml
+++ b/.github/workflows/issue_greeting.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 1
       - name: Render Template
         id: template
-        uses: chuhlomin/render-template@v1.6 # TSCCR: no entry for repository "chuhlomin/render-template"
+        uses: chuhlomin/render-template@204ce622bc2fd5c787ff5ca885ff19fb577e7a41 # v1.6
         with:
           template: .github/issue_greeting_template.md
           vars: |

--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -12,7 +12,7 @@ jobs:
   Comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: bflad/action-milestone-comment@v1 # TSCCR: no entry for repository "bflad/action-milestone-comment"
+      - uses: bflad/action-milestone-comment@ae6c9fdf5778064d4e09b4632604a16b7289096c # v1.0.2
         with:
           body: |
             This functionality has been released in [${{ github.event.milestone.title }} of the Terraform Provider](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).  Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v8 # TSCCR: no entry for repository "actions/stale"
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           days-before-stale: 180


### PR DESCRIPTION
### Description

Pin remaining GitHub Actions to a commit hash.

### References

Code Scanning:

- https://github.com/hashicorp/terraform-provider-vsphere/security/code-scanning/43
- https://github.com/hashicorp/terraform-provider-vsphere/security/code-scanning/38
- https://github.com/hashicorp/terraform-provider-vsphere/security/code-scanning/34

