### PR TITLE
PSS-277: Bump hashicorp/ghaction-terraform-provider-release/.github/w…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v3.0.1
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v4.0.1
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'
       hc-releases-key-staging: '${{ secrets.HC_RELEASES_KEY_STAGING }}'


### PR DESCRIPTION
…orkflows/hashicorp.yml to v4.0.1

This patch bumps hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml to v4.0.1, with the intention of using the new runner labels format (see release notes in https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v4.0.1).

This change is necessary for a runner to pick up jobs using this action.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
