### PR TITLE
docs: guest customizations anchor link

### DIFF
--- a/website/docs/d/guest_os_customization.html.markdown
+++ b/website/docs/d/guest_os_customization.html.markdown
@@ -34,4 +34,4 @@ The following arguments are supported:
 * `description` - The description for the customization specification.
 * `last_update_time` - The time of last modification to the customization specification.
 * `change_version` - The number of last changed version to the customization specification.
-* `spec` - Container object for the guest operating system properties to be customized. See [virtual machine customizations](#virtual-machine-customizations)
+* `spec` - Container object for the guest operating system properties to be customized. See [virtual machine customizations](virtual_machine#virtual-machine-customizations)

--- a/website/docs/r/guest_os_customization.html.markdown
+++ b/website/docs/r/guest_os_customization.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the customization specification is the unique identifier per vCenter Server instance.
 * `type` - (Required) The type of customization specification: One among: Windows, Linux.
 * `description` - (Optional) The description for the customization specification.
-* `spec` - Container object for the Guest OS properties about to be customized . See [virtual machine customizations](#virtual-machine-customizations)
+* `spec` - Container object for the Guest OS properties about to be customized . See [virtual machine customizations](virtual_machine#virtual-machine-customizations)
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

Corrected resource and data source links intended for `virtual_machine#virtual-machine-customizations` instead of `virtual-machine-customizations` on self.

Closes #2102
