### PR TITLE
docs: remove interpolation syntax

### DIFF
--- a/website/docs/r/compute_cluster_host_group.html.markdown
+++ b/website/docs/r/compute_cluster_host_group.html.markdown
@@ -39,30 +39,30 @@ cluster.
 
 ```hcl
 variable "datacenter" {
-  default = "dc1"
+  default = "dc-01"
 }
 
 variable "hosts" {
   default = [
-    "esxi1",
-    "esxi2",
-    "esxi3",
+    "esxi-01.example.com,
+    "esxi-02.example.com,
+    "esxi-03.example.com,
   ]
 }
 
-data "vsphere_datacenter" "dc" {
-  name = "${var.datacenter}"
+data "vsphere_datacenter" "datacenter" {
+  name = var.datacenter
 }
 
 data "vsphere_host" "hosts" {
-  count         = "${length(var.hosts)}"
-  name          = "${var.hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  count         = length(var.hosts)
+  name          = var.hosts[count.index]
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "terraform-compute-cluster-test"
-  datacenter_id   = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id   = data.vsphere_datacenter.datacenter.id
   host_system_ids = ["${data.vsphere_host.hosts.*.id}"]
 
   drs_enabled          = true
@@ -73,7 +73,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 
 resource "vsphere_compute_cluster_host_group" "cluster_host_group" {
   name               = "terraform-test-cluster-host-group"
-  compute_cluster_id = "${vsphere_compute_cluster.compute_cluster.id}"
+  compute_cluster_id = vsphere_compute_cluster.compute_cluster.id
   host_system_ids    = ["${data.vsphere_host.hosts.*.id}"]
 }
 ```

--- a/website/docs/r/compute_cluster_vm_dependency_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_dependency_rule.html.markdown
@@ -45,36 +45,36 @@ exist, which may not possibly happen in the event that the names came from a
 "static" source such as a variable.
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm1" {
   name             = "terraform-test1"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -85,15 +85,15 @@ resource "vsphere_virtual_machine" "vm1" {
 
 resource "vsphere_virtual_machine" "vm2" {
   name             = "terraform-test2"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -104,21 +104,21 @@ resource "vsphere_virtual_machine" "vm2" {
 
 resource "vsphere_compute_cluster_vm_group" "cluster_vm_group1" {
   name                = "terraform-test-cluster-vm-group1"
-  compute_cluster_id  = "${data.vsphere_compute_cluster.cluster.id}"
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
   virtual_machine_ids = ["${vsphere_virtual_machine.vm1.id}"]
 }
 
 resource "vsphere_compute_cluster_vm_group" "cluster_vm_group2" {
   name                = "terraform-test-cluster-vm-group2"
-  compute_cluster_id  = "${data.vsphere_compute_cluster.cluster.id}"
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
   virtual_machine_ids = ["${vsphere_virtual_machine.vm2.id}"]
 }
 
 resource "vsphere_compute_cluster_vm_dependency_rule" "cluster_vm_dependency_rule" {
-  compute_cluster_id       = "${data.vsphere_compute_cluster.cluster.id}"
+  compute_cluster_id       = data.vsphere_compute_cluster.cluster.id
   name                     = "terraform-test-cluster-vm-dependency-rule"
-  dependency_vm_group_name = "${vsphere_compute_cluster_vm_group.cluster_vm_group1.name}"
-  vm_group_name            = "${vsphere_compute_cluster_vm_group.cluster_vm_group2.name}"
+  dependency_vm_group_name = vsphere_compute_cluster_vm_group.cluster_vm_group1.name
+  vm_group_name            = vsphere_compute_cluster_vm_group.cluster_vm_group2.name
 }
 ```
 

--- a/website/docs/r/compute_cluster_vm_group.html.markdown
+++ b/website/docs/r/compute_cluster_vm_group.html.markdown
@@ -40,37 +40,37 @@ then creates a group from these two virtual machines.
 [tf-vsphere-vm-resource]: /docs/providers/vsphere/r/virtual_machine.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   count            = 2
   name             = "terraform-test-${count.index}"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -81,7 +81,7 @@ resource "vsphere_virtual_machine" "vm" {
 
 resource "vsphere_compute_cluster_vm_group" "cluster_vm_group" {
   name                = "terraform-test-cluster-vm-group"
-  compute_cluster_id  = "${data.vsphere_compute_cluster.cluster.id}"
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
   virtual_machine_ids = ["${vsphere_virtual_machine.vm.*.id}"]
 }
 ```

--- a/website/docs/r/compute_cluster_vm_host_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_host_rule.html.markdown
@@ -55,41 +55,41 @@ exist, which may not possibly happen in the event that the names came from a
 "static" source such as a variable.
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_host" "host" {
-  name          = "esxi1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "esxi-01.example.com
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -100,21 +100,21 @@ resource "vsphere_virtual_machine" "vm" {
 
 resource "vsphere_compute_cluster_vm_group" "cluster_vm_group" {
   name                = "terraform-test-cluster-vm-group"
-  compute_cluster_id  = "${data.vsphere_compute_cluster.cluster.id}"
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
   virtual_machine_ids = ["${vsphere_virtual_machine.vm.id}"]
 }
 
 resource "vsphere_compute_cluster_host_group" "cluster_host_group" {
   name               = "terraform-test-cluster-vm-group"
-  compute_cluster_id = "${data.vsphere_compute_cluster.cluster.id}"
+  compute_cluster_id = data.vsphere_compute_cluster.cluster.id
   host_system_ids    = ["${data.vsphere_host.host.id}"]
 }
 
 resource "vsphere_compute_cluster_vm_host_rule" "cluster_vm_host_rule" {
-  compute_cluster_id       = "${data.vsphere_compute_cluster.cluster.id}"
+  compute_cluster_id       = data.vsphere_compute_cluster.cluster.id
   name                     = "terraform-test-cluster-vm-host-rule"
-  vm_group_name            = "${vsphere_compute_cluster_vm_group.cluster_vm_group.name}"
-  affinity_host_group_name = "${vsphere_compute_cluster_host_group.cluster_host_group.name}"
+  vm_group_name            = vsphere_compute_cluster_vm_group.cluster_vm_group.name
+  affinity_host_group_name = vsphere_compute_cluster_host_group.cluster_host_group.name
 }
 ```
 

--- a/website/docs/r/datastore_cluster.html.markdown
+++ b/website/docs/r/datastore_cluster.html.markdown
@@ -36,30 +36,30 @@ the datastore cluster.
 ```hcl
 variable "hosts" {
   default = [
-    "esxi1",
-    "esxi2",
-    "esxi3",
+    "esxi-01.example.com,
+    "esxi-02.example.com,
+    "esxi-03.example.com,
   ]
 }
 
 data "vsphere_datacenter" "datacenter" {}
 
-data "vsphere_host" "esxi_hosts" {
-  count         = "${length(var.hosts)}"
-  name          = "${var.hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+data "vsphere_host" "hosts" {
+  count         = length(var.hosts)
+  name          = var.hosts[count.index]
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "terraform-datastore-cluster-test"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
   sdrs_enabled  = true
 }
 
 resource "vsphere_nas_datastore" "datastore1" {
   name                 = "terraform-datastore-test1"
-  host_system_ids      = ["${data.vsphere_host.esxi_hosts.*.id}"]
-  datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
+  host_system_ids      = ["${data.vsphere_host.hosts.*.id}"]
+  datastore_cluster_id = vsphere_datastore_cluster.datastore_cluster.id
 
   type         = "NFS"
   remote_hosts = ["nfs"]
@@ -68,8 +68,8 @@ resource "vsphere_nas_datastore" "datastore1" {
 
 resource "vsphere_nas_datastore" "datastore2" {
   name                 = "terraform-datastore-test2"
-  host_system_ids      = ["${data.vsphere_host.esxi_hosts.*.id}"]
-  datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
+  host_system_ids      = ["${data.vsphere_host.hosts.*.id}"]
+  datastore_cluster_id = vsphere_datastore_cluster.datastore_cluster.id
 
   type         = "NFS"
   remote_hosts = ["nfs"]

--- a/website/docs/r/datastore_cluster_vm_anti_affinity_rule.html.markdown
+++ b/website/docs/r/datastore_cluster_vm_anti_affinity_rule.html.markdown
@@ -41,37 +41,37 @@ ensuring they will run on different datastores whenever possible.
 [tf-vsphere-vm-resource]: /docs/providers/vsphere/r/virtual_machine.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "datastore-cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   count                = 2
   name                 = "terraform-test-${count.index}"
-  resource_pool_id     = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_cluster_id = "${data.vsphere_datastore_cluster.datastore_cluster.id}"
+  resource_pool_id     = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_cluster_id = data.vsphere_datastore_cluster.datastore_cluster.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -82,7 +82,7 @@ resource "vsphere_virtual_machine" "vm" {
 
 resource "vsphere_datastore_cluster_vm_anti_affinity_rule" "cluster_vm_anti_affinity_rule" {
   name                 = "terraform-test-datastore-cluster-vm-anti-affinity-rule"
-  datastore_cluster_id = "${data.vsphere_datastore_cluster.datastore_cluster.id}"
+  datastore_cluster_id = data.vsphere_datastore_cluster.datastore_cluster.id
   virtual_machine_ids  = ["${vsphere_virtual_machine.vm.*.id}"]
 }
 ```
@@ -124,6 +124,7 @@ not found, or if the rule is of a different type, an error will be returned. An
 example is below:
 
 [docs-import]: https://www.terraform.io/docs/import/index.html
+
 ```
 terraform import vsphere_datastore_cluster_vm_anti_affinity_rule.cluster_vm_anti_affinity_rule \
   '{"compute_cluster_path": "/dc1/datastore/cluster1", \

--- a/website/docs/r/dpm_host_override.html.markdown
+++ b/website/docs/r/dpm_host_override.html.markdown
@@ -38,30 +38,30 @@ cluster does not need it to service virtual machines.
 
 ```hcl
 variable "datacenter" {
-  default = "dc1"
+  default = "dc-01"
 }
 
 variable "hosts" {
   default = [
-    "esxi1",
-    "esxi2",
-    "esxi3",
+    "esxi-01.example.com,
+    "esxi-02.example.com,
+    "esxi-03.example.com,
   ]
 }
 
-data "vsphere_datacenter" "dc" {
-  name = "${var.datacenter}"
+data "vsphere_datacenter" "datacenter" {
+  name = var.datacenter
 }
 
 data "vsphere_host" "hosts" {
-  count         = "${length(var.hosts)}"
-  name          = "${var.hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  count         = length(var.hosts)
+  name          = var.hosts[count.index]
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "terraform-compute-cluster-test"
-  datacenter_id   = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id   = data.vsphere_datacenter.datacenter.id
   host_system_ids = ["${data.vsphere_host.hosts.*.id}"]
 
   drs_enabled          = true
@@ -69,8 +69,8 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 }
 
 resource "vsphere_dpm_host_override" "dpm_host_override" {
-  compute_cluster_id   = "${vsphere_compute_cluster.compute_cluster.id}"
-  host_system_id       = "${data.vsphere_host.hosts.0.id}"
+  compute_cluster_id   = vsphere_compute_cluster.compute_cluster.id
+  host_system_id       = data.vsphere_host.hosts.0.id
   dpm_enabled          = true
   dpm_automation_level = "automated"
 }

--- a/website/docs/r/drs_vm_override.html.markdown
+++ b/website/docs/r/drs_vm_override.html.markdown
@@ -40,42 +40,42 @@ machine, ensuring that it does not move.
 [tf-vsphere-host-data-source]: /docs/providers/vsphere/d/host.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_host" "host" {
-  name          = "esxi1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "esxi-01.example.com
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  host_system_id   = "${data.vsphere_host.host.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  host_system_id   = data.vsphere_host.host.id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -85,8 +85,8 @@ resource "vsphere_virtual_machine" "vm" {
 }
 
 resource "vsphere_drs_vm_override" "drs_vm_override" {
-  compute_cluster_id = "${data.vsphere_compute_cluster.cluster.id}"
-  virtual_machine_id = "${vsphere_virtual_machine.vm.id}"
+  compute_cluster_id = data.vsphere_compute_cluster.cluster.id
+  virtual_machine_id = vsphere_virtual_machine.vm.id
   drs_enabled        = false
 }
 ```

--- a/website/docs/r/ha_vm_override.html.markdown
+++ b/website/docs/r/ha_vm_override.html.markdown
@@ -43,36 +43,36 @@ failure.
 [tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = "cluster-01"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -82,8 +82,8 @@ resource "vsphere_virtual_machine" "vm" {
 }
 
 resource "vsphere_ha_vm_override" "ha_vm_override" {
-  compute_cluster_id = "${data.vsphere_compute_cluster.cluster.id}"
-  virtual_machine_id = "${vsphere_virtual_machine.vm.id}"
+  compute_cluster_id = data.vsphere_compute_cluster.cluster.id
+  virtual_machine_id = vsphere_virtual_machine.vm.id
 
   ha_vm_restart_priority = "highest"
 }

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -26,17 +26,17 @@ page][ref-vsphere-net-concepts].
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {
-  name = "dc1"
+  name = "dc-01"
 }
 
 data "vsphere_host" "host" {
-  name          = "esxi1"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  name          = "esxi-01.example.com
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
   name           = "vSwitchTerraformTest"
-  host_system_id = "${data.vsphere_host.host.id}"
+  host_system_id = data.vsphere_host.host.id
 
   network_adapters = ["vmnic0", "vmnic1"]
 
@@ -49,17 +49,17 @@ resource "vsphere_host_virtual_switch" "switch" {
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {
-  name = "dc1"
+  name = "dc-01"
 }
 
 data "vsphere_host" "host" {
-  name          = "esxi1"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  name          = "esxi-01.example.com
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_host_virtual_switch" "switch" {
   name           = "vSwitchTerraformTest"
-  host_system_id = "${data.vsphere_host.host.id}"
+  host_system_id = data.vsphere_host.host.id
 
   network_adapters = ["vmnic0", "vmnic1"]
 
@@ -189,5 +189,5 @@ Import can the be done via the following command:
 terraform import vsphere_host_virtual_switch.switch tf-HostVirtualSwitch:host-10:vSwitchTerraformTest
 ```
 
-The above would import the vSwtich named `vSwitchTerraformTest` that is located in the `host-10`
+The above would import the vSwitch named `vSwitchTerraformTest` that is located in the `host-10`
 vSphere host.

--- a/website/docs/r/nas_datastore.html.markdown
+++ b/website/docs/r/nas_datastore.html.markdown
@@ -29,23 +29,25 @@ is named `nfs` and has `/export/terraform-test` exported.
 ```hcl
 variable "hosts" {
   default = [
-    "esxi1",
-    "esxi2",
-    "esxi3",
+    "esxi-01.example.com,
+    "esxi-02.example.com,
+    "esxi-03.example.com,
   ]
 }
 
-data "vsphere_datacenter" "datacenter" {}
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
 
-data "vsphere_host" "esxi_hosts" {
-  count         = "${length(var.hosts)}"
-  name          = "${var.hosts[count.index]}"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+data "vsphere_host" "hosts" {
+  count         = length(var.hosts)
+  name          = var.hosts[count.index]
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_nas_datastore" "datastore" {
   name            = "terraform-test"
-  host_system_ids = ["${data.vsphere_host.esxi_hosts.*.id}"]
+  host_system_ids = ["${data.vsphere_host.hosts.*.id}"]
 
   type         = "NFS"
   remote_hosts = ["nfs"]
@@ -65,7 +67,7 @@ The following arguments are supported:
   v3) or `NFS41` (to denote NFS v4.1). Default: `NFS`. Forces a new resource if
   changed.
 * `remote_hosts` - (Required) The hostnames or IP addresses of the remote
-  server or servers. Only one element should be present for NFS v3 but multiple
+  servers. Only one element should be present for NFS v3 but multiple
   can be present for NFS v4.1. Forces a new resource if changed.
 * `remote_path` - (Required) The remote path of the mount point. Forces a new
   resource if changed.
@@ -92,14 +94,13 @@ The following arguments are supported:
 [docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
-* `custom_attributes` - (Optional) Map of custom attribute ids to attribute 
-  value strings to set on datasource resource. See 
-  [here][docs-setting-custom-attributes] for a reference on how to set values 
-  for custom attributes.
+* `custom_attributes` - (Optional) Map of custom attribute ids to attribute
+  value strings to set on resource. See [here][docs-setting-custom-attributes]
+  for a reference on how to set values for custom attributes.
 
 [docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
 
-~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections
 and require vCenter.
 
 ## Attribute Reference
@@ -118,7 +119,7 @@ The following attributes are exported:
   potentially used by all virtual machines on this datastore.
 * `url` - The unique locator for the datastore.
 * `protocol_endpoint` - Indicates that this NAS volume is a protocol endpoint.
-  This field is only populated if the host supports virtual datastores. 
+  This field is only populated if the host supports virtual datastores.
 
 ## Importing
 

--- a/website/docs/r/storage_drs_vm_override.html.markdown
+++ b/website/docs/r/storage_drs_vm_override.html.markdown
@@ -39,41 +39,41 @@ the datastore.
 [tf-vsphere-datastore-data-source]: /docs/providers/vsphere/d/datastore.html
 
 ```hcl
-data "vsphere_datacenter" "dc" {
-  name = "dc1"
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
 }
 
 data "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "datastore-cluster1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_datastore" "member_datastore" {
   name          = "datastore-cluster1-member1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_resource_pool" "pool" {
   name          = "cluster1/Resources"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "public"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.member_datastore.id}"
+  resource_pool_id = data.vsphere_resource_pool.pool.id
+  datastore_id     = data.vsphere_datastore.member_datastore.id
 
   num_cpus = 2
   memory   = 1024
   guest_id = "otherLinux64Guest"
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
   disk {
@@ -83,8 +83,8 @@ resource "vsphere_virtual_machine" "vm" {
 }
 
 resource "vsphere_storage_drs_vm_override" "drs_vm_override" {
-  datastore_cluster_id = "${data.vsphere_datastore_cluster.datastore_cluster.id}"
-  virtual_machine_id   = "${vsphere_virtual_machine.vm.id}"
+  datastore_cluster_id = data.vsphere_datastore_cluster.datastore_cluster.id
+  virtual_machine_id   = vsphere_virtual_machine.vm.id
   sdrs_enabled         = false
 }
 ```

--- a/website/docs/r/vapp_container.html.markdown
+++ b/website/docs/r/vapp_container.html.markdown
@@ -58,7 +58,7 @@ data "vsphere_compute_cluster" "compute_cluster" {
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore-01"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {

--- a/website/docs/r/vapp_entity.html.markdown
+++ b/website/docs/r/vapp_entity.html.markdown
@@ -25,47 +25,47 @@ power on behavior in the vApp container.
 
 ```hcl
 variable "datacenter" {
-  default = "dc1"
+  default = "dc-01"
 }
 
 variable "cluster" {
-  default = "cluster1"
+  default = "cluster-01"
 }
 
-data "vsphere_datacenter" "dc" {
-  name = "${var.datacenter}"
+data "vsphere_datacenter" "datacenter" {
+  name = var.datacenter
 }
 
 data "vsphere_compute_cluster" "compute_cluster" {
-  name          = "${var.cluster}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.cluster
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_network" "network" {
   name          = "network1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_vapp_container" "vapp_container" {
   name                    = "terraform-vapp-container-test"
-  parent_resource_pool_id = "${data.vsphere_compute_cluster.compute_cluster.id}"
+  parent_resource_pool_id = data.vsphere_compute_cluster.compute_cluster.id
 }
 
 resource "vsphere_vapp_entity" "vapp_entity" {
-  target_id    = "${vsphere_virtual_machine.vm.moid}"
-  container_id = "${vsphere_vapp_container.vapp_container.id}"
+  target_id    = vsphere_virtual_machine.vm.moid
+  container_id = vsphere_vapp_container.vapp_container.id
   start_action = "none"
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-virtual-machine-test"
-  resource_pool_id = "${vsphere_vapp_container.vapp_container.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = vsphere_vapp_container.vapp_container.id
+  datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 2
   memory           = 1024
   guest_id         = "ubuntu64Guest"
@@ -76,7 +76,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 }
 ```


### PR DESCRIPTION
### Description

Removes deprecated interpolation syntax where it is no longer required.

**Example**

From:

```hcl
data "vsphere_host" "hosts" {
  count         = "${length(var.hosts)}"
  name          = "${var.hosts[count.index]}"
  datacenter_id = "${data.vsphere_datacenter.dc.id}"
}
```

To:

```hcl
data "vsphere_host" "hosts" {
  count         = length(var.hosts)
  name          = var.hosts[count.index]
  datacenter_id = data.vsphere_datacenter.datacenter.id
}
```