### PR TITLE
Add support for 64 disks per PVSCSI controller

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -221,7 +221,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Optional:    true,
 			Computed:    true,
 			Description: "A specification for a virtual disk device on this virtual machine.",
-			MaxItems:    60,
+			MaxItems:    256,
 			Elem:        &schema.Resource{Schema: virtualdevice.DiskSubresourceSchema()},
 		},
 		"network_interface": {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -858,7 +858,7 @@ an error if you try to label a disk with this prefix.
 
 * `size` - (Required) The size of the disk, in GB. Must be a whole number.
 
-* `unit_number` - (Optional) The disk number on the storage bus. The maximum value for this setting is the value of the controller count times the controller capacity (15 for SCSI, 30 for SATA, and 2 for IDE). Duplicate unit numbers are not allowed. Default `0`, for which one disk must be set to.
+* `unit_number` - (Optional) The disk number on the storage bus. The maximum value for this setting is the value of the controller count times the controller capacity (15 for SCSI or 64 for PVSCSI, 30 for SATA, and 2 for IDE). Duplicate unit numbers are not allowed. Default `0`, for which one disk must be set to.
 
 * `datastore_id` - (Optional) The [managed object reference ID][docs-about-morefs] for the datastore on which the virtual disk is placed. The default is to use the datastore of the virtual machine. See the section on [virtual machine migration](#virtual-machine-migration) for information on modifying this value.
 


### PR DESCRIPTION
### Description
Per the latest vsphere_virtual_machine terraform provider [documentation](https://registry.terraform.io/providers/hashicorp/vsphere/1.16.0/docs/resources/virtual_machine), all references to max disk count list the max as 15 disks per controller regardless of type. VMware [documentation](https://configmax.esp.vmware.com/guest?vmwareproduct=vSphere&release=vSphere%207.0&categories=1-0), however, lists the max disk count for SCSI controllers of type ```PVSCSI``` (Paravirtual SCSI) as 64. This modified provider has been used locally, and successfully imports VMware virtual machines with up to 64 disks attached to each ```PVSCSI``` controller.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make test
==> Checking that code complies with gofmt requirements...
go test $(go list ./... |grep -v 'vendor') || exit 1
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere (cached)
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   (cached)
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     (cached)
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  (cached)
echo $(go list ./... |grep -v 'vendor') | \
                xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere github.com/hashicorp/terraform-provider-vsphere/vsphere github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere (cached)
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   (cached)
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     (cached)
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  (cached)
```

### Release Note
Release not for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
```
Add support for 64 disks per PVSCSI controller
```

### References
#1427 