### PR TITLE
fix: separate vsan fault domains and stretched cluster

### DIFF
--- a/vsphere/internal/helper/testhelper/testing.go
+++ b/vsphere/internal/helper/testhelper/testing.go
@@ -214,3 +214,30 @@ func ConfigDSClusterData() string {
  
 `, os.Getenv("TF_VAR_VSPHERE_DS_CLUSTER1"))
 }
+
+func ConfigDataVsanHost1() string {
+	return fmt.Sprintf(`
+data "vsphere_host" "roothost1" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VSPHERE_VSAN_HOST_1"))
+}
+
+func ConfigDataVsanHost2() string {
+	return fmt.Sprintf(`
+data "vsphere_host" "roothost2" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VSPHERE_VSAN_HOST_2"))
+}
+
+func ConfigDataVsanWitnessHost() string {
+	return fmt.Sprintf(`
+data "vsphere_host" "roothost3" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VSPHERE_VSAN_WITNESS_HOST"))
+}

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -379,6 +379,7 @@ func TestAccResourceVSphereComputeCluster_vsanStretchedCluster(t *testing.T) {
 			RunSweepers()
 			testAccPreCheck(t)
 			testAccResourceVSphereComputeClusterPreCheck(t)
+			testAccResourceVSphereComputeClusterVSANStretchedClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterCheckExists(false),
@@ -687,6 +688,18 @@ func testAccResourceVSphereComputeClusterVSANEsaPreCheck(t *testing.T) {
 	}
 	if version := viapi.ParseVersionFromClient(client); !version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 8, Minor: 0}) {
 		t.Skip("vSAN ESA acceptance test should be run on vSphere 8.0 or higher")
+	}
+}
+
+func testAccResourceVSphereComputeClusterVSANStretchedClusterPreCheck(t *testing.T) {
+	if os.Getenv("TF_VSPHERE_VSAN_HOST_1") == "" {
+		t.Skip("set TF_VSPHERE_VSAN_HOST_1 to run vsphere_compute_cluster stretched cluster acceptance tests")
+	}
+	if os.Getenv("TF_VSPHERE_VSAN_HOST_2") == "" {
+		t.Skip("set TF_VSPHERE_VSAN_HOST_2 to run vsphere_compute_cluster stretched cluster acceptance tests")
+	}
+	if os.Getenv("TF_VSPHERE_VSAN_WITNESS_HOST") == "" {
+		t.Skip("set TF_VSPHERE_VSAN_WITNESS_HOST to run vsphere_compute_cluster stretched cluster acceptance tests")
 	}
 }
 
@@ -1183,9 +1196,9 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 `,
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
-			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataVsanHost1(),
+			testhelper.ConfigDataVsanHost2(),
+			testhelper.ConfigDataVsanWitnessHost(),
 		),
 	)
 }
@@ -1206,9 +1219,9 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 `,
 		testhelper.CombineConfigs(
 			testhelper.ConfigDataRootDC1(),
-			testhelper.ConfigDataRootHost1(),
-			testhelper.ConfigDataRootHost2(),
-			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataVsanHost1(),
+			testhelper.ConfigDataVsanHost2(),
+			testhelper.ConfigDataVsanWitnessHost(),
 		),
 	)
 }

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -540,6 +540,11 @@ resource "vsphere_compute_cluster" "compute_cluster" {
       host_ids = [data.vsphere_host.faultdomain2_hosts.*.id]
     }
   }
+  vsan_stretched_cluster {
+    preferred_fault_domain_host_ids = [data.vsphere_host.preferred_fault_domain_host.*.id]
+    secondary_fault_domain_host_ids = [data.vsphere_host.secondary_fault_domain_host.*.id]
+    witness_node = data.vsphere_host.witness_host.id
+  }
 }
 ```
 


### PR DESCRIPTION
### Description

Patch some fix on vSAN fault domains and stretched cluster:
1. Add several environment variables to skip stretched cluster acc test, since current CI setup doesn't support it.
addressed https://github.com/hashicorp/terraform-provider-vsphere/pull/1885#pullrequestreview-1721947476
2. Add example usage of stretched cluster in document.
3. Separate vSAN fault domains and stretched cluster by adding ConflictWith, fault domain configure and flatten will only be triggered when stretched cluster non-exist.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccResourceVSphereComputeCluster_faultDomain
--- PASS: TestAccResourceVSphereComputeCluster_faultDomain (220.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	223.415s

=== RUN   TestAccResourceVSphereComputeCluster_vsanStretchedCluster
    resource_vsphere_compute_cluster_test.go:696: set TF_VSPHERE_VSAN_HOST_1 to run vsphere_compute_cluster stretched cluster acceptance tests
--- SKIP: TestAccResourceVSphereComputeCluster_vsanStretchedCluster (23.92s)

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
