### PR TITLE
fix: set vSAN client with the current version of the service en…

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -205,7 +205,9 @@ func (c *Config) Client() (*Client, error) {
 	}
 
 	if isEligibleVSANEndpoint(client.vimClient) {
-		client.vimClient.UseServiceVersion("vsan")
+		if err := client.vimClient.UseServiceVersion("vsan"); err != nil {
+			return nil, err
+		}
 		vc, err := vsan.NewClient(ctx, client.vimClient.Client)
 		if err != nil {
 			return nil, err

--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -205,10 +205,12 @@ func (c *Config) Client() (*Client, error) {
 	}
 
 	if isEligibleVSANEndpoint(client.vimClient) {
+		client.vimClient.UseServiceVersion("vsan")
 		vc, err := vsan.NewClient(ctx, client.vimClient.Client)
 		if err != nil {
 			return nil, err
 		}
+		vc.Version = client.vimClient.Version
 		client.vsanClient = vc
 	} else {
 		log.Printf("[DEBUG] Connected endpoint does not support vSAN service")


### PR DESCRIPTION

### Description
Currently the vSAN client created in provider uses reserved version, but it's a best practice to set it as the current version of the service endpoint. Since whatever version of customer's env, 7.0 or 8.0, the compatibility of each vSAN API should be guaranteed by provider side.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References
https://github.com/hashicorp/terraform-provider-vsphere/issues/1933

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
