### PR TITLE
chore: version tracking

### DIFF
--- a/vsphere/internal/helper/guestoscustomizations/customizations_helper.go
+++ b/vsphere/internal/helper/guestoscustomizations/customizations_helper.go
@@ -441,9 +441,12 @@ func flattenWindowsOptions(customizationPrep *types.CustomizationSysprep, versio
 		winOptionsData["domain_admin_password"] = customizationPrep.Identification.DomainAdminPassword.Value
 	}
 	winOptionsData["join_domain"] = customizationPrep.Identification.JoinDomain
+
+	// Minimum Supported Version: 8.0.2
 	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 8, Minor: 0, Patch: 2}) {
 		winOptionsData["domain_ou"] = customizationPrep.Identification.DomainOU
 	}
+
 	winOptionsData["workgroup"] = customizationPrep.Identification.JoinWorkgroup
 	hostName, err := flattenHostName(customizationPrep.UserData.ComputerName)
 	if err != nil {
@@ -617,9 +620,12 @@ func expandCustomizationIdentification(d *schema.ResourceData, prefix string, ve
 		JoinDomain:    d.Get(prefix + "join_domain").(string),
 		DomainAdmin:   d.Get(prefix + "domain_admin_user").(string),
 	}
+
+	// Minimum Supported Version: 8.0.2
 	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 8, Minor: 0, Patch: 2}) {
 		obj.DomainOU = d.Get(prefix + "domain_ou").(string)
 	}
+
 	if v, ok := d.GetOk(prefix + "domain_admin_password"); ok {
 		obj.DomainAdminPassword = &types.CustomizationPassword{
 			Value:     v.(string),

--- a/vsphere/internal/helper/viapi/vim_helper.go
+++ b/vsphere/internal/helper/viapi/vim_helper.go
@@ -137,16 +137,16 @@ type VSphereVersion struct {
 	// The product name. Example: "VMware vCenter Server", or "VMware ESXi".
 	Product string
 
-	// The major version. Example: If "6.5.1" is the full version, the major
-	// version is "6".
+	// The major version. Example: If "" is the full version, the major
+	// version is "x".
 	Major int
 
-	// The minor version. Example: If "6.5.1" is the full version, the minor
-	// version is "5".
+	// The minor version. Example: If "x.y.z" is the full version, the minor
+	// version is "y".
 	Minor int
 
-	// The patch version. Example: If "6.5.1" is the full version, the patch
-	// version is "1".
+	// The patch version. Example: If "x.y.z" is the full version, the patch
+	// version is "z".
 	Patch int
 
 	// The build number. This is usually a lengthy integer. This number should

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -711,6 +711,8 @@ func testAccResourceVSphereComputeClusterVSANEsaPreCheck(t *testing.T) {
 	if err != nil {
 		t.Skip("can not get client")
 	}
+
+	// Minimum Supported Version: 8.0.0
 	if version := viapi.ParseVersionFromClient(client); !version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 8, Minor: 0}) {
 		t.Skip("vSAN ESA acceptance test should be run on vSphere 8.0 or higher")
 	}
@@ -1280,7 +1282,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   drs_automation_level = "fullyAutomated"
 
   ha_enabled = true
-  
+
 	force_evacuate_on_destroy = true
 }
 `,
@@ -1306,7 +1308,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
   datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
   host_system_ids = [data.vsphere_host.roothost3.id]
-  
+
   force_evacuate_on_destroy = true
 
   %s

--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -694,6 +694,7 @@ func expandStorageDrsPodConfigSpec(d *schema.ResourceData, version viapi.VSphere
 		Option:                 expandStorageDrsOptionSpec(d),
 	}
 
+	// Minimum Supported Version: 6.0.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
 		obj.AutomationOverrides = expandStorageDrsAutomationConfig(d)
 	}
@@ -729,6 +730,7 @@ func flattenStorageDrsPodConfigInfo(d *schema.ResourceData, obj types.StorageDrs
 		return err
 	}
 
+	// Minimum Supported Version: 6.0.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
 		if err := flattenStorageDrsAutomationConfig(d, obj.AutomationOverrides); err != nil {
 			return err
@@ -777,6 +779,7 @@ func expandStorageDrsIoLoadBalanceConfig(d *schema.ResourceData, version viapi.V
 		IoLoadImbalanceThreshold: int32(d.Get("sdrs_io_load_imbalance_threshold").(int)),
 	}
 
+	// Minimum Supported Version: 6.0.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
 		obj.ReservableIopsThreshold = int32(d.Get("sdrs_io_reservable_iops_threshold").(int))
 		obj.ReservablePercentThreshold = int32(d.Get("sdrs_io_reservable_percent_threshold").(int))
@@ -797,6 +800,8 @@ func flattenStorageDrsIoLoadBalanceConfig(
 		"sdrs_io_latency_threshold":        obj.IoLatencyThreshold,
 		"sdrs_io_load_imbalance_threshold": obj.IoLoadImbalanceThreshold,
 	}
+
+	// Minimum Supported Version: 6.0.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
 		attrs["sdrs_io_reservable_threshold_mode"] = obj.ReservableThresholdMode
 		if obj.ReservableThresholdMode == string(types.StorageDrsPodConfigInfoBehaviorManual) {
@@ -826,6 +831,7 @@ func expandStorageDrsSpaceLoadBalanceConfig(
 		SpaceUtilizationThreshold:     int32(d.Get("sdrs_space_utilization_threshold").(int)),
 	}
 
+	// Minimum Supported Version: 6.0.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
 		obj.FreeSpaceThresholdGB = int32(d.Get("sdrs_free_space_threshold").(int))
 		obj.SpaceThresholdMode = d.Get("sdrs_free_space_threshold_mode").(string)
@@ -846,6 +852,7 @@ func flattenStorageDrsSpaceLoadBalanceConfig(
 		"sdrs_free_space_threshold_mode":         obj.SpaceThresholdMode,
 	}
 
+	// Minimum Supported Version: 6.0.0
 	freeSpaceSupported := version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6})
 	if freeSpaceSupported && obj.SpaceThresholdMode == string(types.StorageDrsSpaceLoadBalanceConfigSpaceThresholdModeFreeSpace) {
 		attrs["sdrs_free_space_threshold"] = obj.FreeSpaceThresholdGB

--- a/vsphere/resource_vsphere_resource_pool.go
+++ b/vsphere/resource_vsphere_resource_pool.go
@@ -275,6 +275,7 @@ func resourceVSphereResourcePoolIDString(d structure.ResourceIDStringer) string 
 }
 
 func flattenResourcePoolConfigSpec(d *schema.ResourceData, obj types.ResourceConfigSpec, version viapi.VSphereVersion) error {
+	// Minimum Supported Version: 7.0.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 0}) {
 		d.Set("scale_descendants_shares", obj.ScaleDescendantsShares)
 	} else {
@@ -312,6 +313,8 @@ func expandResourcePoolConfigSpec(d *schema.ResourceData, version viapi.VSphereV
 		CpuAllocation:    expandResourcePoolCPUAllocation(d),
 		MemoryAllocation: expandResourcePoolMemoryAllocation(d),
 	}
+
+	// Minimum Supported Version: 7.0.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 0}) {
 		obj.ScaleDescendantsShares = d.Get("scale_descendants_shares").(string)
 	}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -925,20 +925,23 @@ func resourceVSphereVirtualMachineCustomizeDiff(_ context.Context, d *schema.Res
 	log.Printf("[DEBUG] %s: Performing diff customization and validation", resourceVSphereVirtualMachineIDString(d))
 	client := meta.(*Client).vimClient
 
-	// Block certain options from being set depending on the vSphere version.
 	version := viapi.ParseVersionFromClient(client)
+
+	// Minimum Supported Version: 6.5.0
 	if d.Get("efi_secure_boot_enabled").(bool) {
 		if version.Older(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 5}) {
 			return fmt.Errorf("efi_secure_boot_enabled is only supported on vSphere 6.5 and higher")
 		}
 	}
 
+	// Minimum Supported Version: 6.7.0
 	if d.Get("vbs_enabled").(bool) {
 		if version.Older(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 7}) {
 			return fmt.Errorf("vbs_enabled is only supported on vSphere 6.7 and higher")
 		}
 	}
 
+	// Minimum Supported Version: 6.7.0
 	if d.Get("vvtd_enabled").(bool) {
 		if version.Older(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 7}) {
 			return fmt.Errorf("vvtd_enabled is only supported on vSphere 6.7 and higher")

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -392,8 +392,10 @@ func expandVirtualMachineBootOptions(d *schema.ResourceData, client *govmomi.Cli
 		BootRetryEnabled: structure.GetBool(d, "boot_retry_enabled"),
 		BootRetryDelay:   int64(d.Get("boot_retry_delay").(int)),
 	}
-	// Only set EFI secure boot if we are on vSphere 6.5 and higher
+
 	version := viapi.ParseVersionFromClient(client)
+
+	// Minimum Supported Version: 6.5.0
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 5}) {
 		obj.EfiSecureBootEnabled = getBoolWithRestart(d, "efi_secure_boot_enabled")
 	}
@@ -419,7 +421,10 @@ func expandVirtualMachineFlagInfo(d *schema.ResourceData, client *govmomi.Client
 		VirtualMmuUsage:  getWithRestart(d, "ept_rvi_mode").(string),
 		EnableLogging:    getBoolWithRestart(d, "enable_logging"),
 	}
+
 	version := viapi.ParseVersionFromClient(client)
+
+	// Minimum Supported Version: 6.7.0
 	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 7}) {
 		obj.VbsEnabled = getBoolWithRestart(d, "vbs_enabled")
 		obj.VvtdEnabled = getBoolWithRestart(d, "vvtd_enabled")
@@ -436,6 +441,8 @@ func flattenVirtualMachineFlagInfo(d *schema.ResourceData, obj *types.VirtualMac
 	_ = d.Set("enable_logging", obj.EnableLogging)
 
 	version := viapi.ParseVersionFromClient(client)
+
+	// Minimum Supported Version: 6.0.0
 	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 7}) {
 		_ = d.Set("vbs_enabled", obj.VbsEnabled)
 		_ = d.Set("vvtd_enabled", obj.VvtdEnabled)
@@ -457,6 +464,8 @@ func expandToolsConfigInfo(d *schema.ResourceData, client *govmomi.Client) *type
 	}
 
 	version := viapi.ParseVersionFromClient(client)
+
+	// Minimum Supported Version: 7.0.1
 	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 0, Patch: 1}) {
 		obj.SyncTimeWithHostAllowed = structure.GetBool(d, "sync_time_with_host")
 		obj.SyncTimeWithHost = structure.GetBool(d, "sync_time_with_host_periodically")
@@ -476,6 +485,8 @@ func flattenToolsConfigInfo(d *schema.ResourceData, obj *types.ToolsConfigInfo, 
 	_ = d.Set("run_tools_scripts_before_guest_reboot", obj.BeforeGuestReboot)
 
 	version := viapi.ParseVersionFromClient(client)
+
+	// Minimum Supported Version: 7.0.1
 	if version.AtLeast(viapi.VSphereVersion{Product: version.Product, Major: 7, Minor: 0, Patch: 1}) {
 		_ = d.Set("sync_time_with_host", obj.SyncTimeWithHostAllowed)
 		_ = d.Set("sync_time_with_host_periodically", obj.SyncTimeWithHost)


### PR DESCRIPTION
### Description

Adds `// Minimum Supported Version: x.y.z` where there is a version restriction.

This is preparation for removing checks and to support only 7.0 and higher per the product lifecycle.