### PR TITLE
feat: add support for ntpd service on `r/vsphere_host`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
+## 2.8.4 (Not Released)
+
+FEATURES:
+
+* `resource/host` - Added support for ntpd for services on `r/vsphere_host`. This allows for ntpd
+  service settings and policy to be added to a host resource and future expansion of additional
+  services. ([#2232](https://github.com/terraform-providers/terraform-provider-vsphere/pull/2232))
+
 ## 2.8.3 August 13, 2024
 
 BUG FIX:

--- a/vsphere/resource_vsphere_host_test.go
+++ b/vsphere/resource_vsphere_host_test.go
@@ -6,9 +6,11 @@ package vsphere
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
@@ -23,6 +25,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+var fallbackNtpServers = []string{
+	"0.pool.ntp.org",
+	"1.pool.ntp.org",
+	"2.pool.ntp.org",
+	"3.pool.ntp.org",
+}
 
 func TestAccResourceVSphereHost_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -378,6 +387,121 @@ func checkHostLockdown(client *govmomi.Client, hostID, lockdownMode string) (boo
 	return modeString == lockdownMode, nil
 }
 
+func TestAccResourceVSphereHostNtpService(t *testing.T) {
+	configs := []NtpdServiceConfig{
+		{Enabled: true, Policy: "on"},
+		{Enabled: true, Policy: "off"},
+		{Enabled: true, Policy: "automatic"},
+		{Enabled: false, Policy: "on"},
+		{Enabled: false, Policy: "off"},
+		{Enabled: false, Policy: "automatic"},
+	}
+
+	for _, config := range configs {
+		t.Run(fmt.Sprintf("Enabled=%t,Policy=%s", config.Enabled, config.Policy), func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:     func() { testAccPreCheck(t) },
+				Providers:    testAccProviders,
+				CheckDestroy: testAccVSphereHostDestroy,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccVSphereHostConfigNtpdServices(config),
+						Check: resource.ComposeTestCheckFunc(
+							testAccCheckVSphereHostNTPServiceState("vsphere_host.h1", config),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccCheckVSphereHostNTPServiceState(resourceName string, config NtpdServiceConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		actualEnabled := rs.Primary.Attributes["services.0.ntpd.0.enabled"]
+		actualPolicy := rs.Primary.Attributes["services.0.ntpd.0.policy"]
+
+		expectedEnabled := strconv.FormatBool(config.Enabled)
+		expectedPolicy := config.Policy
+
+		if actualEnabled != expectedEnabled {
+			return fmt.Errorf("Expected NTPD service enabled state: %s, got: %s", expectedEnabled, actualEnabled)
+		}
+		if actualPolicy != expectedPolicy {
+			return fmt.Errorf("Expected NTPD policy: %s, got: %s", expectedPolicy, actualPolicy)
+		}
+
+		return nil
+	}
+}
+
+func TestAccResourceVSphereHostNTPServers(t *testing.T) {
+	ntpServers := os.Getenv("NTP_SERVERS")
+	if ntpServers == "" {
+		t.Log("NTP_SERVERS environment variable is not set, using fallback value")
+		ntpServers = strings.Join(fallbackNtpServers, ",")
+	}
+
+	// Split the environment variable into a slice of strings
+	ntpServersSlice := strings.Split(ntpServers, ",")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"ESX_HOSTNAME", "ESX_USERNAME", "ESX_PASSWORD"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereHostConfigNtpServers(ntpServersSlice),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccCheckVSphereHostNTPServers("vsphere_host.h1", ntpServersSlice),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVSphereHostNTPServers(resourceName string, expectedServers []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		log.Printf("Resource attributes: %+v", rs.Primary.Attributes)
+
+		// Retrieve the number of NTP servers
+		ntpServersCount, err := strconv.Atoi(rs.Primary.Attributes["services.0.ntpd.0.ntp_servers.#"])
+		if err != nil {
+			return fmt.Errorf("Error converting ntp_servers count: %s", err)
+		}
+
+		// Collect actual NTP servers
+		var actualServers []string
+		for i := 0; i < ntpServersCount; i++ {
+			server := rs.Primary.Attributes[fmt.Sprintf("services.0.ntpd.0.ntp_servers.%d", i)]
+			actualServers = append(actualServers, server)
+		}
+
+		expectedServersStr := strings.Join(expectedServers, ",")
+		actualServersStr := strings.Join(actualServers, ",")
+
+		if actualServersStr != expectedServersStr {
+			return fmt.Errorf("Expected NTP servers: %s, got: %s", expectedServersStr, actualServersStr)
+		}
+
+		return nil
+	}
+}
+
 func testAccVSphereHostConfig() string {
 	return fmt.Sprintf(`
 	%s
@@ -429,7 +553,7 @@ func testaccvspherehostconfigRootfolder() string {
 
 func testaccvspherehostconfigEmptylicense() string {
 	return fmt.Sprintf(`
-	%s 
+	%s
 	resource "vsphere_host" "h1" {
 	  # Useful only for connection
 	  hostname = "%s"
@@ -455,18 +579,18 @@ func testaccvspherehostconfigImport() string {
 	  name = "%s"
 	  datacenter_id = data.vsphere_datacenter.rootdc1.id
 	}
-		
+
 	resource "vsphere_host" "h1" {
 	  # Useful only for connection
 	  hostname = "%s"
 	  username = "%s"
 	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
-	
+
 	  # Makes sense to update
 	  license = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
-	}	  
+	}
 	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
 		os.Getenv("ESX_HOSTNAME"),
@@ -483,17 +607,17 @@ func testaccvspherehostconfigConnection(connection bool) string {
 	  name = "%s"
 	  datacenter_id = data.vsphere_datacenter.rootdc1.id
 	}
-		
+
 	resource "vsphere_host" "h1" {
 	  hostname = "%s"
 	  username = "%s"
 	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
-	
+
 	  license = "%s"
 	  connected = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
-	}	  
+	}
 	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
 		os.Getenv("ESX_HOSTNAME"),
@@ -511,18 +635,18 @@ func testaccvspherehostconfigMaintenance(maintenance bool) string {
 	  name = "%s"
 	  datacenter_id = data.vsphere_datacenter.rootdc1.id
 	}
-		
+
 	resource "vsphere_host" "h1" {
 	  hostname = "%s"
 	  username = "%s"
 	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
-	
+
 	  license = "%s"
 	  connected = "true"
 	  maintenance = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
-	}	  
+	}
 	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
 		os.Getenv("ESX_HOSTNAME"),
@@ -540,19 +664,19 @@ func testaccvspherehostconfigLockdown(lockdown string) string {
 	  name = "%s"
 	  datacenter_id = data.vsphere_datacenter.rootdc1.id
 	}
-		
+
 	resource "vsphere_host" "h1" {
 	  hostname = "%s"
 	  username = "%s"
 	  password = "%s"
 	  thumbprint = data.vsphere_host_thumbprint.id
-	
+
 	  license = "%s"
 	  connected = "true"
 	  maintenance = "false"
 	  lockdown = "%s"
 	  cluster = vsphere_compute_cluster.c1.id
-	}	  
+	}
 	`, testhelper.ConfigDataRootDC1(),
 		"TestCluster",
 		os.Getenv("ESX_HOSTNAME"),
@@ -560,4 +684,86 @@ func testaccvspherehostconfigLockdown(lockdown string) string {
 		os.Getenv("ESX_PASSWORD"),
 		os.Getenv("TF_VAR_VSPHERE_LICENSE"),
 		lockdown)
+}
+
+type NtpdServiceConfig struct {
+	Enabled bool
+	Policy  string
+}
+
+func testAccVSphereHostConfigNtpdServices(config NtpdServiceConfig) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vsphere_compute_cluster" "c1" {
+  name = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+
+data "vsphere_host_thumbprint" "thumbprint" {
+    address = "%s"
+    insecure = true
+}
+
+resource "vsphere_host" "h1" {
+    hostname = "%s"
+    username = "%s"
+    password = "%s"
+    thumbprint = data.vsphere_host_thumbprint.thumbprint.id
+    services {
+        ntpd {
+            enabled = "%s"
+            policy  = "%s"
+        }
+    }
+    cluster = vsphere_compute_cluster.c1.id
+}
+`, testhelper.ConfigDataRootDC1(),
+		"TestCluster",
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		strconv.FormatBool(config.Enabled),
+		config.Policy)
+}
+
+func testAccVSphereHostConfigNtpServers(ntpServers []string) string {
+	// Convert the NTP servers slice to a string suitable for interpolation in the Terraform configuration
+	serversStr := strings.Join(ntpServers, "\", \"")
+	config := fmt.Sprintf(`
+%s
+
+resource "vsphere_compute_cluster" "c1" {
+  name = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+
+data "vsphere_host_thumbprint" "thumbprint" {
+    address = "%s"
+    insecure = true
+}
+
+resource "vsphere_host" "h1" {
+    hostname = "%s"
+    username = "%s"
+    password = "%s"
+    thumbprint = data.vsphere_host_thumbprint.thumbprint.id
+    services {
+        ntpd {
+             ntp_servers = ["%s"]
+             enabled = true
+             policy = "on"
+        }
+    }
+    cluster = vsphere_compute_cluster.c1.id
+}`, testhelper.ConfigDataRootDC1(),
+		"TestCluster",
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		serversStr)
+	log.Printf("Generated Terraform configuration: %s", config)
+	return config
 }

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -61,6 +61,12 @@ resource "vsphere_host" "esx-01" {
   license  = "00000-00000-00000-00000-00000"
   thumbprint = data.vsphere_host_thumbprint.thumbprint.id
   cluster  = data.vsphere_compute_cluster.cluster.id
+  services {
+    ntpd {
+      enabled     = true
+      policy      = "on"
+      ntp_servers = ["pool.ntp.org"]
+    }
 }
 ```
 
@@ -102,6 +108,11 @@ The following arguments are supported:
 
 ~> **NOTE:** Tagging support is not supported on direct ESXi host
 connections and require vCenter Server.
+
+* `services` - (Optional) Set Services on host, the settings to be set are based on service being set as part of import.
+    * `ntpd` service has three settings, `enabled` sets service to running or not running, `policy` sets service based on setting of `on` which sets service to "Start and stop with host", `off` which sets service to "Start and stop manually", `automatic` which sets service to "Start and stop with port usage".
+
+~> **NOTE:** `services` only supports ntpd service today.
 
 * `custom_attributes` - (Optional) A map of custom attribute IDs and string
   values to apply to the resource. Please refer to the


### PR DESCRIPTION
### Description

Added support for ntpd for services on `r/vsphere_host`. This allows for ntpd service settings and policy to be added to a host resource.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

### Release Note

- `resource/host` - Added support for ntpd for services on `r/vsphere_host`. This allows for ntpd service settings and policy to be added to a host resource and future expansion of additional services.


### References

Closes #1131
