### PR TITLE
chore(ci): ignore workflow status in log download

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -108,6 +108,7 @@ jobs:
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: test-log-${{ env.YESTERDAY_DATE }}
+          workflow_conclusion: "" # ignore status
           path: /tmp/yesterday
 
       - name: Regression check


### PR DESCRIPTION
The GH action that downloads artifacts only downloads successful workflow artifacts by default. Setting to empty string allegedly removes that restriction.