### PR TITLE
fix: reconfigure vm with multiple pci passthrough devices

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -988,6 +988,7 @@ func (c *pciApplyConfig) modifyVirtualPciDevices(devList *schema.Set, op types.V
 					SystemId:                       c.SystemID,
 					VendorId:                       pciDev.VendorId,
 				},
+				Key: c.VirtualDevice.NewKey(),
 			},
 		}
 		vm, err := virtualmachine.FromUUID(c.Client, c.ResourceData.Id())

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -238,10 +238,11 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Elem:        &schema.Resource{Schema: virtualdevice.CdromSubresourceSchema()},
 		},
 		"pci_device_id": {
-			Type:        schema.TypeSet,
-			Optional:    true,
-			Description: "A list of PCI passthrough devices",
-			Elem:        &schema.Schema{Type: schema.TypeString},
+			Type:         schema.TypeSet,
+			Optional:     true,
+			Description:  "A list of PCI passthrough devices",
+			Elem:         &schema.Schema{Type: schema.TypeString},
+			RequiredWith: []string{"host_system_id"},
 		},
 		"clone": {
 			Type:        schema.TypeList,


### PR DESCRIPTION
### Description

Usually when we reconfigure VMs we set negative integers as keys for new devices. vCenter assigns actual keys after the reconfiguration task completes which we then read and reassign to our resource.

This was not the case with PCI passthrough devices. No key was being assigned which meant that every such device got a zero as its key (the default integer value). This is fine if you're adding a single device but if you try with more than one the API fails.

The fix is simple - we simply need to assign a unique negative integer as the device key just like we do for other device types.

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

I had to manually test this one since it requires dedicated devices on the underlying hardware.

There is an important disclaimer to be made here - _adding PCI passthrough devices during VM creation does not work_. It is does not work out of the box and this is not related to this change.

I am **not** making an attempt to resolve this problem with this PR as it requires a _significant refactoring_ effort.

### Release Note

`resource/virtual_machine`: Fixed virtual machine reconfiguration with multiple PCI passthrough devices.

### References

Closes #1688