### PR TITLE
fix: add version check for vsan hci mesh

### DIFF
--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -1385,7 +1385,7 @@ func resourceVSphereComputeClusterFlattenData(
 		d.Set("vsan_dit_rekey_interval", 0)
 	}
 
-	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 1}) {
+	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 0, Patch: 1}) {
 		var dsIDs []string
 		if vsanConfig.DatastoreConfig != nil {
 			for _, ds := range vsanConfig.DatastoreConfig.(*vsantypes.VsanAdvancedDatastoreConfig).RemoteDatastores {

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -1505,7 +1505,7 @@ func resourceVSphereComputeClusterApplyVsanConfig(d *schema.ResourceData, meta i
 	}
 
 	// handle remote datastore/HCI Mesh in a separate call
-	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 1}) {
+	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 0, Patch: 1}) {
 		datastoreConfig, err := expandVsanDatastoreConfig(d, meta)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Add version check before handling vSAN HCI Mesh, since this feature is supported in 70U1 or later.

Test Result:


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:
End-to-end test on vSphere 7.0 with only vSAN enabled. Configuration won't be failed anymore.
```
$ terraform apply
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 0s [id=datacenter-3]
vsphere_compute_cluster.cluster: Refreshing state... [id=domain-c45]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_compute_cluster.cluster will be created
  + resource "vsphere_compute_cluster" "cluster" {
      + datacenter_id                                         = "datacenter-3"
      + dpm_automation_level                                  = "manual"
      + dpm_enabled                                           = false
      + dpm_threshold                                         = 3
      + drs_automation_level                                  = "manual"
      + drs_enable_vm_overrides                               = true
      + drs_enabled                                           = false
      + drs_migration_threshold                               = 3
      + drs_scale_descendants_shares                          = "disabled"
      + ha_admission_control_host_failure_tolerance           = 1
      + ha_admission_control_performance_tolerance            = 100
      + ha_admission_control_policy                           = "resourcePercentage"
      + ha_admission_control_resource_percentage_auto_compute = true
      + ha_admission_control_resource_percentage_cpu          = 100
      + ha_admission_control_resource_percentage_memory       = 100
      + ha_admission_control_slot_policy_explicit_cpu         = 32
      + ha_admission_control_slot_policy_explicit_memory      = 100
      + ha_datastore_apd_recovery_action                      = "none"
      + ha_datastore_apd_response                             = "disabled"
      + ha_datastore_apd_response_delay                       = 180
      + ha_datastore_pdl_response                             = "disabled"
      + ha_enabled                                            = false
      + ha_heartbeat_datastore_policy                         = "allFeasibleDsWithUserPreference"
      + ha_host_isolation_response                            = "none"
      + ha_host_monitoring                                    = "enabled"
      + ha_vm_component_protection                            = "enabled"
      + ha_vm_dependency_restart_condition                    = "none"
      + ha_vm_failure_interval                                = 30
      + ha_vm_maximum_failure_window                          = -1
      + ha_vm_maximum_resets                                  = 3
      + ha_vm_minimum_uptime                                  = 120
      + ha_vm_monitoring                                      = "vmMonitoringDisabled"
      + ha_vm_restart_priority                                = "medium"
      + ha_vm_restart_timeout                                 = 600
      + host_cluster_exit_timeout                             = 3600
      + id                                                    = (known after apply)
      + name                                                  = "test"
      + proactive_ha_automation_level                         = "Manual"
      + proactive_ha_moderate_remediation                     = "QuarantineMode"
      + proactive_ha_severe_remediation                       = "QuarantineMode"
      + resource_pool_id                                      = (known after apply)
      + vsan_compression_enabled                              = false
      + vsan_dedup_enabled                                    = false
      + vsan_dit_encryption_enabled                           = false
      + vsan_dit_rekey_interval                               = (known after apply)
      + vsan_enabled                                          = true
      + vsan_network_diagnostic_mode_enabled                  = false
      + vsan_performance_enabled                              = false
      + vsan_stretched_cluster_enabled                        = false
      + vsan_unmap_enabled                                    = false
      + vsan_verbose_mode_enabled                             = false
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

vsphere_compute_cluster.cluster: Creating...
vsphere_compute_cluster.cluster: Creation complete after 7s [id=domain-c47]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```markdown
BUG FIXES:

`r/vsphere_compute_cluster`:  Added version check for [vSphere 7.0.1 or later](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vsan.doc/GUID-9113BBD6-5428-4287-9F61-C8C3EE51E07E.html) when enabling vSAN HCI Mesh. ([#1931](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1931))
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
Closes #1925
