### PR TITLE
fix: issue gh-2005

### DIFF
--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -1002,7 +1002,7 @@ func GetHardwareVersionID(vint int) string {
 	if vint == 0 {
 		return ""
 	}
-	return fmt.Sprintf("vmx-%d", vint)
+	return fmt.Sprintf("vmx-%02d", vint)
 }
 
 // GetHardwareVersionNumber gets the hardware version number from string.


### PR DESCRIPTION
Customizing VMs ( customize{} block in the spec) with a hardware version less than 10 fails due to formatting error of the version string passed in the API. Changed the formatting code to format the version to 2 digit integer, left padded with 0 when it's less than 10. That way version 9 becomes vmx-09 instead of vmx-9 and version 10 remains vmx-10.

### Description

Fix: `r/vsphere_virtual_machine` Customization fails with when the hardware version of the machine is less than 10.
"Error: cannot find OS family for guest ID "<guestid>": ServerFaultCode: A specified parameter was not correct: key"

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
no regressions
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```
resource/vsphere_virtual_machine: Customization fails when hardware version of the machine is less than 10. [#2009](https://github.com/hashicorp/terraform-provider-vsphere/pull/2009)
```
### References