### PR TITLE
docs: customization spec examples

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -335,9 +335,9 @@ func testAccDataSourceVirtualMachineFolder() string {
 		path		  = "new-vm-folder"
 		datacenter_id = data.vsphere_datacenter.rootdc1.id
 		type		  = "vm"
-	
+
 	}
-	
+
 	resource "vsphere_virtual_machine" "vm" {
 	  name             = "foo"
 	  resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
@@ -345,7 +345,7 @@ func testAccDataSourceVirtualMachineFolder() string {
 	  datastore_id     = data.vsphere_datastore.rootds1.id
 	  num_cpus         = 1
 	  memory           = 1024
-	  guest_id         = "other3xLinux64Guest"
+	  guest_id         = "otherLinux64Guest"
 	  network_interface {
 		network_id = data.vsphere_network.network1.id
 	  }
@@ -356,14 +356,14 @@ func testAccDataSourceVirtualMachineFolder() string {
 	 wait_for_guest_ip_timeout = 0
 	 wait_for_guest_net_timeout  = 0
 	}
-	
+
 	data vsphere_virtual_machine "vm1" {
 		name 		  = vsphere_virtual_machine.vm.name
 		datacenter_id = data.vsphere_datacenter.rootdc1.id
 		folder 		  = vsphere_folder.new_vm_folder.path
 	}
 
-	
+
 `, testhelper.CombineConfigs(
 		testhelper.ConfigDataRootDC1(),
 		testhelper.ConfigDataRootPortGroup1(),

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -4053,13 +4053,13 @@ resource "vsphere_virtual_machine" "vm" {
     unit_number = 16
     size        = 5
   }
-  
+
   disk {
     label       = "disk4"
     unit_number = 30
     size        = 5
   }
-  
+
   disk {
     label       = "disk5"
     unit_number = 31
@@ -4480,7 +4480,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   wait_for_guest_net_timeout = -1
 
@@ -5798,7 +5798,7 @@ resource "vsphere_virtual_machine" "vm" {
     adapter_type = "sriov"
     physical_function = "%s"
   }
-  
+
   network_interface {
     network_id = "${data.vsphere_network.network1.id}"
     adapter_type = "sriov"
@@ -6761,7 +6761,7 @@ variable "extra_vmdk_name" {
 
 data "vsphere_datastore" "ds" {
   datacenter_id = data.vsphere_datacenter.rootdc1.id
-  name          = var.datastore  
+  name          = var.datastore
 }
 
 resource "vsphere_virtual_disk" "disk" {
@@ -7273,7 +7273,7 @@ resource "vsphere_virtual_machine" "vm" {
   guest_id                   = "other3xLinuxGuest"
 	wait_for_guest_net_timeout = -1
 
-  network_interface { 
+  network_interface {
     network_id = data.vsphere_network.network1.id
   }
     disk {
@@ -7479,7 +7479,7 @@ resource "vsphere_guest_os_customization" "gosc_spec" {
 		}
 		network_interface {}
 	}
-	
+
 }
 
 data "vsphere_virtual_machine" "template" {

--- a/website/docs/d/guest_os_customization.html.markdown
+++ b/website/docs/d/guest_os_customization.html.markdown
@@ -14,13 +14,30 @@ The `vsphere_guest_os_customization` data source can be used to discover the det
 Suggested change
 ~> **NOTE:** The name attribute is the unique identifier for the customization specification per vCenter Server instance.
 
-
 ## Example Usage
 
 ```hcl
-  data "vsphere_guest_os_customization" "gosc1" {
-    name          = "linux-spec"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = "windows-template"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+data "vsphere_guest_os_customization" "windows" {
+  name = "windows"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  # ... other configuration ...
+  template_uuid = data.vsphere_virtual_machine.template.id
+  customization_spec {
+    id = data.vsphere_guest_os_customization.windows.id
   }
+  # ... other configuration ...
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/compute_cluster_vm_dependency_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_dependency_rule.html.markdown
@@ -71,7 +71,7 @@ resource "vsphere_virtual_machine" "vm1" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"
@@ -90,7 +90,7 @@ resource "vsphere_virtual_machine" "vm2" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"

--- a/website/docs/r/compute_cluster_vm_group.html.markdown
+++ b/website/docs/r/compute_cluster_vm_group.html.markdown
@@ -67,7 +67,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"

--- a/website/docs/r/compute_cluster_vm_host_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_host_rule.html.markdown
@@ -86,7 +86,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"

--- a/website/docs/r/datastore_cluster_vm_anti_affinity_rule.html.markdown
+++ b/website/docs/r/datastore_cluster_vm_anti_affinity_rule.html.markdown
@@ -68,7 +68,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"

--- a/website/docs/r/drs_vm_override.html.markdown
+++ b/website/docs/r/drs_vm_override.html.markdown
@@ -72,7 +72,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"

--- a/website/docs/r/guest_os_customization.html.markdown
+++ b/website/docs/r/guest_os_customization.html.markdown
@@ -16,8 +16,8 @@ The `vsphere_guest_os_customization` resource can be used to a customization spe
 ## Example Usage
 
 ```hcl
-  resource "vsphere_guest_os_customization" "windows_customization" {
-    name = "windows-spec"
+  resource "vsphere_guest_os_customization" "windows" {
+    name = "windows"
     type = "Windows"
     spec {
         windows_options {

--- a/website/docs/r/ha_vm_override.html.markdown
+++ b/website/docs/r/ha_vm_override.html.markdown
@@ -69,7 +69,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   num_cpus = 2
   memory   = 2048
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"

--- a/website/docs/r/storage_drs_vm_override.html.markdown
+++ b/website/docs/r/storage_drs_vm_override.html.markdown
@@ -70,7 +70,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   num_cpus = 2
   memory   = 1024
-  guest_id = "other3xLinux64Guest"
+  guest_id = "otherLinux64Guest"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -99,7 +99,7 @@ resource "vsphere_virtual_machine" "vm" {
   datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 1
   memory           = 1024
-  guest_id         = "other3xLinux64Guest"
+  guest_id         = "otherLinux64Guest"
   network_interface {
     network_id = data.vsphere_network.network.id
   }
@@ -118,7 +118,9 @@ Building on the above example, the below configuration creates a virtual machine
 
 ~> **NOTE:** Cloning requires vCenter Server and is not supported on direct ESXi host connections.
 
-**Example**:
+**Examples**:
+
+This example clones a Linux template and customizes with the provided settings:
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {
@@ -141,12 +143,12 @@ data "vsphere_network" "network" {
 }
 
 data "vsphere_virtual_machine" "template" {
-  name          = "ubuntu-server-template"
+  name          = "linux-template"
   datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
-  name             = "hello-world"
+  name             = "foo"
   resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
   datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 1
@@ -166,16 +168,29 @@ resource "vsphere_virtual_machine" "vm" {
     template_uuid = data.vsphere_virtual_machine.template.id
     customize {
       linux_options {
-        host_name = "hello-world"
+        host_name = "foo"
         domain    = "example.com"
       }
-      network_interface {
-        ipv4_address = "172.16.11.10"
-        ipv4_netmask = 24
-      }
-      ipv4_gateway = "172.16.11.1"
-    }
   }
+}
+```
+
+This example uses the same structure as the previous example, but customizes with an existing guest customization specification:
+
+```hcl
+# ... other configuration ...
+
+data "vsphere_guest_os_customization" "linux" {
+  name = "linux"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  # ... other configuration ...
+  template_uuid = data.vsphere_virtual_machine.template.id
+  customization_spec {
+    id = data.vsphere_guest_os_customization.linux.id
+  }
+  # ... other configuration ...
 }
 ```
 
@@ -514,7 +529,7 @@ data "vsphere_virtual_machine" "template_from_ovf" {
 }
 
 resource "vsphere_virtual_machine" "vm" {
-  name             = "hello-world"
+  name             = "foo"
   resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
   datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 2
@@ -535,7 +550,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
   vapp {
     properties = {
-      "guestinfo.hostname"     = "hello-world.example.com",
+      "guestinfo.hostname"     = "foo.example.com",
       "guestinfo.ipaddress"    = "172.16.11.101",
       "guestinfo.netmask"      = "255.255.255.0",
       "guestinfo.gateway"      = "172.16.11.1",
@@ -590,7 +605,7 @@ resource "vsphere_virtual_machine" "vm" {
   datastore_cluster_id = data.vsphere_datastore_cluster.datastore_cluster.id
   num_cpus             = 1
   memory               = 1024
-  guest_id             = "other3xLinux64Guest"
+  guest_id             = "otherLinux64Guest"
   network_interface {
     network_id = data.vsphere_network.network.id
   }


### PR DESCRIPTION
### Description

- Adds examples for the use of guest customization specifications.
- Replaces default `guest_id` in examples with a more generic option.

### Reference

Closes #2129