### PR TITLE
Restore regression check

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -93,22 +93,22 @@ jobs:
             echo "No panic found in log file."
           fi
 
-      # - name: Get yesterday's date
-      #   run: echo "YESTERDAY_DATE=$(date -d 'yesterday' +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Get yesterday's date
+        run: echo "YESTERDAY_DATE=$(date -d 'yesterday' +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      # - name: Download previous day's log file
-      #   uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-      #   with:
-      #     name: test-log-${{ env.YESTERDAY_DATE }}
-      #     path: /tmp/yesterday
+      - name: Download previous day's log file
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
+        with:
+          name: test-log-${{ env.YESTERDAY_DATE }}
+          path: /tmp/yesterday
 
-      # - name: Set up Node
-      #   uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # 3.7.0
-      #   with:
-      #     node-version: 18
+      - name: Set up Node
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # 3.7.0
+        with:
+          node-version: 18
 
-      # - name: Run comparison script
-      #   run: node ./scripts/compare-testlogs.js /tmp/gotest.log /tmp/yesterday/gotest.log
+      - name: Run comparison script
+        run: node ./scripts/compare-testlogs.js /tmp/gotest.log /tmp/yesterday/gotest.log
 
       - name: Cleanup testrun resources
         if: always()

--- a/scripts/compare-testlogs.js
+++ b/scripts/compare-testlogs.js
@@ -47,4 +47,10 @@ const outputA = fs.readFileSync(filenameA, 'utf8');
 const outputB = fs.readFileSync(filenameB, 'utf8');
 
 const failedTests = compareTestResults(outputA, outputB);
-console.log(`Tests failed in ${filenameA} that didn't fail in ${filenameB}:`, failedTests);
+
+if (failedTests.length > 0) {
+    console.log(`Tests failed in ${filenameA} that didn't fail in ${filenameB}:`, failedTests);
+    process.exit(1)
+} else {
+    console.log("No new failures")
+}


### PR DESCRIPTION
The previous artifact downloader action didn't support downloads across workflows. Using a popular and HCP approved alternative that does. Added exit code to comparison scripts to flag regressions in CI.
