### PR TITLE
[fix] Error when reading data virtual machine with SRIOV adapter

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -96,6 +96,11 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 						Type:     schema.TypeString,
 						Computed: true,
 					},
+					"physical_function": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The ID of the Physical SR-IOV NIC to attach to, e.g. '0000:d8:00.0'",
+					},
 					"bandwidth_limit": {
 						Type:         schema.TypeInt,
 						Optional:     true,


### PR DESCRIPTION


### Description

Fixing error reated to the SRIOV feature:
Error: error setting network interfaces: Invalid address to set: []string{"network_interfaces", "3", "physical_function"}

The issue is that the data source schema is different from the resource schema and was missing the network_interfaces.#.physical_function attribute in the schema

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

Testing is done manually since the SRIOV  feature requires specific hardware.

HCL 
```
// a vm with sr-iov netowrk adapter
data "vsphere_virtual_machine" "sriov-vm" {
  name = "sriov"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}


output "vm" {
  value = data.vsphere_virtual_machine.sriov-vm
}
```

The network adapter of the vm output 

```
"network_interfaces" = tolist([
    {
      "adapter_type" = "sriov"
      "bandwidth_limit" = 0
      "bandwidth_reservation" = 0
      "bandwidth_share_count" = 0
      "bandwidth_share_level" = ""
      "mac_address" = "00:50:56:9f:8d:d2"
      "network_id" = "dvportgroup-73"
      "physical_function" = "0000:1a:00.1"
    },
  ])
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
