### PR TITLE
fix: guest os customization related vm e2e test

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -7277,7 +7277,7 @@ data "vsphere_network" "network" {
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
 
-resource "vsphere_guest_os_customization_spec" "gosc_spec" {
+resource "vsphere_guest_os_customization" "gosc_spec" {
 	name = %q
 	type = "Linux"
 	spec {
@@ -7320,7 +7320,7 @@ resource "vsphere_virtual_machine" "vm" {
   clone {
     template_uuid = data.vsphere_virtual_machine.template.id
 	customization_spec {
-		id = vsphere_guest_os_customization_spec.gosc_spec.id
+		id = vsphere_guest_os_customization.gosc_spec.id
 	}
   }
 }


### PR DESCRIPTION
### Description

- Changed the resource name in the e2e config which was not applied after addressing gues OS customization resurce review comments
- Verified other VM related tests after Nightly Acceptance tests was restored. Rerun failing tests relted to clone and customization. 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore /opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/vasila/Library/Application Support/JetBrains/IntelliJIdea2023.2/plugins/go-plugin/lib/dlv/macarm/dlv --listen=127.0.0.1:53135 --headless=true --api-version=2 --check-go-version=false --only-same-user=false exec /Users/vasila/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___2terraform_provider_vsphere.test -- -test.v -test.paniconexit0 -test.run ^\QTestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore\E$ API server listening at: 127.0.0.1:53135
=== RUN   TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore
--- PASS: TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore (596.91s)
PASS

Debugger finished with the exit code 0

TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool /opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/vasila/Library/Application Support/JetBrains/IntelliJIdea2023.2/plugins/go-plugin/lib/dlv/macarm/dlv --listen=127.0.0.1:52898 --headless=true --api-version=2 --check-go-version=false --only-same-user=false exec /Users/vasila/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___2terraform_provider_vsphere.test -- -test.v -test.paniconexit0 -test.run ^\QTestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool\E$ API server listening at: 127.0.0.1:52898
=== RUN   TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool
--- PASS: TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool (179.34s)
PASS

Debugger finished with the exit code 0
TestAccResourceVSphereVirtualMachine_cloneImport - FLAKES very often TestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname /opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/vasila/Library/Application Support/JetBrains/IntelliJIdea2023.2/plugins/go-plugin/lib/dlv/macarm/dlv --listen=127.0.0.1:54995 --headless=true --api-version=2 --check-go-version=false --only-same-user=false exec /Users/vasila/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___2terraform_provider_vsphere.test -- -test.v -test.paniconexit0 -test.run ^\QTestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname\E$ API server listening at: 127.0.0.1:54995
=== RUN   TestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname
--- PASS: TestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname (322.63s)
PASS

Debugger finished with the exit code 0
TestAccResourceVSphereVirtualMachine_cloneWithCustomizationSpec /opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/vasila/Library/Application Support/JetBrains/IntelliJIdea2023.2/plugins/go-plugin/lib/dlv/macarm/dlv --listen=127.0.0.1:55105 --headless=true --api-version=2 --check-go-version=false --only-same-user=false exec /Users/vasila/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___2terraform_provider_vsphere.test -- -test.v -test.paniconexit0 -test.run ^\QTestAccResourceVSphereVirtualMachine_cloneWithCustomizationSpec\E$ API server listening at: 127.0.0.1:55105
=== RUN   TestAccResourceVSphereVirtualMachine_cloneWithCustomizationSpec
--- PASS: TestAccResourceVSphereVirtualMachine_cloneWithCustomizationSpec (416.56s)
PASS

Debugger finished with the exit code 0
TestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone /opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/vasila/Library/Application Support/JetBrains/IntelliJIdea2023.2/plugins/go-plugin/lib/dlv/macarm/dlv --listen=127.0.0.1:55430 --headless=true --api-version=2 --check-go-version=false --only-same-user=false exec /Users/vasila/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___2terraform_provider_vsphere.test -- -test.v -test.paniconexit0 -test.run ^\QTestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone\E$ API server listening at: 127.0.0.1:55430
=== RUN   TestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone
--- PASS: TestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone (200.15s)
PASS

Debugger finished with the exit code 0

...
