### PR TITLE
docs: use correct vm template's firmware in local OVF example

### DIFF
--- a/website/docs/d/ovf_vm_template.html.markdown
+++ b/website/docs/d/ovf_vm_template.html.markdown
@@ -137,7 +137,7 @@ resource "vsphere_virtual_machine" "vmFromLocalOvf" {
   num_cores_per_socket = data.vsphere_ovf_vm_template.ovfLocal.num_cores_per_socket
   memory               = data.vsphere_ovf_vm_template.ovfLocal.memory
   guest_id             = data.vsphere_ovf_vm_template.ovfLocal.guest_id
-  firmware             = data.vsphere_ovf_vm_template.ovfRemote.firmware
+  firmware             = data.vsphere_ovf_vm_template.ovfLocal.firmware
   scsi_type            = data.vsphere_ovf_vm_template.ovfLocal.scsi_type
   nested_hv_enabled    = data.vsphere_ovf_vm_template.ovfLocal.nested_hv_enabled
   dynamic "network_interface" {


### PR DESCRIPTION
### Description
This is supposed to use `ovfLocal` instead of `ovfRemote`.

### Acceptance tests
- [N] Have you added an acceptance test for the functionality being added?
- [N] Have you run the acceptance tests on this branch?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

