### PR TITLE
Refactor acctest config to use a virtualized NFS.

### DIFF
--- a/acctests/README.md
+++ b/acctests/README.md
@@ -63,15 +63,14 @@ $ source devrc
 This set of environment variables and setup should allow you to run most of the acceptance tests, current failing ones or ones skipped due to missing or misconfigured environment variables will be addressed ASAP (unfortunately there had been a large amount of technical debt built up around testing).
 
 ### Please Note
-As for writing a few manual steps had to be taken to privately network the nested ESXis and add them to vSphere. You will need to let the first apply fail, then perform the steps and re-apply.
+A few manual steps had to be taken to privately network the nested ESXis and add them to vSphere. You will need to cancel the null_resource provisioner that SSH's into the primary host to retrieve the thumbprints of the nested VMs with `CTRL + C` (it will hang or timeout as the vCenter VM cannot communicate on that network yet).
 
-1. Delete vmk1 and manually recreate it attached to the new vSwitch (which runs on vmnic1), give it an IP on the private subnet
+1. Delete vmk1 and manually recreate it attached to the new vSwitch created by terraform (which runs on vmnic1), give it an IP on the private network (assuming 3 nested ESXIs were created, use the 5th address).
 2. Visit the physical ESXi web UI (likely the vCenter IP - 1) and power off the vcsa VM
 3. Attach vmnet to the vcsa VM
 4. Power on the vcsa VM
 5. Visit the vCenter IP again, but this time port :5480
-6. In the networking tab give it a valid IP on the private subnet the ESXi VMs run on
-7. In vCenter manually create a snapshot of the template VM (this should be easy to capture in config going forward)
+6. In the networking tab give it a valid IP on the private network (assuming 3 nested ESXIs were created, use the 6th address).
 
 ## Running tests
 Tests can be ran via regexp pattern, generally advisable to run them individually or by resource type. It's common practice to have resource tests contain an underscore in their name to make the whole suite of tests for the resource run.

--- a/acctests/equinix/devrc.tpl
+++ b/acctests/equinix/devrc.tpl
@@ -1,11 +1,11 @@
-export TF_VAR_VSPHERE_NAS_HOST=${nas_host}
 export TF_VAR_VSPHERE_ESXI1=${esxi_host_1}
 export TF_VAR_VSPHERE_ESXI1_PW='${esxi_host_1_pw}'
 export VSPHERE_SERVER=${vsphere_host}
+export TF_VAR_VSPHERE_PUBLIC_NETWORK='${public_network}'
 export TF_VAR_VSPHERE_PRIVATE_NETWORK='${private_network}'
 
-export VSPHERE_USER="administrator@vcenter.test.local"
-export VSPHERE_PASSWORD="Password123!"
+export VSPHERE_USER='${admin_user}'
+export VSPHERE_PASSWORD='${admin_password}'
 export VSPHERE_ALLOW_UNVERIFIED_SSL=true
 
 export TF_VAR_VSPHERE_SERVER=$VSPHERE_SERVER

--- a/acctests/equinix/versions.tf
+++ b/acctests/equinix/versions.tf
@@ -12,6 +12,9 @@ terraform {
     time = {
       source = "hashicorp/time"
     }
+    random = {
+      source = "hashicorp/random"
+    }
   }
   required_version = ">= 0.13"
 }

--- a/acctests/vsphere/deploy-nested-esxi.tf
+++ b/acctests/vsphere/deploy-nested-esxi.tf
@@ -5,6 +5,10 @@ variable "NESTED_COUNT" {
   default = 3
 }
 
+variable "DOMAIN" {
+  default = "test.local"
+}
+
 variable "VSPHERE_PRIVATE_NETWORK" {}
 
 variable "PRIV_KEY" {}
@@ -44,12 +48,12 @@ resource "vsphere_virtual_machine" "nested-esxi" {
 
   vapp {
     properties = {
-      "guestinfo.hostname"   = "nested-${count.index + 1}.test.local",
-      "guestinfo.ipaddress"  = cidrhost(var.VSPHERE_PRIVATE_NETWORK, count.index + 3),
+      "guestinfo.hostname"   = "nested-${count.index + 1}.${var.DOMAIN}",
+      "guestinfo.ipaddress"  = cidrhost(var.VSPHERE_PRIVATE_NETWORK, count.index + 2),
       "guestinfo.netmask"    = "255.255.255.248",
       "guestinfo.gateway"    = cidrhost(var.VSPHERE_PRIVATE_NETWORK, 1),
       "guestinfo.dns"        = cidrhost(var.VSPHERE_PRIVATE_NETWORK, 1),
-      "guestinfo.domain"     = "test.local",
+      "guestinfo.domain"     = var.DOMAIN,
       "guestinfo.ntp"        = cidrhost(var.VSPHERE_PRIVATE_NETWORK, 1),
       "guestinfo.ssh"        = "True",
       "guestinfo.password"   = "VMware1!",

--- a/acctests/vsphere/deploy-nfs.tf
+++ b/acctests/vsphere/deploy-nfs.tf
@@ -1,0 +1,80 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "VSPHERE_NFS_DS_NAME" {
+  default = "nfs"
+}
+
+variable "VSPHERE_PUBLIC_NETWORK" {}
+
+locals {
+  vsphere_nas_host = cidrhost(var.VSPHERE_PUBLIC_NETWORK, 4)
+}
+
+resource "vsphere_virtual_machine" "nfs" {
+  name                 = var.VSPHERE_NFS_DS_NAME
+  datacenter_id        = vsphere_datacenter.dc.moid
+  datastore_id         = data.vsphere_ovf_vm_template.ubuntu.datastore_id
+  host_system_id       = data.vsphere_ovf_vm_template.ubuntu.host_system_id
+  resource_pool_id     = data.vsphere_ovf_vm_template.ubuntu.resource_pool_id
+  num_cpus             = data.vsphere_ovf_vm_template.ubuntu.num_cpus
+  num_cores_per_socket = data.vsphere_ovf_vm_template.ubuntu.num_cores_per_socket
+  memory               = data.vsphere_ovf_vm_template.ubuntu.memory
+  guest_id             = data.vsphere_ovf_vm_template.ubuntu.guest_id
+  firmware             = data.vsphere_ovf_vm_template.ubuntu.firmware
+  scsi_type            = data.vsphere_ovf_vm_template.ubuntu.scsi_type
+  nested_hv_enabled    = data.vsphere_ovf_vm_template.ubuntu.nested_hv_enabled
+
+  dynamic "network_interface" {
+    for_each = data.vsphere_ovf_vm_template.ubuntu.ovf_network_map
+    content {
+      network_id = network_interface.value
+    }
+  }
+
+  wait_for_guest_net_timeout = 0
+  wait_for_guest_ip_timeout  = 0
+
+  ovf_deploy {
+    allow_unverified_ssl_cert = false
+    remote_ovf_url            = data.vsphere_ovf_vm_template.ubuntu.remote_ovf_url
+    disk_provisioning         = data.vsphere_ovf_vm_template.ubuntu.disk_provisioning
+    ovf_network_map           = data.vsphere_ovf_vm_template.ubuntu.ovf_network_map
+  }
+
+  cdrom {
+    client_device = true
+  }
+
+  vapp {
+    properties = {
+      "instance-id" = var.VSPHERE_NFS_DS_NAME
+      "hostname"    = var.VSPHERE_NFS_DS_NAME
+      "password"    = "ubuntu"
+      "user-data" = base64encode(
+        templatefile("${path.module}/nfs-cloud-config.yaml.tpl",
+          {
+            ip      = local.vsphere_nas_host
+            gateway = cidrhost(var.VSPHERE_PUBLIC_NETWORK, 1)
+          }
+        )
+      )
+    }
+  }
+}
+
+resource "time_sleep" "wait_180_seconds_nfs" {
+  depends_on = [vsphere_virtual_machine.nfs]
+
+  create_duration = "180s"
+}
+
+resource "vsphere_nas_datastore" "ds" {
+  depends_on = [time_sleep.wait_180_seconds_nfs]
+
+  name            = var.VSPHERE_NFS_DS_NAME
+  host_system_ids = [vsphere_host.host1.id] // TODO: needs to be networked privately for nested ESXIs to connect to it
+  type            = "NFS"
+  remote_hosts    = [local.vsphere_nas_host]
+  remote_path     = "/nfs"
+}

--- a/acctests/vsphere/devrc.tpl
+++ b/acctests/vsphere/devrc.tpl
@@ -1,7 +1,3 @@
-export VSPHERE_REST_SESSION_PATH=$HOME/.govmomi/rest_sessions
-export VSPHERE_VIM_SESSION_PATH=$HOME/.govmomi/sessions
-export VSPHERE_PERSIST_SESSION=true
-
 export TF_VAR_VSPHERE_ESXI2=${esxi_host_2}
 export TF_VAR_VSPHERE_ESXI3=${esxi_host_3}
 export TF_VAR_VSPHERE_ESXI4=${esxi_host_4}
@@ -17,3 +13,4 @@ export TF_VAR_VSPHERE_TEMPLATE=${template}
 export TF_VAR_VSPHERE_TEST_OVF=${test_ovf}
 export TF_VAR_VSPHERE_VM_V1_PATH=${vm_name}
 export TF_VAR_VSPHERE_ESXI_TRUNK_NIC=${trunk_nic}
+export TF_VAR_VSPHERE_NAS_HOST=${nas_host}

--- a/acctests/vsphere/for-acceptance-tests.tf
+++ b/acctests/vsphere/for-acceptance-tests.tf
@@ -5,12 +5,6 @@ variable "VSPHERE_RESOURCE_POOL" {
   default = "hashi-resource-pool"
 }
 
-variable "VSPHERE_NFS_DS_NAME" {
-  default = "nfs"
-}
-
-variable "VSPHERE_NAS_HOST" {}
-
 variable "VSPHERE_TEMPLATE" {
   default = "tfvsphere_template"
 }
@@ -23,17 +17,19 @@ variable "VSPHERE_VM_V1_PATH" {
   default = "pxe-server"
 }
 
+variable "VSPHERE_VMFS_REGEXP" {
+  default = "naa."
+}
+
+data "vsphere_vmfs_disks" "available" {
+  host_system_id = vsphere_host.host1.id
+  rescan         = true
+  filter         = var.VSPHERE_VMFS_REGEXP
+}
+
 resource "vsphere_resource_pool" "pool" {
   name                    = var.VSPHERE_RESOURCE_POOL
   parent_resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
-}
-
-resource "vsphere_nas_datastore" "ds" {
-  name            = var.VSPHERE_NFS_DS_NAME
-  host_system_ids = [vsphere_host.host1.id] // TODO: needs to be networked privately for nested ESXIs to connect to it
-  type            = "NFS"
-  remote_hosts    = [var.VSPHERE_NAS_HOST]
-  remote_path     = "/nfs"
 }
 
 resource "vsphere_virtual_machine" "template" {

--- a/acctests/vsphere/main.tf
+++ b/acctests/vsphere/main.tf
@@ -51,3 +51,13 @@ resource "vsphere_host" "host1" {
   cluster    = vsphere_compute_cluster.compute_cluster.id
   thumbprint = data.vsphere_host_thumbprint.esxi1.id
 }
+
+data "vsphere_network" "public" {
+  name          = "VM Network"
+  datacenter_id = vsphere_datacenter.dc.moid
+}
+
+data "vsphere_datastore" "datastore1" {
+  name          = "datastore1"
+  datacenter_id = vsphere_datacenter.dc.moid
+}

--- a/acctests/vsphere/nested-esxi-template.tf
+++ b/acctests/vsphere/nested-esxi-template.tf
@@ -9,23 +9,6 @@ variable "VSPHERE_PG_NAME" {
   default = "vmnet"
 }
 
-variable "VSPHERE_VMFS_REGEXP" {
-  default = "naa."
-}
-
-data "vsphere_vmfs_disks" "available" {
-  host_system_id = vsphere_host.host1.id
-  rescan         = true
-  filter         = var.VSPHERE_VMFS_REGEXP
-}
-
-# TODO: use datastore1 instead for nested esxi VMs
-resource "vsphere_vmfs_datastore" "nested-esxi" {
-  name           = "nested-esxi"
-  host_system_id = vsphere_host.host1.id
-  disks          = data.vsphere_vmfs_disks.available.disks
-}
-
 resource "vsphere_host_virtual_switch" "switch" {
   name           = "terraform-test"
   host_system_id = vsphere_host.host1.id
@@ -57,7 +40,7 @@ data "vsphere_ovf_vm_template" "nested-esxi" {
   name              = "Nested-ESXi-7.0"
   disk_provisioning = "thin"
   resource_pool_id  = vsphere_compute_cluster.compute_cluster.resource_pool_id
-  datastore_id      = vsphere_vmfs_datastore.nested-esxi.id
+  datastore_id      = data.vsphere_datastore.datastore1.id
   host_system_id    = vsphere_host.host1.id
   remote_ovf_url    = "https://download3.vmware.com/software/vmw-tools/nested-esxi/Nested_ESXi7.0u3_Appliance_Template_v1.ova"
   ovf_network_map = {

--- a/acctests/vsphere/nfs-cloud-config.yaml.tpl
+++ b/acctests/vsphere/nfs-cloud-config.yaml.tpl
@@ -1,0 +1,27 @@
+#cloud-config
+
+write_files:
+  - path: /etc/netplan/01-netcfg.yaml
+    content: |
+      network:
+        version: 2
+        renderer: networkd
+        ethernets:
+          ens192:
+            dhcp4: no
+            addresses: [${ip}/29]
+            gateway4: ${gateway}
+            nameservers:
+              addresses: [8.8.8.8, 8.8.4.4]
+
+runcmd:
+  - netplan apply
+  # internet should now be available
+  - mkdir -p /nfs/ds1 /nfs/ds2 /nfs/ds3
+  - apt-get update
+  - apt-get install nfs-kernel-server -y
+  - echo "/nfs *(rw,no_root_squash)" > /etc/exports
+  - echo "/nfs/ds1 *(rw,no_root_squash)" >> /etc/exports
+  - echo "/nfs/ds2 *(rw,no_root_squash)" >> /etc/exports
+  - echo "/nfs/ds3 *(rw,no_root_squash)" >> /etc/exports
+  - exportfs -a

--- a/acctests/vsphere/output.tf
+++ b/acctests/vsphere/output.tf
@@ -18,6 +18,7 @@ resource "local_sensitive_file" "devrc" {
     test_ovf      = vsphere_virtual_machine.template.ovf_deploy[0].remote_ovf_url
     vm_name       = vsphere_virtual_machine.pxe.name
     trunk_nic     = vsphere_host_virtual_switch.switch.network_adapters[0]
+    nas_host      = local.vsphere_nas_host
   })
   filename = "./devrc"
 }

--- a/acctests/vsphere/ubuntu-template.tf
+++ b/acctests/vsphere/ubuntu-template.tf
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "vsphere_ovf_vm_template" "ubuntu" {
+  name              = "ubuntu"
+  disk_provisioning = "thin"
+  resource_pool_id  = vsphere_compute_cluster.compute_cluster.resource_pool_id
+  datastore_id      = data.vsphere_datastore.datastore1.id
+  host_system_id    = vsphere_host.host1.id
+  remote_ovf_url    = "https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova"
+  ovf_network_map = {
+    "VM Network" = data.vsphere_network.public.id
+  }
+}


### PR DESCRIPTION
This PR further streamlines the config of the acceptance tests to use a virtualized NFS. I also randomly generate the vCenter password. The coming CI will likely run against a public facing instance.