### PR TITLE
chore(ci): check for panic in logfile

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -84,6 +84,9 @@ jobs:
           name: test-log-${{ env.TODAY_DATE }}
           path: /tmp/gotest.log
 
+      - name: Check for panic in log file
+        run: ! grep -q "panic:" /tmp/gotest.log
+
       - name: Get yesterday's date
         run: echo "YESTERDAY_DATE=$(date -d 'yesterday' +'%Y-%m-%d')" >> $GITHUB_ENV
 


### PR DESCRIPTION
little check will exit 1 if "panic:" is found in the logfile. The CI will likely need a little manual cleanup if an acceptance test panics.