### PR TITLE
fix: `r/resouce_pool` scaleable shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
+## 2.9.1 (Not Released)
+
+BUG FIX:
+
+* `resource/vsphere_resource_pool`: Removes the default setting for `scale_descendants_shares` to
+  allows for inheritance from the parent resource pool.
+  ([#2255]https://github.com/hashicorp/terraform-provider-vsphere/pull/2255)
+
 ## 2.9.0 (September 3, 2024)
 
 FEATURES:

--- a/vsphere/resource_vsphere_resource_pool.go
+++ b/vsphere/resource_vsphere_resource_pool.go
@@ -117,7 +117,6 @@ func resourceVSphereResourcePool() *schema.Resource {
 			Type:         schema.TypeString,
 			Description:  "Determines if the shares of all descendants of the resource pool are scaled up or down when the shares of the resource pool are scaled up or down.",
 			Optional:     true,
-			Default:      string(types.ResourceConfigSpecScaleSharesBehaviorDisabled),
 			ValidateFunc: validation.StringInSlice(resourcePoolScaleDescendantsSharesAllowedValues, false),
 		},
 		vSphereTagAttributeKey:    tagsSchema(),


### PR DESCRIPTION
### Description

Removes the default setting for `scale_descendants_shares` to allows for inheritance from the parent resource pool.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```console
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereResourcePool_basic$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	1.069s
```

### Release Note

`resource/resource_pool` - Removes the default setting for `scale_descendants_shares` to allows for inheritance from the parent resource pool.

### References

Closes #1763 
