### PR TITLE
feat: add vsan file services

### DIFF
--- a/vsphere/internal/helper/vsanclient/vsan_client_helper.go
+++ b/vsphere/internal/helper/vsanclient/vsan_client_helper.go
@@ -7,10 +7,18 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vsan"
+	"github.com/vmware/govmomi/vsan/methods"
 	vsantypes "github.com/vmware/govmomi/vsan/types"
 )
+
+var VsanClusterFileServiceSystemInstance = vimtypes.ManagedObjectReference{
+	Type:  "VsanFileServiceSystem",
+	Value: "vsan-cluster-file-service-system",
+}
 
 func Reconfigure(vsanClient *vsan.Client, cluster vimtypes.ManagedObjectReference, spec vsantypes.VimVsanReconfigSpec) error {
 	ctx := context.TODO()
@@ -29,4 +37,58 @@ func GetVsanConfig(vsanClient *vsan.Client, cluster vimtypes.ManagedObjectRefere
 	vsanConfig, err := vsanClient.VsanClusterGetConfig(ctx, cluster.Reference())
 
 	return vsanConfig, err
+}
+
+func FindOvfDownloadUrl(vsanClient *vsan.Client, cluster vimtypes.ManagedObjectReference) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+
+	req := vsantypes.VsanFindOvfDownloadUrl{
+		This:    VsanClusterFileServiceSystemInstance,
+		Cluster: cluster.Reference(),
+	}
+
+	res, err := methods.VsanFindOvfDownloadUrl(ctx, vsanClient, &req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Returnval, err
+}
+
+func DownloadFileServiceOvf(vsanClient *vsan.Client, client *govmomi.Client, fileServiceOvfUrl string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+
+	req := vsantypes.VsanDownloadFileServiceOvf{
+		This:        VsanClusterFileServiceSystemInstance,
+		DownloadUrl: fileServiceOvfUrl,
+	}
+
+	res, err := methods.VsanDownloadFileServiceOvf(ctx, vsanClient, &req)
+	if err != nil {
+		return err
+	}
+
+	task := object.NewTask(client.Client, res.Returnval)
+	return task.Wait(ctx)
+}
+
+func CreateFileServiceDomain(vsanClient *vsan.Client, client *govmomi.Client, domainConfig vsantypes.VsanFileServiceDomainConfig, cluster vimtypes.ManagedObjectReference) error {
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+
+	req := vsantypes.VsanClusterCreateFsDomain{
+		This:         VsanClusterFileServiceSystemInstance,
+		DomainConfig: domainConfig,
+		Cluster:      &cluster,
+	}
+
+	res, err := methods.VsanClusterCreateFsDomain(ctx, vsanClient, &req)
+	if err != nil {
+		return err
+	}
+
+	task := object.NewTask(client.Client, res.Returnval)
+	return task.Wait(ctx)
 }

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -304,6 +304,28 @@ func TestAccResourceVSphereComputeCluster_vsanDITEncryption(t *testing.T) {
 	})
 }
 
+func TestAccResourceVSphereComputeCluster_vsanFileServiceEnabled(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+			testAccResourceVSphereComputeClusterPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereComputeClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereComputeClusterConfigVSANFileServiceEnabled(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereComputeClusterCheckExists(true),
+					resource.TestCheckResourceAttr("vsphere_compute_cluster.compute_cluster", "vsan_enabled", "true"),
+					resource.TestCheckResourceAttr("vsphere_compute_cluster.compute_cluster", "vsan_file_service_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceVSphereComputeCluster_explicitFailoverHost(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -978,6 +1000,34 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 			testhelper.ConfigDataRootDC1(),
 			testhelper.ConfigDataRootHost3(),
 			testhelper.ConfigDataRootHost4(),
+		),
+	)
+}
+
+func testAccResourceVSphereComputeClusterConfigVSANFileServiceEnabled() string {
+	return fmt.Sprintf(`
+%s
+
+resource "vsphere_compute_cluster" "compute_cluster" {
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost2.id, data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+
+  vsan_enabled = true
+  vsan_file_service_enabled = true
+  vsan_file_service_conf {
+    network = data.vsphere_network.vmnet.id
+  }
+  force_evacuate_on_destroy = true
+}
+
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+			testhelper.ConfigDataRootVMNet(),
 		),
 	)
 }

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -489,6 +489,21 @@ details, see the referenced link in the above paragraph.
   group in the cluster.
   * `cache` - The canonical name of the disk to use for vSAN cache.
   * `storage` - An array of disk canonical names for vSAN storage.
+* `vsan_file_service_enabled` - (Optional) Enables vSAN file service on the
+  cluster. `vsan_file_service_conf` should be configured when this is `true`.
+* `vsan_file_service_conf` - (Optional) Configurations of vSAN file service.
+  * `network` - The network selected for vsan file service.
+  It's mandatory when `vsan_file_service_enabled` is set to `true`.
+  * `vsan_file_service_domain_conf` - (Optional) Domain configurations of vSAN file service.
+    * `name` - The name of vSAN file service domain.
+    * `dns_server_addresses` - The DNS server addresses of vSAN file service domain.
+    * `dns_suffixes` - The DNS suffixes of vSAN file service domain.
+    * `gateway` - The gateway of vSAN file server IP config.
+    * `subnet_mask` - The subnet mask of vSAN file server IP config.
+    * `file_server_ip_config` - The IP config for vSAN file server.
+      * `ip_address` - The IP address of vSAN file server IP config.
+      * `fqdn` - The FQDN of vSAN file server IP config.
+      * `is_primary` - If it is primary file server IP.
 
 ~> **NOTE:** You must disable vSphere HA before you enable vSAN on the cluster.
 You can enable or re-enable vSphere HA after vSAN is configured.
@@ -516,6 +531,32 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   vsan_disk_group {
     cache = data.vsphere_vmfs_disks.cache_disks[0]
     storage = data.vsphere_vmfs_disks.storage_disks
+  }
+  vsan_file_service_enabled = true
+  vsan_file_service_conf {
+    network = data.vsphere_network.network.id
+    vsan_file_service_domain_conf {
+      name = "<your_fs_domain_name>"
+      dns_server_addresses = ["1.2.3.4"]
+      dns_suffixes = ["example.com"]
+      gateway = "192.168.111.1"
+      subnet_mask = "255.255.255.0"
+      file_server_ip_config {
+        fqdn = "h192-168-111-2.example.com"
+        ip_address = "192.168.111.2"
+        is_primary = true
+      }
+      file_server_ip_config {
+        fqdn = "h192-168-111-3.example.com"
+        ip_address = "192.168.111.3"
+        is_primary = false
+      }
+      file_server_ip_config {
+        fqdn = "h192-168-111-4.example.com"
+        ip_address = "192.168.111.4"
+        is_primary = false
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Feat: add support for vSAN File Service enablement and its domain configurations.

This feature is to support configuring vSAN File service and its domain settings. We added two new fields in compute cluster resource `vsan_file_service_enabled` and `vsan_file_service_conf`.
`vsan_file_service_enabled` - Switch to enable and disable.
`vsan_file_service_conf` - Configurations for enabling vSAN FS. It contains:
    - `network` - (mandatory) The network selected for vSAN FS.
    - `vsan_file_service_domain_conf` - FS domain configurations.
Testing Details:
We did end to end test from 3 standalone hosts based on the vSphere 7.0 and 8.0. vSAN FS could be enabled with domain configurations, or be disabled by setting switch to `false`.
Please note in this change, FS domain reconfiguration is not supported, this will be implemented in future.
Following is an example for .tf file.
```
data "vsphere_host" "hosts" {
  count         = length(var.hosts)
  name          = var.hosts[count.index]
  datacenter_id = data.vsphere_datacenter.datacenter.id
}
data "vsphere_network" "network" {
  name          = "VM Network"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}
resource "vsphere_compute_cluster" "cluster" {
  name          = "Cluster-1"
  datacenter_id = data.vsphere_datacenter.datacenter.id
  vsan_enabled = true
  vsan_file_service_enabled = true
  vsan_file_service_conf {
    network = data.vsphere_network.network.id
    vsan_file_service_domain_conf {
      name = "<your_fs_domain_name>"
      dns_server_addresses = ["1.2.3.4"]
      dns_suffixes = ["example.com"]
      gateway = "192.168.111.1"
      subnet_mask = "255.255.255.0"
      file_server_ip_config {
        fqdn = "h192-168-111-2.example.com"
        ip_address = "192.168.111.2"
        is_primary = true
      }
      file_server_ip_config {
        fqdn = "h192-168-111-3.example.com"
        ip_address = "192.168.111.3"
        is_primary = false
      }
      file_server_ip_config {
        fqdn = "h192-168-111-4.example.com"
        ip_address = "192.168.111.4"
        is_primary = false
      }
    }
  }
  host_system_ids = "${data.vsphere_host.hosts.*.id}"
}

```

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
zxinyu@zxinyu2HL47 terraform-provider-vsphere % make testacc TESTARGS="-run=TestAccResourceVSphereComputeCluster_vsanFileServiceEnabled"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVSphereComputeCluster_vsanFileServiceEnabled -timeout 360m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
...
=== RUN   TestAccResourceVSphereComputeCluster_vsanFileServiceEnabled
--- PASS: TestAccResourceVSphereComputeCluster_vsanFileServiceEnabled (735.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	735.583s
testing: warning: no tests to run
...
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice	(cached) [no tests to run]
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
https://github.com/hashicorp/terraform-provider-vsphere/issues/1965
