### PR TITLE
feat: allow resizing of virtual disks

### DIFF
--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -338,7 +338,11 @@ func resourceVSphereVirtualDiskUpdate(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[INFO] Updating Virtual Disk")
 	client := meta.(*Client).vimClient
 
-	// TODO - only allow increase
+	oldSize, newSize := d.GetChange("size")
+	if newSize.(int) < oldSize.(int) {
+		return fmt.Errorf("shrinking a virtual disk is not supported")
+	}
+
 	vDisk := virtualDisk{
 		size: d.Get("size").(int),
 	}

--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -38,6 +38,7 @@ func resourceVSphereVirtualDisk() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceVSphereVirtualDiskCreate,
 		Read:   resourceVSphereVirtualDiskRead,
+		Update: resourceVSphereVirtualDiskUpdate,
 		Delete: resourceVSphereVirtualDiskDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceVSphereVirtualDiskImport,
@@ -48,7 +49,6 @@ func resourceVSphereVirtualDisk() *schema.Resource {
 			"size": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true, // TODO Can this be optional (resize)?
 			},
 
 			// TODO:
@@ -334,6 +334,47 @@ func resourceVSphereVirtualDiskRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
+func resourceVSphereVirtualDiskUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating Virtual Disk")
+	client := meta.(*Client).vimClient
+
+	// TODO - only allow increase
+	vDisk := virtualDisk{
+		size: d.Get("size").(int),
+	}
+
+	if v, ok := d.GetOk("vmdk_path"); ok {
+		vDisk.vmdkPath = v.(string)
+	}
+
+	if v, ok := d.GetOk("datastore"); ok {
+		vDisk.datastore = v.(string)
+	}
+
+	if v, ok := d.GetOk("datacenter"); ok {
+		vDisk.datacenter = v.(string)
+	}
+
+	finder := find.NewFinder(client.Client, true)
+
+	dc, err := getDatacenter(client, d.Get("datacenter").(string))
+	if err != nil {
+		return fmt.Errorf("error finding Datacenter: %s: %s", vDisk.datacenter, err)
+	}
+	finder = finder.SetDatacenter(dc)
+
+	ds, err := getDatastore(finder, vDisk.datastore)
+	if err != nil {
+		return fmt.Errorf("error finding Datastore: %s: %s", vDisk.datastore, err)
+	}
+
+	if err := extendHardDisk(client, vDisk.size, ds.Path(vDisk.vmdkPath), vDisk.datacenter); err != nil {
+		return err
+	}
+
+	return resourceVSphereVirtualDiskRead(d, meta)
+}
+
 func resourceVSphereVirtualDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client).vimClient
 
@@ -421,6 +462,29 @@ func createHardDisk(client *govmomi.Client, size int, diskPath string, diskType 
 		return err
 	}
 	log.Printf("[INFO] Created disk.")
+
+	return nil
+}
+
+func extendHardDisk(client *govmomi.Client, capacity int, diskPath string, dc string) error {
+	virtualDiskManager := object.NewVirtualDiskManager(client.Client)
+	datacenter, err := getDatacenter(client, dc)
+	if err != nil {
+		return err
+	}
+
+	capacityKb := int64(1024 * 1024 * capacity)
+	task, err := virtualDiskManager.ExtendVirtualDisk(context.TODO(), diskPath, datacenter, capacityKb, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = task.WaitForResultEx(context.TODO(), nil)
+	if err != nil {
+		log.Printf("[INFO] Failed to extend disk:  %v", err)
+		return err
+	}
+	log.Printf("[INFO] Extended disk.")
 
 	return nil
 }

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -42,16 +42,18 @@ resource "vsphere_virtual_disk" "virtual_disk" {
 
 The following arguments are supported:
 
-~> **NOTE:** All fields in the `vsphere_virtual_disk` resource are currently
+~> **NOTE:** Some fields in the `vsphere_virtual_disk` resource are currently
 immutable and force a new resource if changed.
 
 * `vmdk_path` - (Required) The path, including filename, of the virtual disk to
   be created.  This needs to end in `.vmdk`.
 * `datastore` - (Required) The name of the datastore in which to create the
   disk.
-* `size` - (Required) Size of the disk (in GB).
+* `size` - (Required) Size of the disk (in GB). Decreasing the size of a disk is not possible.
+If a disk of a smaller size is required then the original has to be destroyed along with its data and a new one has to be
+created.
 * `datacenter` - (Optional) The name of the datacenter in which to create the
-  disk. Can be omitted when when ESXi or if there is only one datacenter in
+  disk. Can be omitted when ESXi or if there is only one datacenter in
   your infrastructure.
 * `type` - (Optional) The type of disk to create. Can be one of
   `eagerZeroedThick`, `lazy`, or `thin`. Default: `eagerZeroedThick`. For


### PR DESCRIPTION
### Description

Increasing the size of a disk will no longer recreate it but modify it in-place.

Reductions in size are **not supported** by vCenter and will not be allowed.

The rest of the properties for `r/virtual_disk` are still marked with `ForceNew` and will continue to recreate the disk when changed.

### Acceptance tests

- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Added a new test case for this scenario.

### Release Note

`r/virtual_disk`: Allow resizing of virtual disks

### References

Closes #851
