### PR TITLE
fix: allow `datastore_cluster` for content library clones

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations"
 	"log"
 	"net"
 	"os"
@@ -15,15 +14,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod"
@@ -1007,16 +1006,16 @@ func resourceVSphereVirtualMachineCustomizeDiff(_ context.Context, d *schema.Res
 
 		switch {
 		case d.Get("imported").(bool):
-			// Imported workflows need to have the configuration of the clone
-			// sub-resource block persisted to state without forcing a new resource.
-			// Any changes after that will be properly tracked as a ForceNew, by
-			// flagging the imported flag to off.
-			_ = d.SetNew("imported", false)
+			// If the VM was imported, set the 'imported' flag to false without forcing a new resource.
+			if err := d.SetNew("imported", false); err != nil {
+				return fmt.Errorf("error setting imported: %s", err)
+			}
 		case d.Id() == "":
-			if contentlibrary.IsContentLibraryItem(meta.(*Client).restClient, d.Get("clone.0.template_uuid").(string)) {
-				if ds_cluster_id, ok := d.GetOk("datastore_cluster_id"); ok {
-					err := d.SetNew("datastore_id", ds_cluster_id.(string))
-					if err != nil {
+			templateUUID := d.Get("clone.0.template_uuid").(string)
+			isContentLibraryItem := contentlibrary.IsContentLibraryItem(meta.(*Client).restClient, templateUUID)
+			if isContentLibraryItem {
+				if dsClusterID, ok := d.GetOk("datastore_cluster_id"); ok {
+					if err := d.SetNew("datastore_id", dsClusterID.(string)); err != nil {
 						return fmt.Errorf("error setting datastore_id: %s", err)
 					}
 				}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1014,8 +1014,11 @@ func resourceVSphereVirtualMachineCustomizeDiff(_ context.Context, d *schema.Res
 			_ = d.SetNew("imported", false)
 		case d.Id() == "":
 			if contentlibrary.IsContentLibraryItem(meta.(*Client).restClient, d.Get("clone.0.template_uuid").(string)) {
-				if _, ok := d.GetOk("datastore_cluster_id"); ok {
-					return fmt.Errorf("Cannot use datastore_cluster_id with Content Library source")
+				if ds_cluster_id, ok := d.GetOk("datastore_cluster_id"); ok {
+					err := d.SetNew("datastore_id", ds_cluster_id.(string))
+					if err != nil {
+						return fmt.Errorf("error setting datastore_id: %s", err)
+					}
 				}
 			} else if err := vmworkflow.ValidateVirtualMachineClone(d, client); err != nil {
 				return err


### PR DESCRIPTION
### Description

Allows specifying a `datastore_cluster_id` for `vsphere_virtual_machine` when cloning from `vsphere_content_library_item`.

### References

Closes #2055

https://kb.vmware.com/s/article/91103