### PR TITLE
fix: scsi ids changing on machines built with v2.6.x

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -1118,7 +1118,7 @@ func (r *NetworkInterfaceSubresource) Update(l object.VirtualDeviceList) ([]type
 	// in-place modification.
 	// A result of this is that if you have any SRIOV network interfaces, you
 	// cannot Update the count of non-SRIOV network interfaces.
-	if r.HasChange("adapter_type") || r.HasChange("physical_function") {
+	if r.HasChange("adapter_type") || physicalFunctionChanged(r) {
 		// Ensure network interfaces aren't changing adapter_type to or from sriov
 		if err := r.blockAdapterTypeChangeSriov(); err != nil {
 			return nil, err
@@ -1512,4 +1512,22 @@ func (r *NetworkInterfaceSubresource) assignEthernetCard(l object.VirtualDeviceL
 		d.Key = -1
 	}
 	return nil
+}
+
+func physicalFunctionChanged(r *NetworkInterfaceSubresource) bool {
+	old, n := r.GetChange("physical_function")
+	var oldVal, newVal string
+	if old == nil {
+		oldVal = ""
+	} else {
+		oldVal = old.(string)
+	}
+
+	if n == nil {
+		newVal = ""
+	} else {
+		newVal = n.(string)
+	}
+
+	return newVal != oldVal
 }


### PR DESCRIPTION

### Description

After the introduction of the SR-IOV feature network adapters due to inconsistent check for changes in the `physical_function` attribute have been recreated after clone since the check always returned `true`. The result is that instead of updating existing NICs the relocate tack started after clone was always deleting the existing NICs and creating new ones. This was causing the new VM to be disconnected from network

Changed the check for changes in `physical_function` attribute to treat nil and empty string equaly so missing `physical_function` attribute in the device compared to empty string from the schema won't be cosnidered as changed.

Testing done: cloned VM from template with 2 nics and verified that there is network connectivity. Also verified the output from lspci command on the template VM and on the clone VM.

Fixes #2089


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References
#2089 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
