### PR TITLE
feat: add support for managing vCenter Single Sign-on domain local users and groups 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/vsphere/data_source_vsphere_sso_user.go
+++ b/vsphere/data_source_vsphere_sso_user.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/sso"
+)
+
+func dataSourceVsphereSsoUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereSsoUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the SSO user.",
+				Optional:    false,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func dataSourceVSphereSsoUserRead(d *schema.ResourceData, meta interface{}) error {
+
+	clientConfig := meta.(*Client).ssoAdminClientConfig
+	userName := d.Get("name").(string)
+
+	user, err := sso.AdminPersonUserFromName(clientConfig, userName)
+
+	if err != nil {
+		return fmt.Errorf("error fetching sso user: %s", err)
+	}
+
+	id := user.Id
+	d.SetId(fmt.Sprintf("%s.%s", id.Name, id.Domain))
+
+	return nil
+}

--- a/vsphere/data_source_vsphere_sso_user_test.go
+++ b/vsphere/data_source_vsphere_sso_user_test.go
@@ -1,0 +1,41 @@
+package vsphere
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// The Administrator user is created by default on vCenter Server systems.
+const SsoUserName = "Administrator"
+const SsoUserGeneratedId = "Administrator.vsphere.local"
+
+func TestAccDataSourceVSphereSsoUser_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// RunSweepers()
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereSsoUserConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vsphere_sso_user.user", "name", SsoUserName),
+					resource.TestCheckResourceAttr("data.vsphere_sso_user.user", "id", SsoUserGeneratedId),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVSphereSsoUserConfig() string {
+	return fmt.Sprintf(`
+data "vsphere_sso_user" "user" {
+  name = "%s"
+}
+`,
+		SsoUserName,
+	)
+}

--- a/vsphere/internal/helper/sso/sso_helper.go
+++ b/vsphere/internal/helper/sso/sso_helper.go
@@ -1,0 +1,67 @@
+package sso
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+func AdminPersonUserFromName(clientWrapper *SsoAdminClientConfig, name string) (*types.AdminPersonUser, error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+
+	c, err := newClientWithAuthentication(ctx, *clientWrapper)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Logout(ctx)
+
+	return c.FindPersonUser(ctx, name)
+}
+
+// Wrapper for lazy authenticated SSO admin requests
+type SsoAdminClientConfig struct {
+	VimClient *govmomi.Client
+	UserInfo  *url.Userinfo
+}
+
+// Create a new SSO admin client with authentication on demand
+// SSO admin server has its own session manager, so the govc persisted session cookies cannot
+// be used to authenticate. We have to issue a new token each time.
+func newClientWithAuthentication(ctx context.Context, s SsoAdminClientConfig) (*ssoadmin.Client, error) {
+
+	vc := s.VimClient.Client
+
+	c, err := ssoadmin.NewClient(ctx, vc)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens, err := sts.NewClient(ctx, s.VimClient.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	req := sts.TokenRequest{
+		Certificate: vc.Certificate(),
+		Userinfo:    s.UserInfo,
+	}
+
+	signer, err := tokens.Issue(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = c.Login(c.WithHeader(ctx, soap.Header{Security: signer})); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -175,6 +175,7 @@ func Provider() *schema.Provider {
 			"vsphere_vmfs_disks":                 dataSourceVSphereVmfsDisks(),
 			"vsphere_role":                       dataSourceVsphereRole(),
 			"vsphere_guest_os_customization":     dataSourceVSphereGuestOSCustomization(),
+			"vsphere_sso_user":                   dataSourceVsphereSsoUser(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -122,6 +122,16 @@ func isEligibleVSANEndpoint(client *govmomi.Client) bool {
 	return true
 }
 
+// isEligibleVSANEndpoint is a meta-validation that is used on login to see if
+// the connected endpoint supports the SSO Admin API.
+func isEligibleSSOAdminEndpoint(client *govmomi.Client) bool {
+	if err := viapi.ValidateVirtualCenter(client); err != nil {
+		return false
+	}
+
+	return true
+}
+
 // tagCategoryByName locates a tag category by name. It's used by the
 // vsphere_tag_category data source, and the resource importer.
 func tagCategoryByName(tm *tags.Manager, name string) (string, error) {


### PR DESCRIPTION
### Description

Resolves #1413 - Add support to manage vCenter users and groups. 

_Note: This is a draft for now. Further resources and data sources are in progress.
I want early feedback, especially on the dynamic token implementation, since it introduces a new pattern to the provider._  

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

* `govc` SSO client implementation: https://github.com/vmware/govmomi/blob/main/govc/sso/client.go