### PR TITLE
docs: markdown linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 <!--- Please leave a helpful description of the pull request here. --->
 
 ### Acceptance tests
+
 - [ ] Have you added an acceptance test for the functionality being added?
 - [ ] Have you run the acceptance tests on this branch?
 
@@ -13,6 +14,7 @@ Replace TestAccXXX with a pattern that matches the tests affected by this PR.
 
 For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
 -->
+
 ```
 $ make testacc TESTARGS='-run=TestAccXXX'
 
@@ -20,7 +22,9 @@ $ make testacc TESTARGS='-run=TestAccXXX'
 ```
 
 ### Release Note
+
 Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
+
 <!--
 If change is not user facing, just write "NONE" in the release-note block below.
 -->
@@ -28,6 +32,7 @@ If change is not user facing, just write "NONE" in the release-note block below.
 ```release-note
 ...
 ```
+
 ### References
 
 <!---

--- a/README.md
+++ b/README.md
@@ -8,55 +8,59 @@
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/hashicorp/terraform-provider-vsphere?label=release&style=for-the-badge)](https://github.com/hashicorp/terraform-provider-vsphere/releases/latest)
 [![License](https://img.shields.io/github/license/hashicorp/terraform-provider-vsphere.svg?style=for-the-badge)](LICENSE)
 
-The Terraform Provider for VMware vSphere is a plugin for Terraform that allows you to interact with
-VMware vSphere, notably [vCenter Server][vmware-vcenter] and [ESXi][vmware-esxi]. This provider can
-be used to manage a VMware vSphere environment, including virtual machines, host and cluster
-management, inventory, networking, storage, datastores, content libraries, and more.
+The Terraform Provider for VMware vSphere is a plugin for Terraform that allows
+you to interact with VMware vSphere, notably [vCenter Server][vmware-vcenter]
+and [ESXi][vmware-esxi]. This provider can be used to manage a VMware vSphere
+environment, including virtual machines, host and cluster management, inventory,
+networking, storage, datastores, content libraries, and more.
 
 Learn more:
 
-* Read the provider [documentation][provider-documentation].
+- Read the provider [documentation][provider-documentation].
 
-* Join the community [discussions][provider-discussions].
+- Join the community [discussions][provider-discussions].
 
 ## Requirements
 
-* [Terraform 0.13+][terraform-install]
+- [Terraform 0.13+][terraform-install]
 
-    For general information about Terraform, visit [developer.hashicorp.com][terraform-install] and
-    [the project][terraform-github] on GitHub.
+  For general information about Terraform, visit
+  [developer.hashicorp.com][terraform-install] and
+  [the project][terraform-github] on GitHub.
 
-* [Go 1.22][golang-install]
+- [Go 1.22][golang-install]
 
-    Required if building the provider.
+  Required if building the provider.
 
-* [VMware vSphere][vmware-vsphere-documenation]
+- [VMware vSphere][vmware-vsphere-documenation]
 
-    The plugin supports versions in accordance with the
-    [Broadcom Product Lifecycle][product-lifecycle].
+  The plugin supports versions in accordance with the
+  [Broadcom Product Lifecycle][product-lifecycle].
 
 ## Using the Provider
 
-The Terraform Provider for VMware vSphere is an official provider. Official providers are maintained
-by the Terraform team at [HashiCorp][hashicorp] and are listed on the
-[Terraform Registry][terraform-registry].
+The Terraform Provider for VMware vSphere is an official provider. Official
+providers are maintained by the Terraform team at [HashiCorp][hashicorp] and are
+listed on the [Terraform Registry][terraform-registry].
 
-To use a released version of the Terraform provider in your environment, run `terraform init` and
-Terraform will automatically install the provider from the Terraform Registry.
+To use a released version of the Terraform provider in your environment, run
+`terraform init` and Terraform will automatically install the provider from the
+Terraform Registry.
 
-Unless you are contributing to the provider or require a pre-release bugfix or feature, use an
-**officially** released version of the provider.
+Unless you are contributing to the provider or require a pre-release bugfix or
+feature, use an **officially** released version of the provider.
 
-See [Installing the Terraform Provider for VMware vSphere][provider-install] for additional
-instructions on automated and manual installation methods and how to control the provider version.
+See [Installing the Terraform Provider for VMware vSphere][provider-install] for
+additional instructions on automated and manual installation methods and how to
+control the provider version.
 
-For either installation method, documentation about the provider configuration, resources, and data
-sources can be found on the Terraform Registry.
+For either installation method, documentation about the provider configuration,
+resources, and data sources can be found on the Terraform Registry.
 
 ## Upgrading the Provider
 
-The provider does not upgrade automatically. After each new release, you can run the following
-command to upgrade the provider:
+The provider does not upgrade automatically. After each new release, you can run
+the following command to upgrade the provider:
 
 ```shell
 terraform init -upgrade
@@ -64,15 +68,17 @@ terraform init -upgrade
 
 ## Contributing
 
-The Terraform Provider for VMware vSphere is the work of many contributors and the project team
-appreciates your help!
+The Terraform Provider for VMware vSphere is the work of many contributors and
+the project team appreciates your help!
 
-If you discover a bug or would like to suggest an enhancement, submit [an issue][provider-issues].
-Once submitted, your issue will follow the [lifecycle][provider-issue-lifecycke] process.
+If you discover a bug or would like to suggest an enhancement, submit
+[an issue][provider-issues]. Once submitted, your issue will follow the
+[lifecycle][provider-issue-lifecycke] process.
 
 If you would like to submit a pull request, please read the
-[contribution guidelines][provider-contributing] to get started. In case of enhancement or feature
-contribution, we kindly ask you to open an issue to discuss it beforehand.
+[contribution guidelines][provider-contributing] to get started. In case of
+enhancement or feature contribution, we kindly ask you to open an issue to
+discuss it beforehand.
 
 Learn more in the [Frequently Asked Questions][provider-faq].
 
@@ -94,7 +100,7 @@ The Terraform Provider for VMware vSphere is available under the
 [terraform-install]: https://developer.hashicorp.com/terraform/install
 [terraform-github]: https://github.com/hashicorp/terraform
 [terraform-registry]: https://registry.terraform.io
-[vmware-esxi]: https://www.vmware.com/content/vmware/vmware-published-sites/us/products/esxi-and-esx.html
+[vmware-esxi]: https://www.vmware.com/products/esxi-and-esx.html.html
 [product-lifecycle]: https://support.broadcom.com/group/ecx/productlifecycle
 [vmware-vcenter]: https://www.vmware.com/products/vcenter.html
 [vmware-vsphere-documenation]: https://docs.vmware.com/en/VMware-vSphere/index.html

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,5 +1,6 @@
 # Code of Conduct
 
-The [HashiCorp Community Guidelines][hashicorp-community-guidelines] apply to you when interacting with the community here on GitHub and contributing code.
+The [HashiCorp Community Guidelines][hashicorp-community-guidelines] apply to
+you when interacting with the community here on GitHub and contributing code.
 
 [hashicorp-community-guidelines]: https://www.hashicorp.com/community-guidelines

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,12 +1,17 @@
-## Contributing to the provider
+# Contributing to the Provider
 
-Thank you for your interest in contributing to the vSphere provider. We welcome your contributions. Here you'll find information to help you get started with provider development.
+Thank you for your interest in contributing to the vSphere provider. We welcome
+your contributions. Here you'll find information to help you get started with
+provider development.
 
 ## Documentation
 
-Our [provider development documentation](https://www.terraform.io/docs/extend/) provides a good start into developing an understanding of provider development. It's the best entry point if you are new to contributing to this provider.
+Our [provider development documentation](https://www.terraform.io/docs/extend/)
+provides a good start into developing an understanding of provider development.
+It's the best entry point if you are new to contributing to this provider.
 
-To learn more about how to create issues and pull requests in this repository, and what happens after they are created, you may refer to the resources below:
+To learn more about how to create issues and pull requests in this repository,
+and what happens after they are created, you may refer to the resources below:
 
 - [Issue Creation and Lifecycle](ISSUES.md)
 - [Pull Request Creation and Lifecycle](PULL_REQUESTS.md)
@@ -21,7 +26,8 @@ git clone git@github.com:hashicorp/terraform-provider-vsphere
 
 ## Running the Build
 
-After the clone has been completed, you can enter the provider directory and build the provider.
+After the clone has been completed, you can enter the provider directory and
+build the provider.
 
 ```shell
 cd terraform-provider-vsphere
@@ -30,39 +36,51 @@ make build
 
 ## Installing the Local Plugin
 
-After the build is complete, you can install the binary into your `$GOPATH/bin` folder with:
+After the build is complete, you can install the binary into your `$GOPATH/bin`
+folder with:
 
 ```shell
 make install
 ```
 
-# Developing the Provider
+## Developing the Provider
 
-**NOTE:** Before you start work on a feature, please make sure to check the [issue tracker][gh-issues] and existing [pull requests][gh-prs] to ensure that work is not being duplicated. For further clarification, you can also ask in a new issue.
+**NOTE:** Before you start work on a feature, please make sure to check the
+[issue tracker][gh-issues] and existing [pull requests][gh-prs] to ensure that
+work is not being duplicated. For further clarification, you can also ask in a
+new issue.
 
 [gh-issues]: https://github.com/hashicorp/terraform-provider-vsphere/issues
 [gh-prs]: https://github.com/hashicorp/terraform-provider-vsphere/pulls
 
-If you wish to work on the provider, you'll first need [Go][go-website] installed on your machine.
+If you wish to work on the provider, you'll first need [Go][go-website]
+installed on your machine.
 
 [go-website]: https://golang.org/
-[gopath]: http://golang.org/doc/code.html#GOPATH
 
-See [Building the Provider](#building-the-provider) for details on building the provider.
+## Testing the Provider
 
-# Testing the Provider
+Terraform providers tend to create, update, and destroy real resources to assert
+the provider is working as expected. This is called
+[Acceptance Testing](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests).
+The vSphere provider's implementation is a bit more complex than the average
+provider, and creating a test environment that covers all possible hardware and
+settings combinations is a challenge. Effort has been put into streamlining the
+acceptance testing lab and instructions can be found in the acctests
+[README](/acctests/README.md).
 
-Terraform providers tend to create, update, and destroy real resources to assert the provider is working as expected. This is called [Acceptance Testing](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests). The vSphere provider's implementation is a bit more complex than the average provider, and creating a test environment that covers all possible hardware and settings combinations is a challenge. Effort has been put into streamlining the acceptance testing lab and instructions can be found in the acctests [README](/acctests/README.md).
+## Maintaining the CHANGELOG
 
-# Maintaining the Changelog
+In the future this should be automated, but between releases it's expected to
+add a SemVer entry at the top of the file with the following format.
 
-In the future this should be automated, but between releases it's expected to add a SemVer entry at the top of the file with the following format.
-
-```
-## 2.4.0 (Unreleased)
+```markdown
+## x.y.z (Unreleased)
 
 FEATURES:
-* `d/datasource_name`: Summary of the pull request. ([#1234](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1234))
+
+* `d/datasource_name`: Summary of the pull request.
+  ([#1234](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1234))
 * `r/resource_name`: ...
 
 BUG FIXES:
@@ -74,16 +92,29 @@ IMPROVEMENTS:
 CHORES:
 ...
 ```
-Generally the changes should fall into the categories listed above, when a resource or datasource is affected please follow the format seen above and link to the pull request (mind the brackets).
 
-# Release the Provider
+Generally the changes should fall into the categories listed above, when a
+resource or data source is affected please follow the format seen above and link
+to the pull request (mind the brackets).
 
-Releases will be performed by authorized HashiCorp, VMware, or community contributors. The release process is automated via GitHub Actions and is triggered by pushing a tag. To perform a release, please visit the Changelog and replace `(Unreleased)` with the current date (see the Changelog for the format).
+## Release the Provider
 
-Make sure to have pulled all the latest code changes to the main branch on your local machine (especially if the Changelog was edited via GitHub.com). When ready, create and push an annotated tag with the correct version number.
+Releases will be performed by authorized HashiCorp, VMware, or community
+contributors. The release process is automated via GitHub Actions and is
+triggered by pushing a tag. To perform a release, please visit the Changelog and
+replace `(Unreleased)` with the current date (see the Changelog for the format).
+
+Make sure to have pulled all the latest code changes to the main branch on your
+local machine (especially if the Changelog was edited via GitHub.com). When
+ready, create and push an annotated tag with the correct version number.
+
+```shell
+git tag -a v1.2.3 -m "v1.2.3"
+git push --tag
 ```
-$ git tag -a v1.2.3 -m "v1.2.3"
-$ git push --tag
-```
 
-The process should not require any additional actions. See the release workflow for details. Generally speaking the binaries should be built, signed, and uploaded in a matter of minutes. After which it can take up to an hour for the new release to be picked up by the Terraform Registry. If anything appears to have gone wrong, contact HashiCorp.
+The process should not require any additional actions. See the release workflow
+for details. Generally speaking the binaries should be built, signed, and
+uploaded in a matter of minutes. After which it can take up to an hour for the
+new release to be picked up by the Terraform Registry. If anything appears to
+have gone wrong, contact HashiCorp.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,28 +4,31 @@
 
 The Terraform provider for VMware vSphere team at HashiCorp include:
 
-* Vishnu Ravindra, Product Manager - [@vravind1](https://github.com/vravind1)
-* Alex Pilon, Engineer - [@appilon](https://github.com/appilon)
-* Brandy Jackson, Engineering Manager - [@ibrandyjackson](https://github.com/ibrandyjackson)
+- Vishnu Ravindra, Product Manager - [@vravind1](https://github.com/vravind1)
+- Alex Pilon, Engineer - [@appilon](https://github.com/appilon)
+- Brandy Jackson, Engineering Manager -
+  [@ibrandyjackson](https://github.com/ibrandyjackson)
 
 Collaborators from Broadcom include:
 
-* Ryan Johnson, [@tenthirtyam](https://github.com/tenthirtyam)
-* Stoyan Zhelyazkov, [@spacegospod](https://github.com/spacegospod)
+- Ryan Johnson, [@tenthirtyam](https://github.com/tenthirtyam)
+- Stoyan Zhelyazkov, [@spacegospod](https://github.com/spacegospod)
 
 ## Why isn’t my PR merged yet?
 
-We do our best to focus on the contributions that provide the greatest value to the most community
-members.
+We do our best to focus on the contributions that provide the greatest value to
+the most community members.
 
 ## How do you decide what gets merged for each release?
 
-The number one factor we look at when deciding what issues to look at are your 👍
+The number one factor we look at when deciding what issues to look at are your
+👍
 [reactions](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
-to the original issue/PR description as these can be easily discovered. Comments that further
-explain desired use cases or poor user experience are also heavily factored. The items with the most
-support are always on our radar, and we do our best to keep the community updated on their status
-and potential timelines, however we will focus on features that will benefit a majority of users.
+to the original issue/PR description as these can be easily discovered. Comments
+that further explain desired use cases or poor user experience are also heavily
+factored. The items with the most support are always on our radar, and we do our
+best to keep the community updated on their status and potential timelines,
+however we will focus on features that will benefit a majority of users.
 
 We also are investing time to improve the contributing experience by improving documentation.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,11 +4,16 @@ This document assumes the use of Terraform 0.13 or later.
 
 ## Automated Installation (Recommended)
 
-The Terraform Provider for vSphere is an official provider. Official providers are maintained by the Terraform team at [HashiCorp][hashicorp] and are listed on the [Terraform Registry][terraform-registry].
+The Terraform Provider for vSphere is an official provider. Official providers
+are maintained by the Terraform team at [HashiCorp][hashicorp] and are listed on
+the [Terraform Registry][terraform-registry].
 
 ### Configure the Terraform Configuration Files
 
-Providers listed on the Terraform Registry can be automatically downloaded when initializing a working directory with `terraform init`. The Terraform configuration block is used to configure some behaviors of Terraform itself, such as the Terraform version and the required providers and versions.
+Providers listed on the Terraform Registry can be automatically downloaded when
+initializing a working directory with `terraform init`. The Terraform
+configuration block is used to configure some behaviors of Terraform itself,
+such as the Terraform version and the required providers and versions.
 
 **Example**: A Terraform configuration block.
 
@@ -23,7 +28,8 @@ terraform {
 }
 ```
 
-You can use `version` locking and operators to require specific versions of the provider.
+You can use `version` locking and operators to require specific versions of the
+provider.
 
 **Example**: A Terraform configuration block with the provider versions.
 
@@ -39,11 +45,16 @@ terraform {
 }
 ```
 
-To specify a particular provider version when installing released providers, see the Terraform documentation [on provider versioning][terraform-provider-versioning]
+To specify a particular provider version when installing released providers, see
+the Terraform documentation
+[on provider versioning][terraform-provider-versioning]
 
 ### Verify Terraform Initialization Using the Terraform Registry
 
-To verify the initialization, navigate to the working directory for your Terraform configuration and run `terraform init`. You should see a message indicating that Terraform has been successfully initialized and has installed the provider from the Terraform Registry.
+To verify the initialization, navigate to the working directory for your
+Terraform configuration and run `terraform init`. You should see a message
+indicating that Terraform has been successfully initialized and has installed
+the provider from the Terraform Registry.
 
 **Example**: Initialize and Download the Provider.
 
@@ -64,15 +75,20 @@ Terraform has been successfully initialized!
 
 ## Manual Installation
 
-The latest release of the provider can be found on [`releases.hashicorp.com`][releases]. You can download the appropriate version of the provider for your operating system using a command line shell or a browser.
+The latest release of the provider can be found on
+[`releases.hashicorp.com`][releases]. You can download the appropriate version
+of the provider for your operating system using a command line shell or a
+browser.
 
-This can be useful in environments that do not allow direct access to the Internet.
+This can be useful in environments that do not allow direct access to the
+Internet.
 
 ### Linux
 
 The following examples use Bash on Linux (x64).
 
-1. On a Linux operating system with Internet access, download the plugin from GitHub using the shell.
+1. On a Linux operating system with Internet access, download the plugin from
+   GitHub using the shell.
 
    ```console
    RELEASE=x.y.z
@@ -87,17 +103,16 @@ The following examples use Bash on Linux (x64).
 
 3. Create a directory for the provider.
 
-   > **Note**
-   >
-   > The directory hierarchy that Terraform uses to precisely determine the source of each provider it finds locally.
-   >
+   > **Note** The directory hierarchy that Terraform uses to precisely determine
+   > the source of each provider it finds locally.
    > `$PLUGIN_DIRECTORY/$SOURCEHOSTNAME/$SOURCENAMESPACE/$NAME/$VERSION/$OS_$ARCH/`
 
    ```console
    mkdir -p ~/.terraform.d/plugins/local/hashicorp/vsphere/${RELEASE}/linux_amd64
    ```
 
-4. Copy the extracted plugin to a target system and move to the Terraform plugins directory.
+4. Copy the extracted plugin to a target system and move to the Terraform
+   plugins directory.
 
    ```console
    mv terraform-provider-vsphere_${RELEASE}/terraform-provider-vsphere_v${RELEASE} ~/.terraform.d/plugins/local/hashicorp/vsphere/${RELEASE}/linux_amd64
@@ -114,7 +129,8 @@ The following examples use Bash on Linux (x64).
 
 The following example uses Bash (default) on macOS (Intel).
 
-1. On a macOS operating system with Internet access, install wget with [Homebrew](https://brew.sh).
+1. On a macOS operating system with Internet access, install wget with
+   [Homebrew](https://brew.sh).
 
    ```console
    brew install wget
@@ -135,17 +151,16 @@ The following example uses Bash (default) on macOS (Intel).
 
 4. Create a directory for the provider.
 
-   > **Note**
-   >
-   > The directory hierarchy that Terraform uses to precisely determine the source of each provider it finds locally.
-   >
+   > **Note** The directory hierarchy that Terraform uses to precisely determine
+   > the source of each provider it finds locally.
    > `$PLUGIN_DIRECTORY/$SOURCEHOSTNAME/$SOURCENAMESPACE/$NAME/$VERSION/$OS_$ARCH/`
 
    ```console
    mkdir -p ~/.terraform.d/plugins/local/hashicorp/vsphere/${RELEASE}/darwin_amd64
    ```
 
-5. Copy the extracted plugin to a target system and move to the Terraform plugins directory.
+5. Copy the extracted plugin to a target system and move to the Terraform
+   plugins directory.
 
    ```console
    mv terraform-provider-vsphere_${RELEASE}/terraform-provider-vsphere_v${RELEASE} ~/.terraform.d/plugins/local/hashicorp/vsphere/${RELEASE}/darwin_amd64
@@ -162,7 +177,8 @@ The following example uses Bash (default) on macOS (Intel).
 
 The following examples use PowerShell on Windows (x64).
 
-1. On a Windows operating system with Internet access, download the plugin using the PowerShell.
+1. On a Windows operating system with Internet access, download the plugin using
+   the PowerShell.
 
    ```powershell
    $RELEASE="x.y.z"
@@ -177,12 +193,11 @@ The following examples use PowerShell on Windows (x64).
    cd terraform-provider-vsphere_${RELEASE}_windows_amd64
    ```
 
-3. Copy the extracted plugin to a target system and move to the Terraform plugins directory.
+3. Copy the extracted plugin to a target system and move to the Terraform
+   plugins directory.
 
-   > **Note**
-   >
-   > The directory hierarchy that Terraform uses to precisely determine the source of each provider it finds locally.
-   >
+   > **Note** The directory hierarchy that Terraform uses to precisely determine
+   > the source of each provider it finds locally.
    > `$PLUGIN_DIRECTORY/$SOURCEHOSTNAME/$SOURCENAMESPACE/$NAME/$VERSION/$OS_$ARCH/`
 
    ```powershell
@@ -200,7 +215,10 @@ The following examples use PowerShell on Windows (x64).
 
 ### Configure the Terraform Configuration Files
 
-A working directory can be initialized with providers that are installed locally on a system by using `terraform init`. The Terraform configuration block is used to configure some behaviors of Terraform itself, such as the Terraform version and the required providers source and version.
+A working directory can be initialized with providers that are installed locally
+on a system by using `terraform init`. The Terraform configuration block is used
+to configure some behaviors of Terraform itself, such as the Terraform version
+and the required providers source and version.
 
 **Example**: A Terraform configuration block.
 
@@ -218,7 +236,10 @@ terraform {
 
 ### Verify the Terraform Initialization of a Manually Installed Provider
 
-To verify the initialization, navigate to the working directory for your Terraform configuration and run `terraform init`. You should see a message indicating that Terraform has been successfully initialized and the installed version of the Terraform Provider for vSphere.
+To verify the initialization, navigate to the working directory for your
+Terraform configuration and run `terraform init`. You should see a message
+indicating that Terraform has been successfully initialized and the installed
+version of the Terraform Provider for vSphere.
 
 **Example**: Initialize and Use a Manually Installed Provider
 
@@ -238,7 +259,9 @@ Terraform has been successfully initialized!
 
 ## Get the Provider Version
 
-To find the provider version, navigate to the working directory of your Terraform configuration and run `terraform version`. You should see a message indicating the provider version.
+To find the provider version, navigate to the working directory of your
+Terraform configuration and run `terraform version`. You should see a message
+indicating the provider version.
 
 **Example**: Terraform Provider Version from the Terraform Registry
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -2,44 +2,69 @@
 
 ## Issue Reporting Checklists
 
-We welcome your feature requests and bug reports. Below you'll find short checklists with guidelines for well-formed issues of each type.
+We welcome your feature requests and bug reports. Below you'll find short
+checklists with guidelines for well-formed issues of each type.
 
 ### [Bug Reports](https://github.com/hashicorp/terraform-provider-vsphere/issues/new/choose)
 
-- [ ] __Test Against the Latest Release__: 
+- [ ] **Test Against the Latest Release**:
 
-    Make sure you test against the latest released version. It's possible we already fixed the bug you're experiencing.
+  Make sure you test against the latest released version. It's possible we
+  already fixed the bug you're experiencing.
 
-- [ ] __Search for Possible Duplicate Issues__: 
+- [ ] **Search for Possible Duplicate Issues**:
 
-    It's helpful to keep issues consolidated to one thread, so do a quick search on existing issues to check if anybody else has reported the same thing. You can [scope searches by the label "bug"](https://github.com/hashicorp/terraform-provider-vsphere/issues?q=is%3Aopen+is%3Aissue+label%3Abug) to help narrow your search.
+  It's helpful to keep issues consolidated to one thread, so do a quick search
+  on existing issues to check if anybody else has reported the same thing. You
+  can
+  [scope searches by the label "bug"](https://github.com/hashicorp/terraform-provider-vsphere/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
+  to help narrow your search.
 
-- [ ] __Include the Steps to Reproduce__: 
+- [ ] **Include the Steps to Reproduce**:
 
-    Provide steps to reproduce the issue, along with your `.tf` files. Without this information, it makes it much harder to diagnose and resolve the issue. Please ensure all secrets and identifiable information is removed.
+  Provide steps to reproduce the issue, along with your `.tf` files. Without
+  this information, it makes it much harder to diagnose and resolve the issue.
+  Please ensure all secrets and identifiable information is removed.
 
-- [ ] __For Panics, Include the `crash.log`__: 
+- [ ] **For Panics, Include the `crash.log`**:
 
-    If you experienced a panic, please create a [gist](https://gist.github.com) of the *entire* generated crash log. Review the log to ensure no sensitive or identifiable information is included.
+  If you experienced a panic, please create a [gist](https://gist.github.com) of
+  the _entire_ generated crash log. Review the log to ensure no sensitive or
+  identifiable information is included.
 
 ### [Enhancement and Feature Requests](https://github.com/hashicorp/terraform-provider-vsphere/issues/new/choose)
 
-- [ ] __Search for Possible Duplicate Requests__: 
+- [ ] **Search for Possible Duplicate Requests**:
 
-    It's helpful to keep requests consolidated to one thread. so do a quick search on existing issues to check if anybody else has reported the same thing. You can [scope searches by the label "enhancement"](https://github.com/hashicorp/terraform-provider-vsphere/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) to help narrow your search.
+  It's helpful to keep requests consolidated to one thread. so do a quick search
+  on existing issues to check if anybody else has reported the same thing. You
+  can
+  [scope searches by the label "enhancement"](https://github.com/hashicorp/terraform-provider-vsphere/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement)
+  to help narrow your search.
 
-- [ ] __Include a Use Case Description__: 
+- [ ] **Include a Use Case Description**:
 
-    In addition to describing the behavior of the feature you'd like to see added, it's helpful to also describe the reason why the enhancement or feature would be important and how it would benefit the provider users.
+  In addition to describing the behavior of the feature you'd like to see added,
+  it's helpful to also describe the reason why the enhancement or feature would
+  be important and how it would benefit the provider users.
 
 ## Issue Lifecycle
 
 1. The issue is reported on GitHub.
 
-2. The issue is acknowledged and categorized by a provider collaborator. Categorization is done via GitHub labels. We use one of `bug`, `enhancement`, `feature`, `documentation`, or `question`.
+2. The issue is acknowledged and categorized by a provider collaborator.
+   Categorization is done via GitHub labels. We use one of `bug`, `enhancement`,
+   `feature`, `documentation`, or `question`.
 
-3. An initial triage process determines whether the issue is critical and must be addressed immediately, or can be left open for community discussion. In this step, we typically assign a size estimate to the work involved for that issue for our reference.
+3. An initial triage process determines whether the issue is critical and must
+   be addressed immediately, or can be left open for community discussion. In
+   this step, we typically assign a size estimate to the work involved for that
+   issue for our reference.
 
-4. The issue is then queued in our backlog to be addressed in a pull request or commit. The issue number will be referenced in the commit message and pull request so that the code that fixes it is clearly linked.
+4. The issue is then queued in our backlog to be addressed in a pull request or
+   commit. The issue number will be referenced in the commit message and pull
+   request so that the code that fixes it is clearly linked.
 
-5. The issue is closed. Sometimes, valid issues will be closed because they are tracked elsewhere or non-actionable. The issue is still indexed and available for future viewers or can be re-opened, if necessary.
+5. The issue is closed. Sometimes, valid issues will be closed because they are
+   tracked elsewhere or non-actionable. The issue is still indexed and available
+   for future viewers or can be re-opened, if necessary.

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -1,30 +1,53 @@
 # Pull Request Submission and Lifecycle
 
-We appreciate direct contributions to the provider codebase. Here's what to expect:
+We appreciate direct contributions to the provider codebase. Here's what to
+expect:
 
- * For pull requests that follow the guidelines, we will proceed to reviewing and merging, following the provider team's review schedule. There may be some internal or community discussion needed before we can complete this.
+- For pull requests that follow the guidelines, we will proceed to reviewing and
+  merging, following the provider team's review schedule. There may be some
+  internal or community discussion needed before we can complete this.
 
- * Pull requests that don't follow the guidelines will be commented with what they're missing. The person who submits the pull request or another community member will need to address those requests before they move forward.
+- Pull requests that don't follow the guidelines will be commented with what
+  they're missing. The person who submits the pull request or another community
+  member will need to address those requests before they move forward.
 
 ## Pull Request Lifecycle
 
-1. [Fork the GitHub repository](https://help.github.com/en/articles/fork-a-repo), modify the code, and [create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
+1.
+   [Fork the GitHub repository](https://help.github.com/en/articles/fork-a-repo),
+   modify the code, and
+   [create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
 
-   You are welcome to submit your pull request for commentary or review before it is fully completed by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests).
+   You are welcome to submit your pull request for commentary or review before
+   it is fully completed by creating a
+   [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests).
 
    Please include specific questions or items you'd like feedback on.
 
-2. Once you believe your pull request is ready to be reviewed, ensure the pull request is not a draft pull request by [marking it ready for review](https://help.github.com/en/articles/changing-the-stage-of-a-pull-request) and a maintainer will review it.
+2. Once you believe your pull request is ready to be reviewed, ensure the pull
+   request is not a draft pull request by
+   [marking it ready for review](https://help.github.com/en/articles/changing-the-stage-of-a-pull-request)
+   and a maintainer will review it.
 
-3. One of Terraform provider team members will look over your contribution and either approve it or provide comments letting you know if there is anything left to do. We do our best to keep up with the volume of PRs waiting for review, but it will take some time for us to reach your PR based on the tasks we have in our backlog.
+3. One of Terraform provider team members will look over your contribution and
+   either approve it or provide comments letting you know if there is anything
+   left to do. We do our best to keep up with the volume of PRs waiting for
+   review, but it will take some time for us to reach your PR based on the tasks
+   we have in our backlog.
 
-4. Once all outstanding comments and checklist items have been addressed, your contribution will be merged! Merged PRs will be included in the next release of the Terraform provider. The provider team takes care of updating the CHANGELOG as they merge.
+4. Once all outstanding comments and checklist items have been addressed, your
+   contribution will be merged! Merged PRs will be included in the next release
+   of the Terraform provider. The provider team takes care of updating the
+   CHANGELOG as they merge.
 
-5. In some cases, we might decide that a PR should be closed without merging. We'll make sure to provide clear reasoning when this happens.
+5. In some cases, we might decide that a PR should be closed without merging.
+   We'll make sure to provide clear reasoning when this happens.
 
 ### Go Coding Style
 
-The following Go language resources provide common coding preferences that may be referenced during review, if not automatically handled by the project's linting tools.
+The following Go language resources provide common coding preferences that may
+be referenced during review, if not automatically handled by the project's
+linting tools.
 
 - [Effective Go](https://golang.org/doc/effective_go.html)
 - [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,5 +1,6 @@
 # Support
 
-Terraform is a mature project with a growing community. There are active, dedicated people willing to help you through various mediums.
+Terraform is a mature project with a growing community. There are active,
+dedicated people willing to help you through various mediums.
 
-Take a look at those mediums listed at https://www.terraform.io/community.html
+Take a look at those mediums listed at <https://www.terraform.io/community.html>

--- a/website/docs/d/compute_cluster.html.markdown
+++ b/website/docs/d/compute_cluster.html.markdown
@@ -11,9 +11,11 @@ description: |-
 # vsphere\_compute\_cluster
 
 The `vsphere_compute_cluster` data source can be used to discover the ID of a
-cluster in vSphere. This is useful to fetch the ID of a cluster that you want
-to use for virtual machine placement via the [`vsphere_virtual_machine`][docs-virtual-machine-resource] resource, allowing to specify the cluster's root resource pool directly versus
-using the alias available through the [`vsphere_resource_pool`][docs-resource-pool-data-source]
+cluster in vSphere. This is useful to fetch the ID of a cluster that you want to
+use for virtual machine placement via the
+[`vsphere_virtual_machine`][docs-virtual-machine-resource] resource, allowing to
+specify the cluster's root resource pool directly versus using the alias
+available through the [`vsphere_resource_pool`][docs-resource-pool-data-source]
 data source.
 
 [docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html
@@ -43,10 +45,11 @@ data "vsphere_compute_cluster" "compute_cluster" {
 The following arguments are supported:
 
 * `name` - (Required) The name or absolute path to the cluster.
-* `datacenter_id` - (Optional) The [managed object reference ID][docs-about-morefs]
-  of the datacenter the cluster is located in.  This can be omitted if the
-  search path used in `name` is an absolute path. For default datacenters,
-  use the `id` attribute from an empty `vsphere_datacenter` data source.
+* `datacenter_id` - (Optional) The
+  [managed object reference ID][docs-about-morefs] of the datacenter the cluster
+  is located in. This can be omitted if the search path used in `name` is an
+  absolute path. For default datacenters, use the `id` attribute from an empty
+  `vsphere_datacenter` data source.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 

--- a/website/docs/d/content_library_item.html.markdown
+++ b/website/docs/d/content_library_item.html.markdown
@@ -46,8 +46,10 @@ data "vsphere_content_library_item" "item" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the content library item.
-* `library_id` - (Required) The ID of the content library in which the item exists.
-* `type` - (Required) The type for the content library item. One of `ovf`, `vm-template`, or `iso`
+* `library_id` - (Required) The ID of the content library in which the item
+  exists.
+* `type` - (Required) The type for the content library item. One of `ovf`,
+  `vm-template`, or `iso`
 
 ## Attribute Reference
 

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -9,9 +9,9 @@ description: |-
 
 # vsphere\_datacenter
 
-The `vsphere_datacenter` data source can be used to discover the ID of a
-vSphere datacenter object. This can then be used with resources or data sources
-that require a datacenter, such as the [`vsphere_host`][data-source-vsphere-host]
+The `vsphere_datacenter` data source can be used to discover the ID of a vSphere
+datacenter object. This can then be used with resources or data sources that
+require a datacenter, such as the [`vsphere_host`][data-source-vsphere-host]
 data source.
 
 [data-source-vsphere-host]: /docs/providers/vsphere/d/host.html

--- a/website/docs/d/datastore.html.markdown
+++ b/website/docs/d/datastore.html.markdown
@@ -9,9 +9,9 @@ description: |-
 
 # vsphere_datastore
 
-The `vsphere_datastore` data source can be used to discover the ID of a
-vSphere datastore object. This can then be used with resources or data sources
-that require a datastore. For example, to create virtual machines in using the
+The `vsphere_datastore` data source can be used to discover the ID of a vSphere
+datastore object. This can then be used with resources or data sources that
+require a datastore. For example, to create virtual machines in using the
 [`vsphere_virtual_machine`][docs-virtual-machine-resource] resource.
 
 [docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html
@@ -34,10 +34,11 @@ data "vsphere_datastore" "datastore" {
 The following arguments are supported:
 
 - `name` - (Required) The name of the datastore. This can be a name or path.
-- `datacenter_id` - (Optional) The [managed object reference ID][docs-about-morefs]
-  of the datacenter the datastore is located in. This can be omitted if the
-  search path used in `name` is an absolute path. For default datacenters, use
-  the `id` attribute from an empty `vsphere_datacenter` data source.
+- `datacenter_id` - (Optional) The
+  [managed object reference ID][docs-about-morefs] of the datacenter the
+  datastore is located in. This can be omitted if the search path used in `name`
+  is an absolute path. For default datacenters, use the `id` attribute from an
+  empty `vsphere_datacenter` data source.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
@@ -46,6 +47,6 @@ The following arguments are supported:
 The following attributes are exported:
 
 - `id` - The ID of the datastore.
-- `stats` - The disk space usage statistics for the specific datastore. The total
-  datastore capacity is represented as `capacity` and the free remaining disk is
-  represented as `free`.
+- `stats` - The disk space usage statistics for the specific datastore. The
+  total datastore capacity is represented as `capacity` and the free remaining
+  disk is represented as `free`.

--- a/website/docs/d/datastore_cluster.html.markdown
+++ b/website/docs/d/datastore_cluster.html.markdown
@@ -10,8 +10,8 @@ description: |-
 # vsphere\_datastore\_cluster
 
 The `vsphere_datastore_cluster` data source can be used to discover the ID of a
-vSphere datastore cluster object. This can then be used with resources or data sources
-that require a datastore. For example, to assign datastores using the
+vSphere datastore cluster object. This can then be used with resources or data
+sources that require a datastore. For example, to assign datastores using the
 [`vsphere_nas_datastore`][docs-nas-datastore-resource] or
 [`vsphere_vmfs_datastore`][docs-vmfs-datastore-resource] resources, or to create
 virtual machines in using the

--- a/website/docs/d/datastore_stats.html .markdown
+++ b/website/docs/d/datastore_stats.html .markdown
@@ -4,15 +4,16 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_datastore_stats"
 sidebar_current: "docs-vsphere-data-source-datastore-stats"
 description: |-
-  Provides a data source to return the usage stats for all vSphere datastore objects
-  in a datacenter.
+  Provides a data source to return the usage stats for all vSphere datastore
+  objects in a datacenter.
 ---
 
 # vsphere_datastore_stats
 
-The `vsphere_datastore_stats` data source can be used to retrieve the usage stats
-of all vSphere datastore objects in a datacenter. This can then be used as a
-standalone datasource to get information required as input to other data sources.
+The `vsphere_datastore_stats` data source can be used to retrieve the usage
+stats of all vSphere datastore objects in a datacenter. This can then be used as
+a standalone data source to get information required as input to other data
+sources.
 
 ## Example Usage
 
@@ -26,9 +27,8 @@ data "vsphere_datastore_stats" "datastore_stats" {
 }
 ```
 
-A usefull example of this datasource would be to determine the
-datastore with the most free space. For example, in addition to
-the above:
+A useful example of this data source would be to determine the datastore with
+the most free space. For example, in addition to the above:
 
 Create an `outputs.tf` like that:
 
@@ -54,16 +54,16 @@ locals {
 }
 ```
 
-This way you can get the storage object with the most
-space available.
+This way you can get the storage object with the most space available.
 
 ## Argument Reference
 
 The following arguments are supported:
 
-- `datacenter_id` - (Required) The [managed object reference ID][docs-about-morefs]
-  of the datacenter the datastores are located in. For default datacenters, use
-  the `id` attribute from an empty `vsphere_datacenter` data source.
+- `datacenter_id` - (Required) The
+  [managed object reference ID][docs-about-morefs] of the datacenter the
+  datastores are located in. For default datacenters, use the `id` attribute
+  from an empty `vsphere_datacenter` data source.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
@@ -71,10 +71,10 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-- `datacenter_id` - The [managed object reference ID][docs-about-morefs]
-  of the datacenter the datastores are located in.
+- `datacenter_id` - The [managed object reference ID][docs-about-morefs] of the
+  datacenter the datastores are located in.
 - `free_space` - A mapping of the free space for each datastore in the
-  datacenter, where the name of the datastore is used as key and the free
-  space as value.
-- `capacity` - A mapping of the capacity for all datastore in the datacenter
-  , where the name of the datastore is used as key and the capacity as value.
+  datacenter, where the name of the datastore is used as key and the free space
+  as value.
+- `capacity` - A mapping of the capacity for all datastore in the datacenter,
+  where the name of the datastore is used as key and the capacity as value.

--- a/website/docs/d/distributed_virtual_switch.html.markdown
+++ b/website/docs/d/distributed_virtual_switch.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 # vsphere\_distributed\_virtual\_switch
 
-The `vsphere_distributed_virtual_switch` data source can be used to discover
-the ID and uplink data of a of a vSphere distributed switch (VDS). This
-can then be used with resources or data sources that require a VDS, such as the
+The `vsphere_distributed_virtual_switch` data source can be used to discover the
+ID and uplink data of a of a vSphere distributed switch (VDS). This can then be
+used with resources or data sources that require a VDS, such as the
 [`vsphere_distributed_port_group`][distributed-port-group] resource, for which
 an example is shown below.
 
@@ -52,10 +52,11 @@ resource "vsphere_distributed_port_group" "dvpg" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the VDS. This can be a name or path.
-* `datacenter_id` - (Optional) The [managed object reference ID][docs-about-morefs]
-  of the datacenter the VDS is located in. This can be omitted if the search
-  path used in `name` is an absolute path. For default datacenters, use the `id`
-  attribute from an empty `vsphere_datacenter` data source.
+* `datacenter_id` - (Optional) The
+  [managed object reference ID][docs-about-morefs] of the datacenter the VDS is
+  located in. This can be omitted if the search path used in `name` is an
+  absolute path. For default datacenters, use the `id` attribute from an empty
+  `vsphere_datacenter` data source.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
@@ -64,8 +65,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id`: The UUID of the vSphere distributed switch.
-* `uplinks`: The list of the uplinks on this vSphere distributed switch, as per the
-  [`uplinks`][distributed-virtual-switch-uplinks] argument to the
+* `uplinks`: The list of the uplinks on this vSphere distributed switch, as per
+  the [`uplinks`][distributed-virtual-switch-uplinks] argument to the
   [`vsphere_distributed_virtual_switch`][distributed-virtual-switch-resource]
   resource.
 

--- a/website/docs/d/dynamic.html.markdown
+++ b/website/docs/d/dynamic.html.markdown
@@ -4,16 +4,17 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_dynamic"
 sidebar_current: "docs-vsphere-data-source-dynamic"
 description: |-
-  A data source that can be used to get the [managed object reference ID][docs-about-morefs]
+  A data source that can be used to get the [managed object reference ID
   of any tagged managed object in the vSphere inventory.
 ---
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 # vsphere_dynamic
 
-The `vsphere_dynamic` data source can be used to get the [managed object reference ID][docs-about-morefs]
-of any tagged managed object in vCenter Server by providing a list of tag IDs
-and an optional regular expression to filter objects by name.
+The `vsphere_dynamic` data source can be used to get the
+[managed object reference ID][docs-about-morefs] of any tagged managed object in
+vCenter Server by providing a list of tag IDs and an optional regular expression
+to filter objects by name.
 
 ## Example Usage
 
@@ -45,8 +46,8 @@ The following arguments are supported:
 
 * `filter` - (Required) A list of tag IDs that must be present on an object to
   be a match.
-* `name_regex` - (Optional) A regular expression that will be used to match
-  the object's name.
+* `name_regex` - (Optional) A regular expression that will be used to match the
+  object's name.
 * `type` - (Optional) The managed object type the returned object must match.
   The managed object types can be found in the managed object type section
   [here](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/).

--- a/website/docs/d/host.html.markdown
+++ b/website/docs/d/host.html.markdown
@@ -10,8 +10,8 @@ description: |-
 # vsphere\_host
 
 The `vsphere_host` data source can be used to discover the ID of an ESXi host.
-This can then be used with resources or data sources that require an ESX
-host's [managed object reference ID][docs-about-morefs].
+This can then be used with resources or data sources that require an ESX host's
+[managed object reference ID][docs-about-morefs].
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
@@ -32,10 +32,11 @@ data "vsphere_host" "host" {
 
 The following arguments are supported:
 
-* `datacenter_id` - (Required) The [managed object reference ID][docs-about-morefs]
-  of a vSphere datacenter object.
-* `name` - (Optional) The name of the ESXI host. This can be a name or path.
-  Can be omitted if there is only one host in your inventory.
+* `datacenter_id` - (Required) The
+  [managed object reference ID][docs-about-morefs] of a vSphere datacenter
+  object.
+* `name` - (Optional) The name of the ESXI host. This can be a name or path. Can
+  be omitted if there is only one host in your inventory.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
@@ -48,9 +49,10 @@ returns the ESXi host's object ID, regardless of what is entered into `name`.
 * `resource_pool_id` - The [managed object ID][docs-about-morefs] of the ESXi
   host's root resource pool.
 
--> Note that the resource pool referenced by [`resource_pool_id`](#resource_pool_id)
-  is dependent on the ESXi host's state. If it is a standalone ESXi host, the
-  resource pool will belong to the host only; however, if it is a member of a
-  cluster, the resource pool will be the root for the cluster.
+-> Note that the resource pool referenced by
+[`resource_pool_id`](#resource_pool_id) is dependent on the ESXi host's state.
+If it is a standalone ESXi host, the resource pool will belong to the host only;
+however, if it is a member of a cluster, the resource pool will be the root for
+the cluster.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider

--- a/website/docs/d/host_base_images.html.markdown
+++ b/website/docs/d/host_base_images.html.markdown
@@ -4,19 +4,20 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host_base_images"
 sidebar_current: "docs-vsphere-data-source-host-base-images"
 description: |-
-  Provides a VMware vSphere ESXi base images data source. This can be used to get the
-  list of ESXi base images available for cluster software management.
+  Provides a VMware vSphere ESXi base images data source.
+  This can be used to get the list of ESXi base images available for cluster
+  software management.
 ---
 
 # host\_base\_images
 
-The `vsphere_host_base_images` data source can be used to get the list of ESXi base images available
-for cluster software management.
+The `vsphere_host_base_images` data source can be used to get the list of ESXi
+base images available for cluster software management.
 
 ## Example Usage
 
 ```hcl
-data "vsphere_host_base_images" "baseimages" {}
+data "vsphere_host_base_images" "base_images" {}
 ```
 
 ## Attribute Reference

--- a/website/docs/d/host_pci_device.html.markdown
+++ b/website/docs/d/host_pci_device.html.markdown
@@ -32,18 +32,19 @@ data "vsphere_host_pci_device" "dev" {
   vendor_id = 456
 }
 ```
+
 ## Example Usage with Name Regular Expression
- 
+
  ```hcl
  data "vsphere_datacenter" "datacenter" {
    name = "dc-01"
  }
- 
+
  data "vsphere_host" "host" {
    name          = "esxi-01.example.com"
    datacenter_id = data.vsphere_datacenter.datacenter.id
  }
- 
+
  data "vsphere_host_pci_device" "dev" {
    host_id    = data.vsphere_host.host.id
    name_regex = "MMC"
@@ -54,9 +55,10 @@ data "vsphere_host_pci_device" "dev" {
 
 The following arguments are supported:
 
-* `host_id` - (Required) The [managed object reference ID][docs-about-morefs] of a host.
+* `host_id` - (Required) The [managed object reference ID][docs-about-morefs] of
+  a host.
 * `name_regex` - (Optional) A regular expression that will be used to match the
-   host PCI device name.
+  host PCI device name.
 * `vendor_id` - (Optional) The hexadecimal PCI device vendor ID.
 * `class_id` - (Optional) The hexadecimal PCI device class ID
 

--- a/website/docs/d/host_thumbprint.html.markdown
+++ b/website/docs/d/host_thumbprint.html.markdown
@@ -9,10 +9,10 @@ description: |-
 
 # vsphere\_host\_thumbprint
 
-The `vsphere_thumbprint` data source can be used to discover the host
-thumbprint of an ESXi host. This can be used when adding the `vsphere_host`
-resource. If the ESXi host is using a certificate chain, the first one returned
-will be used to generate the thumbprint.
+The `vsphere_thumbprint` data source can be used to discover the host thumbprint
+of an ESXi host. This can be used when adding the `vsphere_host` resource. If
+the ESXi host is using a certificate chain, the first one returned will be used
+to generate the thumbprint.
 
 ## Example Usage
 
@@ -26,13 +26,12 @@ data "vsphere_host_thumbprint" "thumbprint" {
 
 The following arguments are supported:
 
-* `address` - (Required) The address of the ESXi host to retrieve the
-  thumbprint from.
+* `address` - (Required) The address of the ESXi host to retrieve the thumbprint
+  from.
 * `port` - (Optional) The port to use connecting to the ESXi host. Default: 443
 * `insecure` - (Optional) Disables SSL certificate verification.
   Default: `false`
 
 ## Attribute Reference
 
-The only exported attribute is `id`, which is the thumbprint of the ESXi
-host.
+The only exported attribute is `id`, which is the thumbprint of the ESXi host.

--- a/website/docs/d/license.html.markdown
+++ b/website/docs/d/license.html.markdown
@@ -4,8 +4,8 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_license"
 sidebar_current: "docs-vsphere-data-source-admin-license"
 description: |-
-  Provides a VMware vSphere license data source. This can be used to get the
-  general attributes of license keys.
+  Provides a VMware vSphere license data source.
+  This can be used to get the general attributes of license keys.
 ---
 
 # vsphere\_license
@@ -31,7 +31,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `labels` - A map of key/value pairs attached as labels (tags) to the license key.
+* `labels` - A map of key/value pairs attached as labels (tags) to the license
+  key.
 * `edition_key` - The product edition of the license key.
 * `total` - Total number of units (example: CPUs) contained in the license.
 * `used` - The number of units (example: CPUs) assigned to this license.

--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -4,17 +4,17 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_network"
 sidebar_current: "docs-vsphere-data-source-network"
 description: |-
-  Provides a vSphere network data source. This can be used to get the general
-  attributes of a vSphere network.
+  Provides a vSphere network data source.
+  This can be used to get the general attributes of a vSphere network.
 ---
 
 # vsphere\_network
 
-The `vsphere_network` data source can be used to discover the ID of a network
-in vSphere. This can be any network that can be used as the backing for a
-network interface for `vsphere_virtual_machine` or any other vSphere resource
-that requires a network. This includes standard (host-based) port groups,
-distributed port groups, or opaque networks such as those managed by NSX.
+The `vsphere_network` data source can be used to discover the ID of a network in
+vSphere. This can be any network that can be used as the backing for a network
+interface for `vsphere_virtual_machine` or any other vSphere resource that
+requires a network. This includes standard (host-based) port groups, distributed
+port groups, or opaque networks such as those managed by NSX.
 
 ## Example Usage
 
@@ -34,14 +34,15 @@ data "vsphere_network" "network" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the network. This can be a name or path.
-* `datacenter_id` - (Optional) The [managed object reference ID][docs-about-morefs]
-  of the datacenter the network is located in. This can be omitted if the
-  search path used in `name` is an absolute path. For default datacenters,
-  use the `id` attribute from an empty `vsphere_datacenter` data source.
+* `datacenter_id` - (Optional) The
+  [managed object reference ID][docs-about-morefs] of the datacenter the network
+  is located in. This can be omitted if the search path used in `name` is an
+  absolute path. For default datacenters, use the `id` attribute from an empty
+  `vsphere_datacenter` data source.
 * `distributed_virtual_switch_uuid` - (Optional) For distributed port group type
-   network objects, the ID of the distributed virtual switch for which the port
-   group belongs. It is useful to differentiate port groups with same name
-   using the distributed virtual switch ID.
+  network objects, the ID of the distributed virtual switch for which the port
+  group belongs. It is useful to differentiate port groups with same name using
+  the distributed virtual switch ID.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 

--- a/website/docs/d/resource_pool.html.markdown
+++ b/website/docs/d/resource_pool.html.markdown
@@ -4,8 +4,8 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_resource_pool"
 sidebar_current: "docs-vsphere-data-source-resource-pool"
 description: |-
-  Provides a vSphere resource pool data source. This can be used to get the
-  general attributes of a vSphere resource pool.
+  Provides a vSphere resource pool data source.
+  This can be used to get the general attributes of a vSphere resource pool.
 ---
 
 # vsphere\_resource\_pool
@@ -32,15 +32,15 @@ data "vsphere_resource_pool" "pool" {
 
 ### Specifying the Root Resource Pool for a Standalone ESXi Host
 
--> **NOTE:** Returning the root resource pool for a cluster can be done
-directly via the [`vsphere_compute_cluster`][docs-compute-cluster-data-source]
-data source.
+-> **NOTE:** Returning the root resource pool for a cluster can be done directly
+via the [`vsphere_compute_cluster`][docs-compute-cluster-data-source] data
+source.
 
 [docs-compute-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html
 
 All compute resources in vSphere have a resource pool, even if one has not been
-explicitly created. This resource pool is referred to as the
-_root resource pool_ and can be looked up by specifying the path.
+explicitly created. This resource pool is referred to as the _root resource
+pool_ and can be looked up by specifying the path.
 
 ```
 data "vsphere_resource_pool" "pool" {
@@ -49,7 +49,9 @@ data "vsphere_resource_pool" "pool" {
 }
 ```
 
-For more information on the root resource pool, see [Managing Resource Pools][vmware-docs-resource-pools] in the vSphere documentation.
+For more information on the root resource pool, see
+[Managing Resource Pools][vmware-docs-resource-pools] in the vSphere
+documentation.
 
 [vmware-docs-resource-pools]: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-resource-management/GUID-60077B40-66FF-4625-934A-641703ED7601.html
 
@@ -59,17 +61,17 @@ The following arguments are supported:
 
 * `name` - (Optional) The name of the resource pool. This can be a name or
   path. This is required when using vCenter.
-* `datacenter_id` - (Optional) The [managed object reference ID][docs-about-morefs]
-  of the datacenter in which the resource pool is located. This can be omitted
-  if the search path used in `name` is an absolute path. For default
-  datacenters, use the id attribute from an empty `vsphere_datacenter` data
-  source.
+* `datacenter_id` - (Optional) The
+  [managed object reference ID][docs-about-morefs] of the datacenter in which
+  the resource pool is located. This can be omitted if the search path used in
+  `name` is an absolute path. For default datacenters, use the id attribute from
+  an empty `vsphere_datacenter` data source.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
-~> **Note:** When using ESXi without a vCenter Server instance, you do not
-need to specify either attribute to use this data source. An empty declaration
-will load the ESXi host's root resource pool.
+~> **Note:** When using ESXi without a vCenter Server instance, you do not need
+to specify either attribute to use this data source. An empty declaration will
+load the ESXi host's root resource pool.
 
 ## Attribute Reference
 

--- a/website/docs/d/tag.html.markdown
+++ b/website/docs/d/tag.html.markdown
@@ -4,14 +4,14 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_tag"
 sidebar_current: "docs-vsphere-data-source-tag-data-source"
 description: |-
-  Provides a vSphere tag data source. This can be used to reference tags not
-  managed in Terraform.
+  Provides a vSphere tag data source.
+  This can be used to reference tags not managed in Terraform.
 ---
 
 # vsphere\_tag
 
-The `vsphere_tag` data source can be used to reference tags that are not
-managed by Terraform. Its attributes are exactly the same as the
+The `vsphere_tag` data source can be used to reference tags that are not managed
+by Terraform. Its attributes are exactly the same as the
 [`vsphere_tag` resource][resource-tag], and, like importing, the data source
 uses a name and category as search criteria. The `id` and other attributes are
 populated with the data found by the search.

--- a/website/docs/d/tag_category.html.markdown
+++ b/website/docs/d/tag_category.html.markdown
@@ -4,8 +4,8 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_tag_category"
 sidebar_current: "docs-vsphere-data-source-tag-category"
 description: |-
-  Provides a vSphere tag category data source. This can be used to reference
-  tag categories not managed in Terraform.
+  Provides a vSphere tag category data source.
+  This can be used to reference tag categories not managed in Terraform.
 ---
 
 # vsphere\_tag\_category

--- a/website/docs/d/vapp_container.html.markdown
+++ b/website/docs/d/vapp_container.html.markdown
@@ -4,8 +4,8 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_vapp_container"
 sidebar_current: "docs-vsphere-data-source-resource-pool"
 description: |-
-  Provides a vSphere vApp container data source. This can be used to return the
-  general attributes of a vSphere vApp container.
+  Provides a vSphere vApp container data source.
+  This can be used to return the general attributes of a vSphere vApp container.
 ---
 
 # vsphere\_resource\_pool
@@ -36,12 +36,13 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the vApp container. This can be a name or
   path.
-* `datacenter_id` - (Required) The [managed object reference ID][docs-about-morefs]
-  of the datacenter in which the vApp container is located.
+* `datacenter_id` - (Required) The
+  [managed object reference ID][docs-about-morefs] of the datacenter in which
+  the vApp container is located.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Attribute Reference
 
-The only exported attribute for this data source is `id`, which
-represents the ID of the vApp container that was looked up.
+The only exported attribute for this data source is `id`, which represents the
+ID of the vApp container that was looked up.

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -4,14 +4,15 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_machine"
 sidebar_current: "docs-vsphere-data-source-virtual-machine"
 description: |-
-  Provides a VMware vSphere virtual machine data source. This can be used to return data from a virtual machine or template.
+  Provides a VMware vSphere virtual machine data source.
+  This can be used to return data from a virtual machine or template.
 ---
 
 # vsphere\_virtual\_machine
 
 The `vsphere_virtual_machine` data source can be used to find the UUID of an
-existing virtual machine or template. The most common purpose is for finding
-the UUID of a template to be used as the source for cloning to a new
+existing virtual machine or template. The most common purpose is for finding the
+UUID of a template to be used as the source for cloning to a new
 [`vsphere_virtual_machine`][docs-virtual-machine-resource] resource. It also
 reads the guest ID so that can be supplied as well.
 
@@ -19,8 +20,8 @@ reads the guest ID so that can be supplied as well.
 
 ## Example Usage
 
-In the following example, a virtual machine template is returned by its
-unique name within the `vsphere_datacenter`.
+In the following example, a virtual machine template is returned by its unique
+name within the `vsphere_datacenter`.
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {
@@ -32,6 +33,7 @@ data "vsphere_virtual_machine" "template" {
   datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 ```
+
 In the following example, each virtual machine template is returned by its
 unique full path within the `vsphere_datacenter`.
 
@@ -55,27 +57,31 @@ data "vsphere_virtual_machine" "development_template" {
 
 The following arguments are supported:
 
-* `name` - (Optional) The name of the virtual machine. This can be a name or
-  the full path relative to the datacenter. This is required if a UUID lookup
-  is not performed.
-* `uuid` - (Optional) Specify this field for a UUID lookup, `name` and `datacenter_id`
-  are not required if this is specified.
-* `folder` - (Optional) The name of the virtual machine folder where the virtual machine is located. The `name` argument is limited to 80 characters. If the `name` argument includes the full path to the virtual machine and exceeds the 80 characters limit, the `folder` folder argument can be used.
+* `name` - (Optional) The name of the virtual machine. This can be a name or the
+  full path relative to the datacenter. This is required if a UUID lookup is not
+  performed.
+* `uuid` - (Optional) Specify this field for a UUID lookup, `name` and
+  `datacenter_id` are not required if this is specified.
+* `folder` - (Optional) The name of the virtual machine folder where the virtual
+  machine is located. The `name` argument is limited to 80 characters. If the
+  `name` argument includes the full path to the virtual machine and exceeds the
+  80 characters limit, the `folder` folder argument can be used.
 * `datacenter_id` - (Optional) The [managed object reference
   ID][docs-about-morefs] of the datacenter the virtual machine is located in.
-  This can be omitted if the search path used in `name` is an absolute path.
-  For default datacenters, use the `id` attribute from an empty
-  `vsphere_datacenter` data source.
+  This can be omitted if the search path used in `name` is an absolute path. For
+  default datacenters, use the `id` attribute from an empty `vsphere_datacenter`
+  data source.
 * `scsi_controller_scan_count` - (Optional) The number of SCSI controllers to
   scan for disk attributes and controller types on. Default: `1`.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ~> **NOTE:** For best results, ensure that all the disks on any templates you
-use with this data source reside on the primary controller, and leave this
-value at the default. See the [`vsphere_virtual_machine`][docs-virtual-machine-resource]
-resource documentation for the significance of this setting, specifically the
-[additional requirements and notes for cloning][docs-virtual-machine-resource-cloning] 
+use with this data source reside on the primary controller, and leave this value
+at the default. See the
+[`vsphere_virtual_machine`][docs-virtual-machine-resource] resource
+documentation for the significance of this setting, specifically the
+[additional requirements and notes for cloning][docs-virtual-machine-resource-cloning]
 section.
 
 [docs-virtual-machine-resource-cloning]: /docs/providers/vsphere/r/virtual_machine.html#additional-requirements-and-notes-for-cloning
@@ -87,14 +93,16 @@ The following attributes are exported:
 * `id` - The UUID of the virtual machine or template.
 * `guest_id` - The guest ID of the virtual machine or template.
 * `alternate_guest_name` - The alternate guest name of the virtual machine when
-`guest_id` is a non-specific operating system, like `otherGuest` or `otherGuest64`.
+  `guest_id` is a non-specific operating system, like `otherGuest` or
+  `otherGuest64`.
 * `annotation` - The user-provided description of this virtual machine.
 * `memory` - The size of the virtual machine's memory, in MB.
 * `num_cpus` - The total number of virtual processor cores assigned to this
   virtual machine.
-* `num_cores_per_socket` - The number of cores per socket for this virtual machine.
-* `firmware` - The firmware interface that is used by this virtual machine. Can be
-  either `bios` or `efi`.
+* `num_cores_per_socket` - The number of cores per socket for this virtual
+  machine.
+* `firmware` - The firmware interface that is used by this virtual machine. Can
+  be either `bios` or `efi`.
 * `hardware_version` - The hardware version number on this virtual machine.
 * `scsi_type` - The common type of all SCSI controllers on this virtual machine.
   Will be one of `lsilogic` (LSI Logic Parallel), `lsilogic-sas` (LSI Logic
@@ -108,10 +116,10 @@ The following attributes are exported:
   template. These are sorted by bus and unit number so that they can be applied
   to a `vsphere_virtual_machine` resource in the order the resource expects
   while cloning. This is useful for discovering certain disk settings while
-  performing a linked clone, as all settings that are output by this data
-  source must be the same on the destination virtual machine as the source.
-  Only the first number of controllers defined by `scsi_controller_scan_count`
-  are scanned for disks. The sub-attributes are:
+  performing a linked clone, as all settings that are output by this data source
+  must be the same on the destination virtual machine as the source. Only the
+  first number of controllers defined by `scsi_controller_scan_count` are
+  scanned for disks. The sub-attributes are:
  * `label` -  The label for the disk.
  * `size` - The size of the disk, in GIB.
  * `eagerly_scrub` - Set to `true` if the disk has been eager zeroed.
@@ -119,34 +127,36 @@ The following attributes are exported:
  * `unit_number` - The disk number on the storage bus.
 * `network_interface_types` - The network interface types for each network
   interface found on the virtual machine, in device bus order. Will be one of
-  `e1000`, `e1000e`, `pcnet32`, `sriov`, `vmxnet2`, `vmxnet3vrdma`, or `vmxnet3`.
-* `network_interfaces` - Information about each of the network interfaces on this 
-  virtual machine or template. These are sorted by device bus order so that they 
-  can be applied to a `vsphere_virtual_machine` resource in the order the resource 
-  expects while cloning. This is useful for discovering certain network interface 
-  settings while performing a linked clone, as all settings that are output by this 
-  data source must be the same on the destination virtual machine as the source.
-  The sub-attributes are:
- * `adapter_type` -  The network interface types for each network interface found 
-  on the virtual machine, in device bus order. Will be one of `e1000`, `e1000e`, 
-  `vmxnet3vrdma`, or `vmxnet3`.
- * `bandwidth_limit` - The upper bandwidth limit of this network interface, 
+  `e1000`, `e1000e`, `pcnet32`, `sriov`, `vmxnet2`, `vmxnet3vrdma`, or
+  `vmxnet3`.
+* `network_interfaces` - Information about each of the network interfaces on
+  this virtual machine or template. These are sorted by device bus order so that
+  they can be applied to a `vsphere_virtual_machine` resource in the order the
+  resource expects while cloning. This is useful for discovering certain network
+  interface settings while performing a linked clone, as all settings that are
+  output by this data source must be the same on the destination virtual machine
+  as the source. The sub-attributes are:
+ * `adapter_type` - The network interface types for each network interface found
+   on the virtual machine, in device bus order. Will be one of `e1000`,
+   `e1000e`, `vmxnet3vrdma`, or `vmxnet3`.
+ * `bandwidth_limit` - The upper bandwidth limit of this network interface,
   in Mbits/sec.
- * `bandwidth_reservation` - The bandwidth reservation of this network interface, 
-  in Mbits/sec.
- * `bandwidth_share_level` - The bandwidth share allocation level for this interface. 
-  Can be one of `low`, `normal`, `high`, or `custom`.
- * `bandwidth_share_count` - The share count for this network interface when the 
-  share level is custom.
+ * `bandwidth_reservation` - The bandwidth reservation of this network
+   interface, in Mbits/sec.
+ * `bandwidth_share_level` - The bandwidth share allocation level for this
+   interface. Can be one of `low`, `normal`, `high`, or `custom`.
+ * `bandwidth_share_count` - The share count for this network interface when the
+   share level is custom.
  * `mac_address` - The MAC address of this network interface.
- * `network_id` - The managed object reference ID of the network this interface is 
-  connected to.
-* `firmware` - The firmware type for this virtual machine. Can be `bios` or `efi`.
-* `default_ip_address` - Whenever possible, this is the first IPv4 address that is reachable through
-  the default gateway configured on the machine, then the first reachable IPv6
-  address, and then the first general discovered address if neither exist. If
-  VMware Tools is not running on the virtual machine, or if the VM is powered
-  off, this value will be blank.
+ * `network_id` - The managed object reference ID of the network this interface
+   is connected to.
+* `firmware` - The firmware type for this virtual machine. Can be `bios` or
+  `efi`.
+* `default_ip_address` - Whenever possible, this is the first IPv4 address that
+  is reachable through the default gateway configured on the machine, then the
+  first reachable IPv6 address, and then the first general discovered address if
+  neither exist. If VMware Tools is not running on the virtual machine, or if
+  the VM is powered off, this value will be blank.
 * `guest_ip_addresses` - A list of IP addresses as reported by VMware Tools.
 * `instance_uuid` - The instance UUID of the virtual machine or template.
 

--- a/website/docs/d/vsphere_role.html.markdown
+++ b/website/docs/d/vsphere_role.html.markdown
@@ -9,9 +9,8 @@ description: |-
 
 # vsphere\_role
 
-The `vsphere_role` data source can be used to discover the `id` and privileges associated
-with a role given its name or display label.
-
+The `vsphere_role` data source can be used to discover the `id` and privileges
+associated with a role given its name or display label.
 
 ## Example Usage
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -246,7 +246,7 @@ To get all the necessary data in a single output, use `govc ls -l -i PATH`.
 
 Sample output is below:
 
-```
+```shell
 $ govc ls -l -i /dc-01/vm
 VirtualMachine:vm-123 /dc-01/vm/foobar
 Folder:group-v234 /dc-01/vm/subfolder
@@ -254,7 +254,7 @@ Folder:group-v234 /dc-01/vm/subfolder
 
 To do a reverse search, supply the `-L` switch:
 
-```
+```shell
 $ govc ls -i -l -L VirtualMachine:vm-123
 VirtualMachine:vm-123 /dc-01/vm/foo
 ```

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -406,7 +406,7 @@ The following settings control specific settings for Admission Control when
 
 #### vSphere HA Datastore Settings
 
-vSphere HA uses datastore heartbeating to determine the health of a particular
+vSphere HA uses datastore heartbeats to determine the health of a particular
 host. Depending on how your datastores are configured, the settings below may
 need to be altered to ensure that specific datastores are used over others.
 
@@ -420,7 +420,7 @@ If you require a user-defined list of datastores, ensure you select either
   `allFeasibleDsWithUserPreference`. Default:
   `allFeasibleDsWithUserPreference`.
 * `ha_heartbeat_datastore_ids` - (Optional) The list of managed object IDs for
-  preferred datastores to use for HA heartbeating. This setting is only useful
+  preferred datastores to use for HA heartbeats. This setting is only useful
   when [`ha_heartbeat_datastore_policy`](#ha_heartbeat_datastore_policy) is set
   to either `userSelectedDs` or `allFeasibleDsWithUserPreference`.
 

--- a/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
@@ -24,7 +24,7 @@ to ensure that the virtual machines run on different hosts, or prevent any
 operation that would keep that from happening, depending on the value of the
 [`mandatory`](#mandatory) flag.
 
--> An anti-affinity rule can only be used to place virtual machines on seperate
+-> An anti-affinity rule can only be used to place virtual machines on separate
 _non-specific_ hosts. Specific hosts cannot be specified with this rule.
 To enable this capability, use VM-Host Groups, see the
 [`vsphere_compute_cluster_vm_host_rule`][tf-vsphere-cluster-vm-host-rule-resource]

--- a/website/docs/r/content_library_item.html.markdown
+++ b/website/docs/r/content_library_item.html.markdown
@@ -100,6 +100,8 @@ The only attribute this resource exports is the `id` of the resource, which is
 a combination of the [managed object reference ID][docs-about-morefs] of the
 cluster, and the name of the virtual machine group.
 
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+
 ## Importing
 
 An existing content library item can be [imported][docs-import] into this resource by

--- a/website/docs/r/custom_attribute.html.markdown
+++ b/website/docs/r/custom_attribute.html.markdown
@@ -62,6 +62,7 @@ resource "vsphere_virtual_machine" "vm" {
   # ... other configuration ...
 }
 ```
+
 The following example creates a [`vsphere_virtual_machine`][docs-virtual-machine-resource] resource and an existing custom attribute is then applied with an assigned value to the virtual machine.
 
 [docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html

--- a/website/docs/r/datacenter.html.markdown
+++ b/website/docs/r/datacenter.html.markdown
@@ -44,14 +44,14 @@ The following arguments are supported:
 
 [docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
 
-* `custom_attributes` - (Optional) Map of custom attribute ids to value 
-  strings to set for datacenter resource. See 
-  [here][docs-setting-custom-attributes] for a reference on how to set values 
+* `custom_attributes` - (Optional) Map of custom attribute ids to value
+  strings to set for datacenter resource. See
+  [here][docs-setting-custom-attributes] for a reference on how to set values
   for custom attributes.
 
 [docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
 
-~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections
 and require vCenter.
 
 ## Attribute Reference
@@ -62,7 +62,7 @@ and require vCenter.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
-## Importing 
+## Importing
 
 An existing datacenter can be [imported][docs-import] into this resource
 via supplying the full path to the datacenter. An example is below:

--- a/website/docs/r/license.html.markdown
+++ b/website/docs/r/license.html.markdown
@@ -32,7 +32,6 @@ The following arguments are supported:
 * `license_key` - (Required) The license key to add.
 * `labels` - (Optional) A map of key/value pairs to be attached as labels (tags) to the license key.
 
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/virtual_machine_class.html.markdown
+++ b/website/docs/r/virtual_machine_class.html.markdown
@@ -24,6 +24,7 @@ resource "vsphere_virtual_machine_class" "basic_class" {
 ```
 
 **Create a class with a vGPU**
+
 ```hcl
 resource "vsphere_virtual_machine_class" "vgp_class" {
   name = "vgpu-class"

--- a/website/docs/r/vm_storage_policy.html.markdown
+++ b/website/docs/r/vm_storage_policy.html.markdown
@@ -4,13 +4,13 @@ layout: "vsphere"
 page_title: "VMware vSphere: vm_storage_policy"
 sidebar_current: "docs-vsphere-resource-vm-storage-policy"
 description: |-
-  Storage policies can select the most appropriate datastore for the virtual machine and enforce the required level of service. 
+  Storage policies can select the most appropriate datastore for the virtual machine and enforce the required level of service.
 ---
 
 # vsphere\_vm\_storage\_policy
 
-The `vsphere_vm_storage_policy` resource can be used to create and manage storage 
-policies. Using this resource, tag based placement rules can be created to 
+The `vsphere_vm_storage_policy` resource can be used to create and manage storage
+policies. Using this resource, tag based placement rules can be created to
 place virtual machines on a datastore with matching tags. If storage requirements for the applications on the virtual machine change, you can modify the storage policy that was originally applied to the virtual machine.
 
 ## Example Usage
@@ -139,7 +139,7 @@ resource "vsphere_vm_storage_policy" "dev_silver_nonreplicated" {
 }
 ```
 
-Lasttly, when creating a virtual machine resource, a storage policy can be specificed to direct virtual machine placement to a datastore which matches the policy's `tags_rules`.
+Lastly, when creating a virtual machine resource, a storage policy can be specified to direct virtual machine placement to a datastore which matches the policy's `tags_rules`.
 
 ```hcl
 data "vsphere_storage_policy" "prod_platinum_replicated" {
@@ -168,7 +168,7 @@ resource "vsphere_virtual_machine" "dev_vm" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the storage policy.
-* `description` - (Optional) Description of the storage policy. 
+* `description` - (Optional) Description of the storage policy.
 * `tag_rules` - (Required) List of tag rules. The tag category and tags to be associated to this storage policy.
   * `tag_category` - (Required) Name of the tag category.
   * `tags` - (Required) List of Name of tags to select from the given category.

--- a/website/docs/r/vmfs_datastore.html.markdown
+++ b/website/docs/r/vmfs_datastore.html.markdown
@@ -16,11 +16,11 @@ disks presented to a host or multiple hosts over Fibre Channel or iSCSI.
 Devices can be specified manually, or discovered using the
 [`vsphere_vmfs_disks`][data-source-vmfs-disks] data source.
 
-[data-source-vmfs-disks]: /docs/providers/vsphere/d/vmfs_disks.html 
+[data-source-vmfs-disks]: /docs/providers/vsphere/d/vmfs_disks.html
 
 ## Auto-Mounting of Datastores Within vCenter
 
-Note that the current behaviour of this resource will auto-mount any created
+Note that the current behavior of this resource will auto-mount any created
 datastores to any other host within vCenter that has access to the same disk.
 
 Example: You want to create a datastore with a iSCSI LUN that is visible on 3
@@ -30,7 +30,7 @@ create the datastore on `esxi1`, the datastore will be automatically mounted on
 those two hosts.
 
 Future versions of this resource may allow you to control the hosts that a
-datastore is mounted to, but currently, this automatic behaviour cannot be
+datastore is mounted to, but currently, this automatic behavior cannot be
 changed, so keep this in mind when writing your configurations and deploying
 your disks.
 
@@ -58,20 +58,20 @@ datastore with local disks to a single ESXi server.
 ~> **NOTE:** There are some situations where datastore creation will not work
 when working through vCenter (usually when trying to create a datastore on a
 single host with local disks). If you experience trouble creating the datastore
-you need through vCenter, break the datstore off into a different configuration
+you need through vCenter, break the datastore off into a different configuration
 and deploy it using the ESXi server as the provider endpoint, using a similar
 configuration to what is below.
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {}
 
-data "vsphere_host" "esxi_host" {
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+data "vsphere_host" "host" {
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
   name           = "terraform-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  host_system_id = data.vsphere_host.host.id
 
   disks = [
     "mpx.vmhba1:C0:T1:L0",
@@ -94,23 +94,23 @@ into `vsphere_vmfs_datastore`. The datastore is also placed in the
 
 ```hcl
 data "vsphere_datacenter" "datacenter" {
-  name = "dc1"
+  name = "dc-01"
 }
 
-data "vsphere_host" "esxi_host" {
-  name          = "esxi1"
-  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+data "vsphere_host" "host" {
+  name          = "esxi-01.example.com"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_vmfs_disks" "available" {
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  host_system_id = data.vsphere_host.host.id
   rescan         = true
   filter         = "naa.60a98000"
 }
 
 resource "vsphere_vmfs_datastore" "datastore" {
   name           = "terraform-test"
-  host_system_id = "${data.vsphere_host.esxi_host.id}"
+  host_system_id = data.vsphere_host.host.id
   folder         = "datastore-folder"
 
   disks = ["${data.vsphere_vmfs_disks.available.disks}"]
@@ -145,14 +145,14 @@ The following arguments are supported:
 [docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
-* `custom_attributes` (Optional) Map of custom attribute ids to attribute 
-   value string to set on datastore resource. See 
-   [here][docs-setting-custom-attributes] for a reference on how to set values 
+* `custom_attributes` (Optional) Map of custom attribute ids to attribute
+   value string to set on datastore resource. See
+   [here][docs-setting-custom-attributes] for a reference on how to set values
    for custom attributes.
 
 [docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
 
-~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections
 and require vCenter.
 
 ## Attribute Reference

--- a/website/docs/r/vsphere_entity_permissions.html.markdown
+++ b/website/docs/r/vsphere_entity_permissions.html.markdown
@@ -4,33 +4,37 @@ layout: "vsphere"
 page_title: "VMware vSphere: Entity Permissions"
 sidebar_current: "docs-vsphere-entity-permissions"
 description: |-
-  Provides CRUD operations on a vsphere entity permissions. Permissions can be created on an entity for a given user or
-  group with the specified roles.
+  Provides CRUD operations on a vsphere entity permissions.
+  Permissions can be created on an entity for a given user or group with the
+  specified roles.
 ---
 
 # vsphere\_entity\_permissions
 
-The `vsphere_entity_permissions` resource can be used to create and manage entity permissions.
-Permissions can be created on an entity for a given user or group with the specified role.
+The `vsphere_entity_permissions` resource can be used to create and manage
+entity permissions. Permissions can be created on an entity for a given user or
+group with the specified role.
 
 ## Example Usage
 
-This example creates entity permissions on the virtual machine VM1 for the user group DCClients with role Datastore
-consumer and for user group ExternalIDPUsers with role my_terraform_role. The `entity_id` can be the managed object id
-(or uuid for some resources). The `entity_type` is one of the managed object types which can be found from the
-managed object types section [here](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/). Keep the permissions sorted
-alphabetically, ignoring case on `user_or_group` for a better user experience.
+This example creates entity permissions on the virtual machine VM1 for the user
+group DCClients with role Datastore consumer and for user group ExternalIDPUsers
+with role my_terraform_role. The `entity_id` can be the managed object id (or
+uuid for some resources). The `entity_type` is one of the managed object types
+which can be found from the managed object types section
+[here](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/).
+Keep the permissions sorted alphabetically, ignoring case on `user_or_group` for
+a better user experience.
 
 
 ```hcl
-
-data "vsphere_datacenter" "dc" {
+data "vsphere_datacenter" "datacenter" {
   name = "Sample_DC_2"
 }
 
-data "vsphere_virtual_machine" vm1 {
+data "vsphere_virtual_machine" "vm" {
   name = "VM1"
-  datacenter_id = data.vsphere_datacenter.dc.id
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
 data "vsphere_role" "role1" {
@@ -43,7 +47,7 @@ resource vsphere_role "role2" {
 }
 
 resource "vsphere_entity_permissions" p1 {
-  entity_id = data.vsphere_virtual_machine.vm1.id
+  entity_id = data.vsphere_virtual_machine.vm.id
   entity_type = "VirtualMachine"
   permissions {
     user_or_group = "vsphere.local\\DCClients"
@@ -58,21 +62,25 @@ resource "vsphere_entity_permissions" p1 {
     role_id = vsphere_role.role2.id
   }
 }
-
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `entity_id`   - (Required) The managed object id (uuid for some entities) on which permissions are to be created.
-* `entity_type` - (Required) The managed object type, types can be found in the managed object type section
-   [here](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/).
-
-* `permissions`     - (Required) The permissions to be given on this entity. Keep the permissions sorted
-                       alphabetically on `user_or_group` for a better user experience.
+* `entity_id` - (Required) The managed object id (uuid for some entities) on
+  which permissions are to be created.
+* `entity_type` - (Required) The managed object type, types can be found in the
+  managed object type section
+  [here](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/).
+* `permissions` - (Required) The permissions to be given on this entity. Keep
+  the permissions sorted alphabetically on `user_or_group` for a better user
+  experience.
   * `user_or_group` - (Required) The user/group getting the permission.
-  * `is_group`      - (Required) Whether user_or_group field refers to a user or a group. True for a group and false for a user.
-  * `role_id`       - (Required) The role id of the role to be given to the user on the specified entity.
-  * `propagate`     - (Required) Whether or not this permission propagates down the hierarchy to sub-entities.
+  * `is_group` - (Required) Whether `user_or_group` field refers to a user or a
+    group. True for a group and false for a user.
+  * `role_id` - (Required) The role id of the role to be given to the user on
+    the specified entity.
+  * `propagate` - (Required) Whether or not this permission propagates down the
+    hierarchy to sub-entities.
 

--- a/website/docs/r/vsphere_role.html.markdown
+++ b/website/docs/r/vsphere_role.html.markdown
@@ -9,22 +9,21 @@ description: |-
 
 # vsphere\_role
 
-The `vsphere_role` resource can be used to create and manage roles. Using this resource, privileges can be 
+The `vsphere_role` resource can be used to create and manage roles. Using this resource, privileges can be
 associated with the roles. The role can be used while granting permissions to an entity.
 
 ## Example Usage
 
-This example creates a role with name my_terraform_role and privileges create, acknowledge for Alarm and 
+This example creates a role with name my_terraform_role and privileges create, acknowledge for Alarm and
 create, move for Datacenter. While providing `role_privileges`, the id of the privilege has to be provided.
 The format of the privilege id is privilege name preceded by its categories joined by a `.`.
-For example a privilege with path `category->subcategory->privilege` should be provided as 
+For example a privilege with path `category->subcategory->privilege` should be provided as
 `category.subcategory.privilege`. Keep the `role_privileges` sorted alphabetically for a better user experience.
 
 ~> **NOTE:** While providing `role_privileges`, the id of the privilege and its categories are to be provided
 joined by a `.` .
 
 ```hcl
-
 resource vsphere_role "role1" {
   name = "my_terraform_role"
   role_privileges = ["Alarm.Acknowledge", "Alarm.Create", "Datacenter.Create", "Datacenter.Move"]
@@ -42,9 +41,10 @@ The following arguments are supported:
 
 An existing role can be imported into this resource by supplying the role id. An example is below:
 
-```hcl
+```
 terraform import vsphere_role.role1 -709298051
 ```
+
 ~> **NOTE:** System roles can't be imported because they can't be modified or deleted.
 Use [`vsphere_role` data source][ref-vsphere-role-data-source]
 to read information about system roles.


### PR DESCRIPTION
### Description

Addressed markdownlint issues for documentation.

Results:

```shell
terraform-provider-vsphere on  docs/markdown-linting [!?] via 🐹 v1.22.4 
➜ markdownlint "website/docs/*"


terraform-provider-vsphere on  docs/markdown-linting [!?] via 🐹 v1.22.4 
➜ 
```
