### PR TITLE
Revert "bugfix: Remove default values for ept_rvi_mode and hv_mode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
+## 2.8.1 (May 08, 2024)
+
+BUG FIX:
+
+* `resource/virtual_machine`: Reverts removing the default values for `ept_rvi_mode` and `hv_mode`
+  from the virtual machine configuration.
+  ([#2194](https://github.com/terraform-providers/terraform-provider-vsphere/pull/2194))
+
 ## 2.8.0 (May 07, 2024)
 
 BUG FIX:

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -127,12 +127,14 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"hv_mode": {
 			Type:         schema.TypeString,
 			Optional:     true,
+			Default:      string(types.VirtualMachineFlagInfoVirtualExecUsageHvAuto),
 			Description:  "The (non-nested) hardware virtualization setting for this virtual machine. Can be one of hvAuto, hvOn, or hvOff.",
 			ValidateFunc: validation.StringInSlice(virtualMachineVirtualExecUsageAllowedValues, false),
 		},
 		"ept_rvi_mode": {
 			Type:         schema.TypeString,
 			Optional:     true,
+			Default:      string(types.VirtualMachineFlagInfoVirtualMmuUsageAutomatic),
 			Description:  "The EPT/RVI (hardware memory virtualization) setting for this virtual machine. Can be one of automatic, on, or off.",
 			ValidateFunc: validation.StringInSlice(virtualMachineVirtualMmuUsageAllowedValues, false),
 		},


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-vsphere#2172

We need to look for a way to fix ept_rvi_mode and hv_mode without causing disruption to running VMs

Related issue - https://github.com/hashicorp/terraform-provider-vsphere/issues/2193