### PR TITLE
fix: set `sync_time_with_host` to default to `true`

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -151,7 +151,13 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"sync_time_with_host": {
 			Type:        schema.TypeBool,
 			Optional:    true,
+			Default:     true,
 			Description: "Enable guest clock synchronization with the host. On vSphere 7.0 U1 and above, with only this setting the clock is synchronized on startup and resume. Requires VMware Tools to be installed.",
+		},
+		"sync_time_with_host_periodically": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable periodic clock synchronization with the host. Supported only on vSphere 7.0 U1 and above. On prior versions setting `sync_time_with_host` is enough for periodic synchronization. Requires VMware Tools to be installed.",
 		},
 		"tools_upgrade_policy": {
 			Type:         schema.TypeString,
@@ -159,11 +165,6 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Default:      string(types.UpgradePolicyManual),
 			Description:  "Set the upgrade policy for VMware Tools. Can be one of `manual` or `upgradeAtPowerCycle`.",
 			ValidateFunc: validation.StringInSlice(virtualMachineUpgradePolicyAllowedValues, false),
-		},
-		"sync_time_with_host_periodically": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "Enable periodic clock synchronization with the host. Supported only on vSphere 7.0 U1 and above. On prior versions setting `sync_time_with_host` is enough for periodic synchronization. Requires VMware Tools to be installed.",
 		},
 		"run_tools_scripts_after_power_on": {
 			Type:        schema.TypeBool,

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -749,7 +749,7 @@ The following options control VMware Tools settings on the virtual machine:
 
 * `run_tools_scripts_before_guest_standby` - (Optional) Enable pre-standby scripts to run when VMware Tools is installed. Default: `true`.
 
-* `sync_time_with_host` - (Optional) Enable the guest operating system to synchronization its clock with the host when the virtual machine is powered on or resumed. Requires vSphere 7.0 Update 1 and later. Requires VMware Tools to be installed. Default: `false`.
+* `sync_time_with_host` - (Optional) Enable the guest operating system to synchronization its clock with the host when the virtual machine is powered on or resumed. Requires vSphere 7.0 Update 1 and later. Requires VMware Tools to be installed. Default: `true`.
 
 * `sync_time_with_host_periodically` - (Optional) Enable the guest operating system to periodically synchronize its clock with the host. Requires vSphere 7.0 Update 1 and later. On previous versions, setting `sync_time_with_host` is will enable periodic synchronization. Requires VMware Tools to be installed. Default: `false`.
 


### PR DESCRIPTION
### Description

- Changed the default value for `sync_time_with_host` in `r/vsphere_virtual_machine` to `true` to align with default value provided by the UI.
- Updated documentation

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Testing Done:

1. Created VM before changes - s`yncTimeWithHostAllowed` was `false`
2. After the changes without explicit configuration `syncTimeWithHostAllowed` was equal to `true`

### Release Note

```markdown
`r/virtual_machine`: Changed the default value for `sync_time_with_host` in `r/vsphere_virtual_machine` to `true` to align with default value provided by the UI.
```

### References

Closes #1443