### PR TITLE
fix: r/vsphere_virtual_disk with lazy forces replacement

### DIFF
--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -303,6 +303,16 @@ func resourceVSphereVirtualDiskRead(d *schema.ResourceData, meta interface{}) er
 		Path:      vDisk.vmdkPath,
 	}
 	diskType, err := virtualdisk.QueryDiskType(client, dp.String(), dc)
+	/**
+	Thick Provisioned Lazy Zeroed disk type a.k.a "lazy" in the provider context is actually
+	"preallocated" for the VC. Due to historical reasons i.e. the disk type is documented as "lazy".
+	In order to fix https://github.com/hashicorp/terraform-provider-vsphere/issues/1824 the value must be converted,
+	otherwise the disk is recreated
+	*/
+	if diskType == "preallocated" {
+		diskType = "lazy"
+	}
+
 	if err != nil {
 		return errors.New("Failed to query disk type")
 	}


### PR DESCRIPTION
Fixes #1824

### Description

Issue addressed - when r/vsphere_virtual_disk.type is set as "lazy" as documented here:
https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_disk#type i.e. Thick Provisioned Lazy Zeroed it is sent and received as "preallocated". The value is mapped when sent but not when received which causes disk recreaion when terraform apply is executed for the second time without changing the HCL config.

Fix applied - when virtual disk type is read from the backend the value is transformed to "lazy" if "preallocated" is received.

Testing done:
With HCL:
```
resource "vsphere_virtual_disk" "virtual_disk_test" {
  count              = 1
  datacenter         = data.vsphere_datacenter.datacenter.name
  datastore          = data.vsphere_datastore.datastore.name
  vmdk_path          = "/${var.VSPHERE_ESXI1}/test.vmdk"
  create_directories = true

  size               = 2
  type               = "lazy" # Thick Provision Lazy Zeroed (allocate then zero on first write)
}
```

executed `terraform apply` twice

Output from the second execution:
```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:


```
vasila@vasila2VDJN terraform-provider-vsphere % make testacc TESTARGS='-run=TestAccResourceVSphereVirtualDisk'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVSphereVirtualDisk -timeout 360m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
=== RUN   TestAccResourceVSphereVirtualDisk_basic
--- PASS: TestAccResourceVSphereVirtualDisk_basic (93.77s)
=== RUN   TestAccResourceVSphereVirtualDisk_multi
--- PASS: TestAccResourceVSphereVirtualDisk_multi (105.79s)
=== RUN   TestAccResourceVSphereVirtualDisk_multiWithParent
--- PASS: TestAccResourceVSphereVirtualDisk_multiWithParent (107.49s)
=== RUN   TestAccResourceVSphereVirtualDisk_withParent
--- PASS: TestAccResourceVSphereVirtualDisk_withParent (100.44s)
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere 408.441s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   0.950s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     1.124s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  1.202s [no tests to run]


...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
Fixes #1824 - r/vsphere_virtual_disk is recreated due to bad disk type handling
```
### References
#1824 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
