### PR TITLE
[fix] Fixing failing unit tests

### DIFF
--- a/vsphere/resource_vsphere_file.go
+++ b/vsphere/resource_vsphere_file.go
@@ -149,13 +149,10 @@ func createDirectory(datastoreFileManager *object.DatastoreFileManager, f *file)
 
 // fileUpload - upload file to a vSphere datastore
 func fileUpload(client *govmomi.Client, dc *object.Datacenter, ds *object.Datastore, source, destination string) error {
-	dsurl, err := ds.URL(context.TODO(), dc, destination)
-	if err != nil {
-		return err
-	}
+	dsurl := ds.NewURL(destination)
 
 	p := soap.DefaultUpload
-	err = client.Client.UploadFile(context.TODO(), source, dsurl, &p)
+	err := client.Client.UploadFile(context.TODO(), source, dsurl, &p)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

### Description

Datastore ds.URL method was removed as deprecated in vmware govmomi lib in favour of ds.NewURL but usages in code were not removed causing unit tests to start failing after the upgrade to govmomi v0.34.2 with: Error: vsphere/resource_vsphere_file.go:152:19: ds.URL undefined (type *object.Datastore has no field or method URL)

Updated the usages of the deprecated method with the recommended one

Testing done:

Executed `make test` without errors

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing: N/A

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
