### PR TITLE
Revert "fix: set vSAN client with the current version of the service en…"

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -205,9 +205,7 @@ func (c *Config) Client() (*Client, error) {
 	}
 
 	if isEligibleVSANEndpoint(client.vimClient) {
-		if err := client.vimClient.UseServiceVersion("vsan"); err != nil {
-			return nil, err
-		}
+		client.vimClient.UseServiceVersion("vsan")
 		vc, err := vsan.NewClient(ctx, client.vimClient.Client)
 		if err != nil {
 			return nil, err

--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -205,12 +205,10 @@ func (c *Config) Client() (*Client, error) {
 	}
 
 	if isEligibleVSANEndpoint(client.vimClient) {
-		client.vimClient.UseServiceVersion("vsan")
 		vc, err := vsan.NewClient(ctx, client.vimClient.Client)
 		if err != nil {
 			return nil, err
 		}
-		vc.Version = client.vimClient.Version
 		client.vsanClient = vc
 	} else {
 		log.Printf("[DEBUG] Connected endpoint does not support vSAN service")


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-vsphere#1955

Well +1 for CI. Unfortunately this change seems to do something very mutative to the client? It seems to cause many "diffs" in testing across several resources. Perhaps forcing certain backend values that are falling out of sync with Terraform?

Ex:
```
=== RUN   TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter
    data_source_vsphere_compute_cluster_test.go:42: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
         <= read (data resources)

        Terraform will perform the following actions:

          # data.vsphere_compute_cluster.compute_cluster_data will be read during apply
          # (depends on a resource or a module with changes pending)
         <= data "vsphere_compute_cluster" "compute_cluster_data" {
              + id               = (known after apply)
              + name             = "/hashidc/host/testacc-datastore-cluster"
              + resource_pool_id = (known after apply)
            }

          # vsphere_compute_cluster.compute_cluster will be updated in-place
          ~ resource "vsphere_compute_cluster" "compute_cluster" {
              + drs_scale_descendants_shares                          = "disabled"
                id                                                    = "domain-c7300"
                name                                                  = "testacc-datastore-cluster"
                # (50 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter (28.07s)
```

Specifically I've seen something around ` + drs_scale_descendants_shares                          = "disabled"` a few times. Perhaps there needs to be some massaging of that attribute specifically on resource pool/computer cluster resources?
cc @zxinyu08 