### PR TITLE
docs: update `api_timeout`

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -14,8 +14,8 @@ This provider can be used to manage many aspects of a vSphere environment,
 including virtual machines, standard and distributed switches, datastores,
 content libraries, and more.
 
-[vmware-vcenter]: https://www.vmware.com/products/vcenter-server.html
-[vmware-esxi]: https://www.vmware.com/products/esxi-and-esx.html
+[vmware-vcenter]: https://www.vmware.com/products/vcenter.html
+[vmware-esxi]: https://www.vmware.com/content/vmware/vmware-published-sites/us/products/esxi-and-esx.html.html
 
 Use the navigation to read about the resources and data sources supported by
 this provider.
@@ -46,6 +46,7 @@ provider "vsphere" {
   password             = var.vsphere_password
   vsphere_server       = var.vsphere_server
   allow_unverified_ssl = true
+  api_timeout          = 10
 }
 
 data "vsphere_datacenter" "datacenter" {
@@ -73,7 +74,7 @@ resource "vsphere_virtual_machine" "vm" {
   datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 1
   memory           = 1024
-  guest_id         = "other3xLinux64Guest"
+  guest_id         = "otherLinux64Guest"
   network_interface {
     network_id = data.vsphere_network.network.id
   }
@@ -110,7 +111,11 @@ The following arguments are used to configure the provider:
   without API interaction do not result in a session timeout. Can also be
   specified with the `VSPHERE_VIM_KEEP_ALIVE` environment variable.
 * `api_timeout` - (Optional) Sets the number of minutes to wait for operations
-  to complete. The default timeout is 5 minutes.
+  to complete. The default timeout is 5 minutes. Can also be
+  specified with the `VSPHERE_API_TIMEOUT` environment variable.
+
+~> **NOTE:** Use of the `api_timeout` option to extend the timeout from the
+default is recommended when creating virtual machines with large disks.
 
 ### Session Persistence Options
 
@@ -233,7 +238,7 @@ below.
 
 #### Using `govc`
 
-[govc][docs-govc] is an vSphere CLI built on [govmomi][docs-govmomi], the
+[`govc`][docs-govc] is an vSphere CLI built on [govmomi][docs-govmomi], the
 vSphere Go SDK. It has a robust inventory browser command that can also be used
 to list managed object IDs.
 
@@ -254,19 +259,16 @@ $ govc ls -i -l -L VirtualMachine:vm-123
 VirtualMachine:vm-123 /dc-01/vm/foo
 ```
 
-For details on setting up govc, see the [GitHub project][docs-govc].
+For details on setting up `govc`, see the [GitHub project][docs-govc].
 
-[docs-govc]: https://github.com/vmware/govmomi/tree/master/govc
+[docs-govc]: https://github.com/vmware/govmomi/tree/main/govc
 [docs-govmomi]: https://github.com/vmware/govmomi
 
 #### Using the vSphere Managed Object Browser (MOB)
 
 The Managed Object Browser (MOB) allows one to browse the entire vSphere
 inventory as it's presented to the API. It's normally accessed using
-`https://<vcenter_fqdn>/mob`. For more information, see
-[here][vsphere-docs-using-mob].
-
-[vsphere-docs-using-mob]: https://developer.vmware.com/doc/PG_Appx_Using_MOB.21.2.html#994699
+`https://<vcenter_fqdn>/mob`.
 
 ~> **NOTE:** The MOB also offers API method invocation capabilities, and for
 security reasons should be used sparingly. Modern vSphere installations may

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -861,10 +861,12 @@ The options are:
 
 ~> **NOTE:** It's recommended that you set the disk label to a format matching `diskN`, where `N` is the number of the disk, starting from disk number 0. This will ensure that your configuration is compatible when importing a virtual machine. See the section on [importing](#importing) for more information.
 
-~> **NOTE:** Do not choose a label that starts with `orphaned_disk_` (_e.g._  `orphaned_disk_0`), as this prefix is reserved for disks that the provider does not recognize. Such as disks that are attached externally. The Terraform provider will issue
+~> **NOTE:** Do not choose a label that starts with `orphaned_disk_` (_e.g._ `orphaned_disk_0`), as this prefix is reserved for disks that the provider does not recognize. Such as disks that are attached externally. The Terraform provider will issue
 an error if you try to label a disk with this prefix.
 
 * `size` - (Required) The size of the disk, in GB. Must be a whole number.
+
+~> **NOTE:** Use the [`api_timeout`](/docs/providers/vsphere/index.html#argument-reference) option to increase the default timeout when creating virtual machines with large disk sizes and avoid "context deadline exceeded" errors.
 
 * `unit_number` - (Optional) The disk number on the storage bus. The maximum value for this setting is the value of the controller count times the controller capacity (15 for SCSI, 30 for SATA, and 2 for IDE). Duplicate unit numbers are not allowed. Default `0`, for which one disk must be set to.
 


### PR DESCRIPTION
### Description

- Adds additional informatation regarding the provider's `api_timeout` configuration option and includes a reference in `r/virtual_machine`.
- Corrects some old links. (more to come.)

### References

Closes #2195