### PR TITLE
chore: update to sha256 for session file

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -325,7 +325,7 @@ func (c *Config) sessionFile() (string, error) {
 	// Key session file off of full URI and insecure setting.
 	// Hash key to get a predictable, canonical format.
 	key := fmt.Sprintf("%s#insecure=%t", u.String(), c.InsecureFlag)
-	name := fmt.Sprintf("%040x", sha1.Sum([]byte(key)))
+	name := fmt.Sprintf("%040x", sha256.Sum256([]byte(key)))
 	return name, nil
 }
 


### PR DESCRIPTION
### Description

In general, vSphere is maving from SHA1 to SHA256-based TLS certificate thumbprints. This change allows the use of a SHA256 thumbprint when connecting to vCenter Server.

Support for SHA256 was added to `vmware/govmomi` v0.36.1.

### References

Closes #2152

https://github.com/vmware/govmomi/commit/279963476f88c9853c9c867909e892b7296fa14b

https://github.com/vmware/govmomi/releases/tag/v0.36.1

https://github.com/hashicorp/terraform-provider-vsphere/pull/1808#issuecomment-1993057186