### PR TITLE
fix: add vm folder when querying for vm

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -1377,8 +1378,11 @@ func resourceVsphereMachineDeployOvfAndOva(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return nil, fmt.Errorf("error while getting datacenter with id %s %s", dataCenterID, err)
 	}
-
-	vm, err := virtualmachine.FromPath(client, ovfHelper.Name, datacenterObj)
+	searchPath := ovfHelper.Name
+	if ovfHelper.Folder != nil && len(ovfHelper.Folder.InventoryPath) > 0 {
+		searchPath = filepath.Join(ovfHelper.Folder.InventoryPath, searchPath)
+	}
+	vm, err := virtualmachine.FromPath(client, searchPath, datacenterObj)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching the created vm, %s", err)
 	}


### PR DESCRIPTION
### Description

- Added the VM folder in the search for VMs criteria in deploy from OVF scenario.
- Added an e2e test. Verified that when the VM folder is not strictly specified the OVF deploy is passing. The query is in the default VM folder.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccXXX'

API server listening at: 127.0.0.1:65413
=== RUN   TestAccResourceVSphereVirtualMachine_deployOvfFromUrlMultipleVmsSameName
--- PASS: TestAccResourceVSphereVirtualMachine_deployOvfFromUrlMultipleVmsSameName (162.90s)
PASS

Debugger finished with the exit code 0
```

### Release Note

```marrkdown
`r/virtual_machine`: Added the virtual machine folder in the search for virtual machine criteria when deploying from an OVF/OVA. scenario. Allows virtaul machines with same names in different virtual machine folders to be not distinguished as different managed entities. [GH 2118](https://github.com/hashicorp/terraform-provider-vsphere/pull/2118)
```

### References

Closes #1524

