### PR TITLE
fix: update searchPath

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"net"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -1405,7 +1405,7 @@ func resourceVsphereMachineDeployOvfAndOva(d *schema.ResourceData, meta interfac
 	}
 	searchPath := ovfHelper.Name
 	if ovfHelper.Folder != nil && len(ovfHelper.Folder.InventoryPath) > 0 {
-		searchPath = filepath.Join(ovfHelper.Folder.InventoryPath, searchPath)
+		searchPath = path.Join(ovfHelper.Folder.InventoryPath, searchPath)
 	}
 	vm, err := virtualmachine.FromPath(client, searchPath, datacenterObj)
 	if err != nil {


### PR DESCRIPTION
### Description

Updates `searchPath` to use `path` instead of `filepath` since this is a vSphere inventory path (e.g., `\Datacenter\vm\<vm_name>`), not a directory path.

```go
searchPath := ovfHelper.Name
if ovfHelper.Folder != nil && len(ovfHelper.Folder.InventoryPath) > 0 {
	searchPath = path.Join(ovfHelper.Folder.InventoryPath, searchPath)
}
```

### Testing

- Terraform v1.8.5
- VMware vSphere 8.0.2

🟢 **PASS**: Test on Windows 11 Pro, 22H2

```powershell
PS C:\Users\Owner\Desktop> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      7.4.2
PSEdition                      Core
GitCommitId                    7.4.2
OS                             Microsoft Windows 10.0.22621
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

PS C:\Users\Owner\Desktop> terraform apply -auto-approve
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 0s [id=datacenter-3]
data.vsphere_compute_cluster.cluster: Reading...
data.vsphere_datastore.datastore: Reading...
data.vsphere_network.network: Reading...
data.vsphere_host.host: Reading...
data.vsphere_network.network: Read complete after 0s [id=network-18085]
data.vsphere_host.host: Read complete after 0s [id=host-18072]
data.vsphere_datastore.datastore: Read complete after 0s [id=datastore-18076]
data.vsphere_compute_cluster.cluster: Read complete after 0s [id=domain-c18070]
data.vsphere_resource_pool.pool: Reading...
data.vsphere_resource_pool.pool: Read complete after 0s [id=resgroup-18071]
data.vsphere_ovf_vm_template.ovf: Reading...
data.vsphere_ovf_vm_template.ovf: Read complete after 1s [id=ubuntu-24.04-server-cloudimg-amd64]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_virtual_machine.nested_esxi will be created
  + resource "vsphere_virtual_machine" "nested_esxi" {
      + annotation                              = (known after apply)
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datacenter_id                           = "datacenter-3"
      + datastore_id                            = "datastore-18076"
      + default_ip_address                      = (known after apply)
      + ept_rvi_mode                            = "automatic"
      + extra_config_reboot_required            = true
      + firmware                                = "bios"
      + folder                                  = "management"
      + force_power_off                         = true
      + guest_id                                = "ubuntu64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = "host-18072"
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 1024
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "ubuntu-01"
      + num_cores_per_socket                    = 0
      + num_cpus                                = 2
      + power_state                             = (known after apply)
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-18071"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + sync_time_with_host                     = true
      + tools_upgrade_policy                    = "manual"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 0

      + cdrom {
          + client_device  = true
          + device_address = (known after apply)
          + key            = (known after apply)
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-18085"
        }

      + ovf_deploy {
          + allow_unverified_ssl_cert = true
          + disk_provisioning         = "thin"
          + enable_hidden_properties  = false
          + ovf_network_map           = {
              + "VM Network" = "network-18085"
            }
          + remote_ovf_url            = "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.ova"     
        }

      + vapp {
          + properties = {
              + "hostname"    = "ubuntu-01"
              + "instance-id" = "ubuntu-01"
              + "password"    = "VMware1!"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
vsphere_virtual_machine.nested_esxi: Creating...
vsphere_virtual_machine.nested_esxi: Still creating... [10s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [20s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [30s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [40s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [50s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [1m0s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [1m10s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [1m20s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [1m30s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [1m40s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [1m50s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [2m0s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [2m10s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [2m20s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [2m30s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [2m40s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [2m50s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [3m0s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [3m10s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [3m20s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [3m30s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [3m40s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [3m50s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [4m0s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [4m10s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [4m20s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [4m30s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [4m40s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [4m50s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [5m0s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [5m10s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [5m20s elapsed]
vsphere_virtual_machine.nested_esxi: Still creating... [5m30s elapsed]
vsphere_virtual_machine.nested_esxi: Creation complete after 5m38s [id=421edbdf-e244-8ee8-8541-e3afbb719c09]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

🟢 **PASS**: Regression Test on Linux and macOS.

### Reference

Closes #2166