### PR TITLE
docs: update `FAQ.md`

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-### Who are the maintainers?
+## Who are the maintainers?
 
 The Terraform provider for VMware vSphere team at HashiCorp include:
 
@@ -8,21 +8,21 @@ The Terraform provider for VMware vSphere team at HashiCorp include:
 * Alex Pilon, Engineer - [@appilon](https://github.com/appilon)
 * Brandy Jackson, Engineering Manager - [@ibrandyjackson](https://github.com/ibrandyjackson)
 
-Collaborators from VMware include:
+Collaborators from Broadcom include:
 
-* Ryan Johnson, Senior Staff Solutions Architect - [@tenthirtyam](https://github.com/tenthirtyam)
-* Vasil Atanasov, Member of Technical Staff - [@vasilsatanasov](https://github.com/vasilsatanasov)
+* Ryan Johnson, [@tenthirtyam](https://github.com/tenthirtyam)
+* Vasil Atanasov, [@vasilsatanasov](https://github.com/vasilsatanasov)
 
-### Why isn’t my PR merged yet?
+## Why isn’t my PR merged yet?
 
-We do our best to focus on the contributions that provide the greatest value to the most community members. 
+We do our best to focus on the contributions that provide the greatest value to the most community members.
 
-### How do you decide what gets merged for each release?
+## How do you decide what gets merged for each release?
 
 The number one factor we look at when deciding what issues to look at are your 👍 [reactions](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue/PR description as these can be easily discovered. Comments that further explain desired use cases or poor user experience are also heavily factored. The items with the most support are always on our radar, and we do our best to keep the community updated on their status and potential timelines, however we will focus on features that will benefit a majority of users.
 
 We also are investing time to improve the contributing experience by improving documentation.
 
-### How can I help?
+## How can I help?
 
 Check out the [Contributing Guide](CONTRIBUTING.md) for additional information.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,7 +4,7 @@
 
 The Terraform provider for VMware vSphere team at HashiCorp include:
 
-* Tejitha Raju, Product Manager - [@tejavar](https://github.com/tejavar)
+* Vishnu Ravindra, Product Manager - [@vravind1](https://github.com/vravind1)
 * Alex Pilon, Engineer - [@appilon](https://github.com/appilon)
 * Brandy Jackson, Engineering Manager - [@ibrandyjackson](https://github.com/ibrandyjackson)
 


### PR DESCRIPTION
### Description

VMware was acquired by Broadcom, Inc. on November 23, 2023.

Update `FAQ.md` to represent Broadcom collaborators.

**Note**: There are no changes required for the product names.
