### PR TITLE
fix: support for sr-iov passthrough virtual machine network adapters

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -333,10 +333,15 @@ func computeDevAddr(device types.BaseVirtualDevice, ctlr types.BaseVirtualContro
 	if err != nil {
 		return "", err
 	}
+
+	un := -1
+	if vd.UnitNumber != nil {
+		un = int(structure.DeRef(vd.UnitNumber).(int32))
+	}
 	parts := []string{
 		ctype,
 		strconv.Itoa(int(vc.BusNumber)),
-		strconv.Itoa(int(structure.DeRef(vd.UnitNumber).(int32))),
+		strconv.Itoa(un),
 	}
 	return strings.Join(parts, ":"), nil
 }
@@ -469,7 +474,7 @@ func (r *Subresource) FindVirtualDeviceByAddr(l object.VirtualDeviceList) (types
 	dsf := findVirtualDeviceInListDeviceSelectFunc(ckey, du)
 	devices := l.Select(dsf)
 	if len(devices) != 1 {
-		return nil, fmt.Errorf("invalid device result - %d results returned (expected 1): controller key %q, disk number: %d", len(devices), ckey, du)
+		return nil, fmt.Errorf("invalid device result - %d results returned (expected 1): controller key %q, device number: %d", len(devices), ckey, du)
 	}
 	device := devices[0]
 	log.Printf("[DEBUG] FindVirtualDevice: Device found: %s", l.Name(device))


### PR DESCRIPTION
### Description

This change fixes 2 deficiencies in the support for passthrough network adapters on virtual machines.

The support for SR-IOV adapters was added with https://github.com/hashicorp/terraform-provider-vsphere/pull/2059 which was simply a port of an old change that never made it in https://github.com/hashicorp/terraform-provider-vsphere/pull/1417

The issues introduced by these changes are:
1. In-place repacement of NICs is not supported if the source or destination type is "sriov". The reason provided for this is that "it was too fiddly".
2. The current implementation for SRIOV NICs cannot work with hardware version 20 and onwards, released with vSphere 8

Both problems have the same root cause. A very long time a go someone made the assumption that virtual network adapters are placed on the virtual PCI bus sequentially on slots 7 onwards. More specifically they made the assumption that passthrough adapters are placed on slots 36-45 descending. The entire implementation hangs on its capability to guess the slot number on which the kernel will place a device. We attempt to set the UnitNumber field on each virtual device (even though this is not respected by the kernel) and compute an address for it that we use internally to find the device in the list of devices post-creation.

This already sounds super-fishy and the original developers of the passthrough support decided that the in-place swapping of adapters when SR-IOV is involved is "too fiddly". Can't blame them.

But there is more! The actual problem is that VMware never guaranteed these PCI slot numbers. All of this is based on assumptions.
Starting from hardware version 20 (vSphere 8 and onwards) the kernel creates VMs with a new motherboard layout called ACPI which changes the bus topology (passthrough adapters go to slot 65 and increment from there for example, but again, this is not guaranteed).

My change effectively eliminates all of the guessing when it comes to network adapters. There is no more special handling for SR-IOV. Adapters are instead identified by their position in the list of network devices. This means that the provider will have the same interface for network adapters as the vSphere client, where they are identified by their position.

No changes are being made to devices other than network adapters.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

Ran all tests for virtual nics and added one new case

```console
=== RUN   TestAccResourceVSphereVirtualMachine_cloneMultiNICFromSingleNICTemplate
--- PASS: TestAccResourceVSphereVirtualMachine_cloneMultiNICFromSingleNICTemplate (86.75s)
PASS

=== RUN   TestAccResourceVSphereVirtualMachine_cloneMultiNICSRIOVFromVMXNET3Template
--- PASS: TestAccResourceVSphereVirtualMachine_cloneMultiNICSRIOVFromVMXNET3Template (92.30s)
PASS

=== RUN   TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs
--- PASS: TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs (85.89s)
PASS

=== RUN   TestAccResourceVSphereVirtualMachine_SRIOV
--- PASS: TestAccResourceVSphereVirtualMachine_SRIOV (79.10s)
```

### Release Note

```release-note
Fix the support for SR-IOV passthrough virtual machine network adapters
```
### References

Closes #2092
