### PR TITLE
bugfix: Remove default values for ept_rvi_mode and hv_mode

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -127,14 +127,12 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"hv_mode": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			Default:      string(types.VirtualMachineFlagInfoVirtualExecUsageHvAuto),
 			Description:  "The (non-nested) hardware virtualization setting for this virtual machine. Can be one of hvAuto, hvOn, or hvOff.",
 			ValidateFunc: validation.StringInSlice(virtualMachineVirtualExecUsageAllowedValues, false),
 		},
 		"ept_rvi_mode": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			Default:      string(types.VirtualMachineFlagInfoVirtualMmuUsageAutomatic),
 			Description:  "The EPT/RVI (hardware memory virtualization) setting for this virtual machine. Can be one of automatic, on, or off.",
 			ValidateFunc: validation.StringInSlice(virtualMachineVirtualMmuUsageAllowedValues, false),
 		},


### PR DESCRIPTION
### Description

I'm removing the default values for `ept_rvi_mode` and `hv_mode` from the virtual machine configuration.
These properties are overwritten during the "read" phase and cause in uplace updates on the VM even if the configuration hasn't changed.

We should allow the vCenter to control the defaults instead of setting them ourselves

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Ran `TestAccResourceVSphereVirtualMachine_basic`

Manually tested by applying the same confguration twice

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```release-note
NONE
```
### References

https://github.com/hashicorp/terraform-provider-vsphere/issues/1902