### PR TITLE
Fix for https://github.com/hashicorp/terraform-provider-vsphere/issue…

### DIFF
--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -169,14 +169,14 @@ func DefaultDevicesFromReference(client *govmomi.Client, ref types.ManagedObject
 
 // OSFamily uses the compute resource's environment browser to get the OS family
 // for a specific guest ID.
-func OSFamily(client *govmomi.Client, ref types.ManagedObjectReference, guest string) (string, error) {
+func OSFamily(client *govmomi.Client, ref types.ManagedObjectReference, guest string, hardwareVersion string) (string, error) {
 	b, err := EnvironmentBrowserFromReference(client, ref)
 	if err != nil {
 		return "", err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
 	defer cancel()
-	return b.OSFamily(ctx, guest)
+	return b.OSFamily(ctx, guest, hardwareVersion)
 }
 
 // EnvironmentBrowserFromReference loads an environment browser for the

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -72,7 +72,7 @@ func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, key string, hos
 }
 
 // OSFamily fetches the operating system family for the supplied guest ID.
-func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string, error) {
+func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string, hardwareVersion string) (string, error) {
 	var eb mo.EnvironmentBrowser
 
 	err := b.Properties(ctx, b.Reference(), nil, &eb)
@@ -84,6 +84,7 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 		This: b.Reference(),
 		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
 			GuestId: []string{guest},
+			Key:     hardwareVersion,
 		},
 	}
 	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)

--- a/vsphere/internal/helper/resourcepool/resource_pool_helper.go
+++ b/vsphere/internal/helper/resourcepool/resource_pool_helper.go
@@ -153,13 +153,13 @@ func DefaultDevices(client *govmomi.Client, pool *object.ResourcePool, guest str
 
 // OSFamily uses the resource pool's environment browser to get the OS family
 // for a specific guest ID.
-func OSFamily(client *govmomi.Client, pool *object.ResourcePool, guest string) (string, error) {
+func OSFamily(client *govmomi.Client, pool *object.ResourcePool, guest string, hardwareVersion string) (string, error) {
 	log.Printf("[DEBUG] Looking for OS family for guest ID %q", guest)
 	pprops, err := Properties(pool)
 	if err != nil {
 		return "", err
 	}
-	return computeresource.OSFamily(client, pprops.Owner, guest)
+	return computeresource.OSFamily(client, pprops.Owner, guest, hardwareVersion)
 }
 
 // Create creates a ResourcePool.

--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -128,7 +128,7 @@ func ValidateVirtualMachineClone(d *schema.ResourceDiff, c *govmomi.Client) erro
 			if err != nil {
 				return fmt.Errorf("could not find resource pool ID %q: %s", poolID, err)
 			}
-			family, err := resourcepool.OSFamily(c, pool, d.Get("guest_id").(string))
+			family, err := resourcepool.OSFamily(c, pool, d.Get("guest_id").(string), d.Get("hardware_version").(string))
 			if err != nil {
 				return fmt.Errorf("cannot find OS family for guest ID %q: %s", d.Get("guest_id").(string), err)
 			}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1641,7 +1641,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	var cw *virtualMachineCustomizationWaiter
 	// Send customization spec if any has been defined.
 	if len(d.Get("clone.0.customize").([]interface{})) > 0 {
-		family, err := resourcepool.OSFamily(client, pool, d.Get("guest_id").(string))
+		family, err := resourcepool.OSFamily(client, pool, d.Get("guest_id").(string), d.Get("hardware_version").(string))
 		if err != nil {
 			return fmt.Errorf("cannot find OS family for guest ID %q: %s", d.Get("guest_id").(string), err)
 		}


### PR DESCRIPTION
…s/1939



### Description

Supported guest OS are dependent on the VM hardware version. Changed querying the OS Family when deploying a VM from template to read the template hardware version instead of using the server default version.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
Fixed https://github.com/hashicorp/terraform-provider-vsphere/issues/1939
vSphere provider now correctly uses the template hardware version instead of the server default when deploying a VM from a template.
-->

```release-note
...
```