### PR TITLE
Update issue-comment-created.yml to not use `actions-ecosystem/action-remove-labels`

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -8,11 +8,11 @@ jobs:
   issue_comment_triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
+      - id: remove-stale
+        uses: ./.github/workflows/remove-issue-label.yml
         with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          labels: stale
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
+          label-name: "stale"
+      - id: remove-waiting-response
+        uses: ./.github/workflows/remove-issue-label.yml
         with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          labels: waiting-response
+          label-name: "waiting-response"

--- a/.github/workflows/remove-issue-label.yml
+++ b/.github/workflows/remove-issue-label.yml
@@ -1,0 +1,52 @@
+name: Remove specified label from issue
+
+on:
+  # This file is reused, and called from other workflows
+  workflow_call:
+      inputs:
+        label-name:
+          required: true
+          type: string
+
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        env:
+          REMOVE_LABEL: ${{ inputs.label-name }}
+        with:
+          script: |
+            const { REMOVE_LABEL } = process.env
+            console.log(`Attempting to remove label "${REMOVE_LABEL}"`)
+            
+            const { data } = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            
+            // Return early if there are no labels
+            if (data.length == 0){
+              console.log(`Issue has no labels; not attempting to remove label "${REMOVE_LABEL}"`)
+              return
+            }
+            
+            // Check if REMOVE_LABEL is present
+            const filteredData = data.filter(label => label.name == REMOVE_LABEL)
+            
+            // Return early if filtering didn't identify the label as present
+            if (filteredData.length == 0){
+              console.log(`Label "${REMOVE_LABEL}" not found on issue; not attempting to remove it.`)
+              return
+            }
+
+            console.log(`Label "${REMOVE_LABEL}" found! Now deleting it from the issue...`)
+
+            await github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: REMOVE_LABEL
+            })


### PR DESCRIPTION
### Description

Closes https://github.com/hashicorp/terraform-provider-vsphere/issues/1906

The actions-ecosystem/action-remove-labels GHA is not maintained and will stop working when GitHub stops supporting use of Node12.

This PR uses a different GHA to edit labels on an issue in response to a comment. 
It can handle:
- The issue having no labels
- The targeted label being present on the issue
- The targeted label NOT being present on the issue

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

Not applicable

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

- The action we're moving away from has not addressed this issue: https://github.com/actions-ecosystem/action-remove-labels/issues/413
