### PR TITLE
Use node20 in GH actions

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 18
+          node-version: 20
 
       # Due to third party action restrictions, install and use the tool directly
       - name: Set up gotestfmt
@@ -84,7 +84,7 @@ jobs:
         run: echo "TODAY_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Upload test log
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: test-log-${{ env.TODAY_DATE }}
           path: /tmp/gotest.log

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,10 +28,10 @@ jobs:
           go-version-file: "go.mod"
           cache: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4262713b504983e61c7728f5452be240d9385a7 # codeql-bundle-v2.14.3
+        uses: github/codeql-action/init@c4fb451437765abf5018c6fbf22cce1a7da1e5cc # codeql-bundle-v2.17.1
         with:
           languages: "${{ matrix.language }}"
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4262713b504983e61c7728f5452be240d9385a7 # codeql-bundle-v2.14.3
+        uses: github/codeql-action/autobuild@c4fb451437765abf5018c6fbf22cce1a7da1e5cc # codeql-bundle-v2.17.1
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4262713b504983e61c7728f5452be240d9385a7 # codeql-bundle-v2.14.3
+        uses: github/codeql-action/analyze@c4fb451437765abf5018c6fbf22cce1a7da1e5cc # codeql-bundle-v2.17.1

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-    - uses: github/issue-labeler@6bea9ed491bb74fce38775b3d863e64a59dbd9eb # v3.3
+    - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml

--- a/.github/workflows/issue_greeting.yml
+++ b/.github/workflows/issue_greeting.yml
@@ -23,7 +23,7 @@ jobs:
           vars: |
             author: ${{ github.actor }}
       - name: Create Comment
-        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3.1.0
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: '${{ github.event.issue.number }}'
           body: '${{ steps.template.outputs.result }}'

--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -12,7 +12,7 @@ jobs:
   Comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: bflad/action-milestone-comment@ae6c9fdf5778064d4e09b4632604a16b7289096c # v1.0.2
+      - uses: bflad/action-milestone-comment@4618cbf8bf938d31af1c576beeaaa77f486f5af3 # v2.0.0
         with:
           body: |
             This functionality has been released in [${{ github.event.milestone.title }} of the Terraform Provider](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).  Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Generate Release Notes
         run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: release-notes
           path: release-notes.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v3.0.1
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'
       hc-releases-key-staging: '${{ secrets.HC_RELEASES_KEY_STAGING }}'


### PR DESCRIPTION
Update transitive GitHub actions to trusted versions that use node 20.

Waiting on update for:

- [x] https://github.com/bflad/action-milestone-comment