### PR TITLE
feat: add data source vgpu profiles

### DIFF
--- a/vsphere/data_source_vsphere_host_vgpu_profile.go
+++ b/vsphere/data_source_vsphere_host_vgpu_profile.go
@@ -1,0 +1,156 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vsphere
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func dataSourceVSphereHostVGpuProfile() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereHostVGpuProfileRead,
+		Schema: map[string]*schema.Schema{
+			"host_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The Managed Object ID of the host system.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the vGPU Profile to search for on host.",
+			},
+			"vgpu_profiles": {
+				Type:        schema.TypeList,
+				Description: "List of vGPU profiles available via host.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vgpu": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name of a particular VGPU available as a shared GPU device (vGPU profile).",
+						},
+						"disk_snapshot_supported": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether the GPU plugin on this host is capable of disk-only snapshots when VM is not powered off.",
+						},
+						"memory_snapshot_supported": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether the GPU plugin on this host is capable of memory snapshots.",
+						},
+						"suspend_supported": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether the GPU plugin on this host is capable of suspend-resume.",
+						},
+						"migrate_supported": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether the GPU plugin on this host is capable of migration.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVSphereHostVGpuProfileRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] DataHostVGpuProfile: Beginning vGPU Profile lookup on %s", d.Get("host_id").(string))
+
+	client := meta.(*Client).vimClient
+
+	host, err := hostsystem.FromID(client, d.Get("host_id").(string))
+	if err != nil {
+		return err
+	}
+
+	hprops, err := hostsystem.Properties(host)
+	if err != nil {
+		return err
+	}
+
+	// Create unique ID based on the host_id
+	idsum := sha256.New()
+	if _, err := idsum.Write([]byte(fmt.Sprintf("%#v", d.Get("host_id").(string)))); err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%x", idsum.Sum(nil)))
+
+	log.Printf("[DEBUG] DataHostVGpuProfile: Looking for available vGPU profiles")
+
+	// Retrieve the SharedGpuCapabilities from host properties
+	vgpusRaw := hprops.Config.SharedGpuCapabilities
+
+	// If searching for a specific vGPU profile (by name)
+	name, ok := d.GetOk("name")
+	if (ok) && (name.(string) != "") {
+		return searchVGpuProfileByName(d, vgpusRaw, name.(string))
+	}
+
+	// Loop over all vGPU profiles on host
+	vgpus := make([]interface{}, len(vgpusRaw))
+	for i, v := range vgpusRaw {
+		log.Printf("[DEBUG] Host %s has vGPU profile %s", d.Get("host_id").(string), v.Vgpu)
+		vgpu := map[string]interface{}{
+			"vgpu":                      v.Vgpu,
+			"disk_snapshot_supported":   v.DiskSnapshotSupported,
+			"memory_snapshot_supported": v.MemorySnapshotSupported,
+			"suspend_supported":         v.SuspendSupported,
+			"migrate_supported":         v.MigrateSupported,
+		}
+		vgpus[i] = vgpu
+	}
+
+	// Set the `vgpu_profile` output to all vGPU profiles
+	if err := d.Set("vgpu_profiles", vgpus); err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] DataHostVGpuProfile: Identified %d vGPU profiles available on %s", len(vgpus), d.Get("host_id").(string))
+
+	return nil
+}
+
+func searchVGpuProfileByName(d *schema.ResourceData, vgpusRaw []types.HostSharedGpuCapabilities, name string) error {
+	vgpus := make([]interface{}, 1)
+
+	// Loop over all vGPU profile and attempt to match by name
+	for _, v := range vgpusRaw {
+		if v.Vgpu == name {
+			// Identified matching vGPU profile
+			log.Printf("[DEBUG] Host %s has vGPU profile %s", d.Get("host_id").(string), v.Vgpu)
+			vgpu := map[string]interface{}{
+				"vgpu":                      v.Vgpu,
+				"disk_snapshot_supported":   v.DiskSnapshotSupported,
+				"memory_snapshot_supported": v.MemorySnapshotSupported,
+				"suspend_supported":         v.SuspendSupported,
+				"migrate_supported":         v.MigrateSupported,
+			}
+			vgpus[0] = vgpu
+		}
+	}
+
+	if len(vgpus) == 0 {
+		log.Printf("[DEBUG] Host %s does not support vGPU profile %s", d.Get("host_id").(string), name)
+	}
+
+	// Set the `vgpu_profile` output to located vGPU.
+	// If a matching vGPU profile is not found, return null
+	if err := d.Set("vgpu_profiles", vgpus); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vsphere/data_source_vsphere_host_vgpu_profile.go
+++ b/vsphere/data_source_vsphere_host_vgpu_profile.go
@@ -138,7 +138,7 @@ func searchVGpuProfileByName(d *schema.ResourceData, vgpusRaw []types.HostShared
 				"suspend_supported":         v.SuspendSupported,
 				"migrate_supported":         v.MigrateSupported,
 			}
-			vgpus[0] = vgpu
+			vgpus = append(vgpus, vgpu)
 		}
 	}
 

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -158,6 +158,7 @@ func Provider() *schema.Provider {
 			"vsphere_host":                       dataSourceVSphereHost(),
 			"vsphere_host_pci_device":            dataSourceVSphereHostPciDevice(),
 			"vsphere_host_thumbprint":            dataSourceVSphereHostThumbprint(),
+			"vsphere_host_vgpu_profile":          dataSourceVSphereHostVGpuProfile(),
 			"vsphere_license":                    dataSourceVSphereLicense(),
 			"vsphere_network":                    dataSourceVSphereNetwork(),
 			"vsphere_ovf_vm_template":            dataSourceVSphereOvfVMTemplate(),

--- a/website/docs/d/host_vgpu_profile.html.markdown
+++ b/website/docs/d/host_vgpu_profile.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "Host and Cluster Management"
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_host_vgpu_profile"
+sidebar_current: "docs-vsphere-data-source-host_vgpu_profile"
+description: |-
+  A data source that can be used to get information for
+  one or all vGPU profiles available on an ESXi host.
+---
+
+# vsphere_host_vgpu_profile
+
+The `vsphere_host_vgpu_profile` data source can be used to discover the
+available vGPU profiles of a vSphere host.
+
+## Example Usage to return all vGPU profiles
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name          = "dc-01"
+}
+
+data "vsphere_host" "host" {
+  name          = "esxi-01.example.com"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+data "vsphere_host_vgpu_profile" "vgpu_profile" {
+  host_id       = data.vsphere_host.host.id
+}
+```
+
+## Example Usage with vGPU profile name_regex
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name          = "dc-01"
+}
+
+data "vsphere_host" "host" {
+  name          = "esxi-01.example.com"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+data "vsphere_host_vgpu_profile" "vgpu_profile" {
+  host_id       = data.vsphere_host.host.id
+  name_regex    = "a100"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `host_id` - (Required) The [managed object reference ID][docs-about-morefs] of a host.
+* `name_regex` - (Optional) A regular expression that will be used to match the
+   host vGPU profile name.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `host_id` - The [managed objectID][docs-about-morefs] of the ESXi host.
+* `id` - Unique (SHA256) id based on the host_id if the ESXi host.
+* `name_regex` - (Optional) A regular expression that will be used to match the
+  host vGPU profile name.
+* `vgpu_profiles` - The list of available vGPU profiles on the ESXi host.
+  This may be and empty array if no vGPU profile are identified.
+  * `vgpu` - Name of a particular vGPU available as a shared GPU device (vGPU profile).
+  * `disk_snapshot_supported` - Indicates whether the GPU plugin on this host is
+    capable of disk-only snapshots when VM is not powered off.
+  * `memory_snapshot_supported` - Indicates whether the GPU plugin on this host is
+    capable of memory snapshots.
+  * `migrate_supported` - Indicates whether the GPU plugin on this host is capable
+    of migration.
+  * `suspend_supported` - Indicates whether the GPU plugin on this host is capable
+    of suspend-resume.


### PR DESCRIPTION
### Description

Add a new data source to the provider to query and return available vGPU profiles for a host.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

No acceptance tests added.

### Provider tests
Output from provider testing:

#### ESXi host with A100 GPU
ESXi host with A100 GPU - no vGPU profile name filter
```
Changes to Outputs:
  + all_host_vgpu_profiles = {
      + host_id       = "host-1021"
      + id            = "fdcccc4252c0516e9d54a1ee6e851ba9f336c64502d6e80c5a684072f6e02bdc"
      + name          = null
      + vgpu_profiles = [
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-4c"
            },
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-8c"
            },
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-10c"
            },
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-16c"
            },
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-20c"
            },
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-40c"
            },
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-80c"
            },
        ]
    }
```

ESXi host with A100 GPU - vGPU profile name filter `grid_a100d-80c`
```
Changes to Outputs:
  + single_host_vgpu_profile = {
      + host_id       = "host-1021"
      + id            = "fdcccc4252c0516e9d54a1ee6e851ba9f336c64502d6e80c5a684072f6e02bdc"
      + name          = "grid_a100d-80c"
      + vgpu_profiles = [
          + {
              + disk_snapshot_supported   = true
              + memory_snapshot_supported = true
              + migrate_supported         = true
              + suspend_supported         = true
              + vgpu                      = "grid_a100d-80c"
            },
        ]
    }
```

#### ESXi host without GPU
ESXi host without GPU - no vGPU profile name filter
```
Changes to Outputs:
  + all_host_vgpu_profiles = {
      + host_id       = "host-4016"
      + id            = "7025a70fb666db1fd6f2f0d3f27ca9c6cb574a780443fd37d49685275e5b9b66"
      + name          = null
      + vgpu_profiles = []
    }
```

ESXi host without GPU - vGPU profile name filter `grid_a100d-80c`
```
Changes to Outputs:
  + single_host_vgpu_profiles = {
      + host_id       = "host-4016"
      + id            = "7025a70fb666db1fd6f2f0d3f27ca9c6cb574a780443fd37d49685275e5b9b66"
      + name          = "grid_a100d-80c"
      + vgpu_profiles = []
    }
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Closes #2047 