### PR TITLE
fix: Differences between creation and import state

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1234,14 +1234,25 @@ func DiskImportOperation(d *schema.ResourceData, l object.VirtualDeviceList) err
 		// the device address.
 		m["key"] = (i + 1) * -1
 		m["device_address"] = addr
-		// Assign a computed label. This label *needs* be the label this disk is
-		// assigned in config, or you risk service interruptions or data corruption.
-		m["label"] = fmt.Sprintf("disk%d", i)
+		// Assign disk label coming from the configuration
+		// If there is no info about the label - assign computed label
+		deviceLabel := ""
+		deviceDescription := device.GetVirtualDevice().DeviceInfo.GetDescription()
+		if deviceDescription != nil {
+			deviceLabel = deviceDescription.Label
+		}
+		keepAfterRemove := false
+		if len(deviceLabel) > 0 {
+			m["label"] = deviceLabel
+		} else {
+			keepAfterRemove = true
+			m["label"] = fmt.Sprintf("disk%d", i)
+		}
 		// Set keep_on_remove to ensure that if labels are assigned incorrectly,
 		// all that happens is that the disk is removed. The comments above
 		// regarding the risk of incorrect label assignment are still true, but
 		// this greatly reduces the risk of data loss.
-		m["keep_on_remove"] = true
+		m["keep_on_remove"] = keepAfterRemove
 
 		curSet = append(curSet, m)
 	}

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -2399,6 +2399,7 @@ func TestAccResourceVSphereVirtualMachine_cloneImport(t *testing.T) {
 					"clone",
 					"cdrom",
 					"wait_for_guest_net_timeout",
+					"sata_controller_count",
 				},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					vm, err := testGetVirtualMachine(s, "vm")


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
There are differences between the state in the r/vsphere_virtual_machine when it is imported and when it is created/cloned. Fixed several of them which maked sense for me.

- datastore_cluster_id - adding the property to the state when the VM is imported in order to keep the pervious behaviour.
- disk.label / disk.keep_on_remove - the logic was to assign a computed label in format "disk<number of the diks>" instead of the actual label added by the system and in such cases the disk was marked as keep_on_remove. Changed this to set the actual label and not setting the keep_on_remove property (defaulting to folse). If the label is not present - keeping the old logic.

- Not sure how to proceed with sata_controller_count - looks like this should be a computed property, but this is a breaking change which I would avoid introducing.

Fixes #1706
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
API server listening at: 127.0.0.1:62880
=== RUN   TestAccResourceVSphereVirtualMachine_basic
--- PASS: TestAccResourceVSphereVirtualMachine_basic (117.01s)
PASS

Debugger finished with the exit code 0

API server listening at: 127.0.0.1:63049
=== RUN   TestAccResourceVSphereVirtualMachine_cloneImport
--- PASS: TestAccResourceVSphereVirtualMachine_cloneImport (229.53s)
PASS

Debugger finished with the exit code 0

TestAccResourceVSphereVirtualMachine_multipleDisksAtDifferentSCSISlotsImport failing with the same error as in nightly acc tests
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
Unifies disk.keep_on_remove with default and disk.label with the correct one assigned to the VM disk during import
If a VM datastore is part of a datastore cluster the datastore_cluster_id attribute is filled during import.
```
### References
#1706 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
