### PR TITLE
chore: Store CI log

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -76,6 +76,13 @@ jobs:
           set -euo pipefail
           TF_ACC=1 go test -json -v ./... -timeout 360m 2>&1 | tee /tmp/gotest.log | gotestfmt
 
+      - name: Upload test log
+        uses: actions/upload-artifact@v0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: always()
+        with:
+          name: test-log
+          path: /tmp/gotest.log
+
       - name: Cleanup testrun resources
         if: always()
         run: |


### PR DESCRIPTION
The pretty test printing does not provide summary data or comparison data to previous runs. Store the testlog as an artifact for further processing.