### PR TITLE
Issue 1939

### DIFF
--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -169,14 +169,14 @@ func DefaultDevicesFromReference(client *govmomi.Client, ref types.ManagedObject
 
 // OSFamily uses the compute resource's environment browser to get the OS family
 // for a specific guest ID.
-func OSFamily(client *govmomi.Client, ref types.ManagedObjectReference, guest string) (string, error) {
+func OSFamily(client *govmomi.Client, ref types.ManagedObjectReference, guest string, hardwareVersion string) (string, error) {
 	b, err := EnvironmentBrowserFromReference(client, ref)
 	if err != nil {
 		return "", err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
 	defer cancel()
-	return b.OSFamily(ctx, guest)
+	return b.OSFamily(ctx, guest, hardwareVersion)
 }
 
 // EnvironmentBrowserFromReference loads an environment browser for the

--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -168,8 +168,9 @@ func DefaultDevicesFromReference(client *govmomi.Client, ref types.ManagedObject
 }
 
 // OSFamily uses the compute resource's environment browser to get the OS family
-// for a specific guest ID.
-func OSFamily(client *govmomi.Client, ref types.ManagedObjectReference, guest string, hardwareVersion string) (string, error) {
+// for a specific guest ID. The list of supported OS is dependent on the hardware version of the vm/template
+// so that is also passed to the environment browser.
+func OSFamily(client *govmomi.Client, ref types.ManagedObjectReference, guest string, hardwareVersion int) (string, error) {
 	b, err := EnvironmentBrowserFromReference(client, ref)
 	if err != nil {
 		return "", err

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -72,7 +72,7 @@ func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, key string, hos
 }
 
 // OSFamily fetches the operating system family for the supplied guest ID.
-func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string, error) {
+func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string, hardwareVersion string) (string, error) {
 	var eb mo.EnvironmentBrowser
 
 	err := b.Properties(ctx, b.Reference(), nil, &eb)
@@ -84,6 +84,7 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 		This: b.Reference(),
 		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
 			GuestId: []string{guest},
+			Key:     hardwareVersion,
 		},
 	}
 	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -72,7 +73,8 @@ func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, key string, hos
 }
 
 // OSFamily fetches the operating system family for the supplied guest ID.
-func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string, hardwareVersion string) (string, error) {
+// The list of supported OS is dependent on the hardware version of the vm/template
+func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string, hardwareVersion int) (string, error) {
 	var eb mo.EnvironmentBrowser
 
 	err := b.Properties(ctx, b.Reference(), nil, &eb)
@@ -84,8 +86,10 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string, hardwar
 		This: b.Reference(),
 		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
 			GuestId: []string{guest},
-			Key:     hardwareVersion,
 		},
+	}
+	if hardwareVersion > 0 {
+		req.Spec.Key = virtualmachine.GetHardwareVersionID(hardwareVersion)
 	}
 	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)
 	if err != nil {

--- a/vsphere/internal/helper/resourcepool/resource_pool_helper.go
+++ b/vsphere/internal/helper/resourcepool/resource_pool_helper.go
@@ -152,8 +152,9 @@ func DefaultDevices(client *govmomi.Client, pool *object.ResourcePool, guest str
 }
 
 // OSFamily uses the resource pool's environment browser to get the OS family
-// for a specific guest ID.
-func OSFamily(client *govmomi.Client, pool *object.ResourcePool, guest string, hardwareVersion string) (string, error) {
+// for a specific guest ID. The list of supported OS is dependent on the hardware version of the vm/template
+// so that is also passed to the environment browser.
+func OSFamily(client *govmomi.Client, pool *object.ResourcePool, guest string, hardwareVersion int) (string, error) {
 	log.Printf("[DEBUG] Looking for OS family for guest ID %q", guest)
 	pprops, err := Properties(pool)
 	if err != nil {

--- a/vsphere/internal/helper/resourcepool/resource_pool_helper.go
+++ b/vsphere/internal/helper/resourcepool/resource_pool_helper.go
@@ -153,13 +153,13 @@ func DefaultDevices(client *govmomi.Client, pool *object.ResourcePool, guest str
 
 // OSFamily uses the resource pool's environment browser to get the OS family
 // for a specific guest ID.
-func OSFamily(client *govmomi.Client, pool *object.ResourcePool, guest string) (string, error) {
+func OSFamily(client *govmomi.Client, pool *object.ResourcePool, guest string, hardwareVersion string) (string, error) {
 	log.Printf("[DEBUG] Looking for OS family for guest ID %q", guest)
 	pprops, err := Properties(pool)
 	if err != nil {
 		return "", err
 	}
-	return computeresource.OSFamily(client, pprops.Owner, guest)
+	return computeresource.OSFamily(client, pprops.Owner, guest, hardwareVersion)
 }
 
 // Create creates a ResourcePool.

--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -128,10 +128,29 @@ func ValidateVirtualMachineClone(d *schema.ResourceDiff, c *govmomi.Client) erro
 			if err != nil {
 				return fmt.Errorf("could not find resource pool ID %q: %s", poolID, err)
 			}
-			family, err := resourcepool.OSFamily(c, pool, d.Get("guest_id").(string), d.Get("hardware_version").(string))
+
+			// Retrieving the vm/template data to extract the hardware version.
+			// If there's a higher hardware version specified in the spec that value is used instead.
+			vm, err := virtualmachine.FromUUID(c, tUUID)
+			if err != nil {
+				return fmt.Errorf("cannot locate virtual machine or template with UUID %q: %s", tUUID, err)
+			}
+			vprops, err := virtualmachine.Properties(vm)
+			if err != nil {
+				return fmt.Errorf("error fetching virtual machine or template properties: %s", err)
+			}
+			vmHardwareVersion := virtualmachine.GetHardwareVersionNumber(vprops.Config.Version)
+			vmSpecHardwareVersion := d.Get("hardware_version").(int)
+			if vmSpecHardwareVersion > vmHardwareVersion {
+				vmHardwareVersion = vmSpecHardwareVersion
+			}
+
+			// Retrieving the guest OS family of the vm/template.
+			family, err := resourcepool.OSFamily(c, pool, d.Get("guest_id").(string), vmHardwareVersion)
 			if err != nil {
 				return fmt.Errorf("cannot find OS family for guest ID %q: %s", d.Get("guest_id").(string), err)
 			}
+			// Validating the customization spec is valid for the vm/template's guest OS family
 			if err := ValidateCustomizationSpec(d, family); err != nil {
 				return err
 			}

--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -128,7 +128,7 @@ func ValidateVirtualMachineClone(d *schema.ResourceDiff, c *govmomi.Client) erro
 			if err != nil {
 				return fmt.Errorf("could not find resource pool ID %q: %s", poolID, err)
 			}
-			family, err := resourcepool.OSFamily(c, pool, d.Get("guest_id").(string))
+			family, err := resourcepool.OSFamily(c, pool, d.Get("guest_id").(string), d.Get("hardware_version").(string))
 			if err != nil {
 				return fmt.Errorf("cannot find OS family for guest ID %q: %s", d.Get("guest_id").(string), err)
 			}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1646,7 +1646,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 		if vmSpecHardwareVersion > vmHardwareVersion {
 			vmHardwareVersion = vmSpecHardwareVersion
 		}
-		fmt.Errorf(virtualmachine.GetHardwareVersionID(vmHardwareVersion))
+
 		family, err := resourcepool.OSFamily(client, pool, d.Get("guest_id").(string), vmHardwareVersion)
 		if err != nil {
 			return fmt.Errorf("cannot find OS family for guest ID %q: %s", d.Get("guest_id").(string), err)

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1641,7 +1641,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	var cw *virtualMachineCustomizationWaiter
 	// Send customization spec if any has been defined.
 	if len(d.Get("clone.0.customize").([]interface{})) > 0 {
-		family, err := resourcepool.OSFamily(client, pool, d.Get("guest_id").(string))
+		family, err := resourcepool.OSFamily(client, pool, d.Get("guest_id").(string), d.Get("hardware_version").(string))
 		if err != nil {
 			return fmt.Errorf("cannot find OS family for guest ID %q: %s", d.Get("guest_id").(string), err)
 		}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1641,7 +1641,13 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	var cw *virtualMachineCustomizationWaiter
 	// Send customization spec if any has been defined.
 	if len(d.Get("clone.0.customize").([]interface{})) > 0 {
-		family, err := resourcepool.OSFamily(client, pool, d.Get("guest_id").(string), d.Get("hardware_version").(string))
+		vmHardwareVersion := virtualmachine.GetHardwareVersionNumber(vprops.Config.Version)
+		vmSpecHardwareVersion := d.Get("hardware_version").(int)
+		if vmSpecHardwareVersion > vmHardwareVersion {
+			vmHardwareVersion = vmSpecHardwareVersion
+		}
+		fmt.Errorf(virtualmachine.GetHardwareVersionID(vmHardwareVersion))
+		family, err := resourcepool.OSFamily(client, pool, d.Get("guest_id").(string), vmHardwareVersion)
 		if err != nil {
 			return fmt.Errorf("cannot find OS family for guest ID %q: %s", d.Get("guest_id").(string), err)
 		}


### PR DESCRIPTION
### Description

Bugfix for [issue 1939] (https://github.com/hashicorp/terraform-provider-vsphere/issues/1939) 
Cloning and configuring VMs with newer guest operating systems (Windows 2022 in this case) was failing in some cases due to the backend using the ESXi default hardware version instead of the template or VM hardware version being cloned from or configured. This was causing the guest OS to not be recognised as supported.
Changed the backend pass the hardware version when retrieving the OS family.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
no regressions
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`r/virtual_machine`: Fix "Error: cannot find OS family for guest ID ... " when cloning and/or configuring a VM/Template ([#1939](https://github.com/hashicorp/terraform-provider-vsphere/issues/1939))
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
Closes #1939 