### PR TITLE
fix: add `memory_reservation_locked_to_max` property to `r/vsphere_virtual_macine` schema for sr-iov

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -33,6 +33,7 @@ func TestAccDataSourceVSphereVirtualMachine_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "guest_id"),
 					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "scsi_type"),
 					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "memory"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "memory_reservation_locked_to_max"),
 					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "num_cpus"),
 					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "num_cores_per_socket"),
 					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "firmware"),


### PR DESCRIPTION
### Description

The ` memory_reservation_locked_to_max` property was missing from `vsphere_virtual_macine` schema (both data and resource). The property of the VM was automatically set to `false` if `memory` and `memory_reservation` properties have different values. 

With this commit the property can be set to true explicitly and it will be applied only if `memory` and `memory_reservation properties` have same values. If the `memory_reservation_locked_to_max` is not explicitly set to `true` the original behaviour is preserved.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
API server listening at: 127.0.0.1:60172
=== RUN   TestAccDataSourceVSphereVirtualMachine_basic
--- PASS: TestAccDataSourceVSphereVirtualMachine_basic (71.99s)
PASS

Debugger finished with the exit code 0

=== RUN   TestAccResourceVSphereVirtualMachine_createMemoryReservationLockedToMax
--- PASS: TestAccResourceVSphereVirtualMachine_createMemoryReservationLockedToMax (112.44s)
PASS

Debugger finished with the exit code 0

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
Added support for memory_reservation_locked_to_max property for virtual machine
```
### References
Closes #2091
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
