### PR TITLE
Fix hardware version bug

### DIFF
--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -1002,7 +1002,7 @@ func GetHardwareVersionID(vint int) string {
 	if vint == 0 {
 		return ""
 	}
-	return fmt.Sprintf("vmx-%d", vint)
+	return fmt.Sprintf("vmx-%02d", vint)
 }
 
 // GetHardwareVersionNumber gets the hardware version number from string.


### PR DESCRIPTION
### Description
vSphere refers to hardware_version in a `vmx-xx` format. The attribute is converted directly into an integer within provider schema I assume because it made version comparison more intuitive. HOWEVER because vSphere does in fact leftpad the integer with a leading `0` if the value is < 10, we could have left the attribute as is when initially designed  and relied on lexicographical comparisons.

A recent change #1995 fixed an issue of setting the incorrect hardware version when using a template which has revealed this bug, that we naively did not leftpad the integer with a `0` when < 10. This change fixes this.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
no regressions on VM resource
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```release-note

```
### References

Closes #2005 