### PR TITLE
chore(ci): codeql-analysis with go1.21+

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      # Workaround for Go 1.21 compatibility.
+      # TODO: Remove when GitHub Action runners Support Go 1.21+.
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+        go-version-file: "go.mod"
+      cache: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4262713b504983e61c7728f5452be240d9385a7 # codeql-bundle-v2.14.3
         with:


### PR DESCRIPTION
### Description

- Workaround for Go 1.21 compatibility.
- Remove when GitHub Action runners Support Go 1.21+.
