### PR TITLE
fix: add vm to existing vm group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
+## 2.9.2 (not Released)
+
+BUG FIX:
+
+* `resource/vsphere_compute_cluster_vm_group.go`: Add new code to handle updating existing VM groups. This will need put ran in conjunction with Import.
+([#2260]https://github.com/hashicorp/terraform-provider-vsphere/pull/2260)
+
+
 ## 2.9.1 (September 9, 2024)
 
 BUG FIX:

--- a/website/docs/r/compute_cluster_vm_group.html.markdown
+++ b/website/docs/r/compute_cluster_vm_group.html.markdown
@@ -108,6 +108,8 @@ resource. Make sure your names are unique across both resources.
 
 [tf-vsphere-cluster-host-group-resource]: /docs/providers/vsphere/r/compute_cluster_host_group.html
 
+** To update a existing group, first import group with imported command in Import section, also note if you import group validate on apply that all groups that are needed to be in the group are added to `virtual_machine_ids`. If you leave any off the list the Virtual Machines will be removed from the group.**
+
 ## Attribute Reference
 
 The only attribute this resource exports is the `id` of the resource, which is


### PR DESCRIPTION
### Description

Updates `r/sphere_compute_cluster_vm_group` to allow for additional virtual machines to be adding or removed from a VM Group.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereComputeClusterVMGroup_basic$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	(cached)

Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereComputeClusterVMGroup_update$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	(cached)

...
```

### Release Note

`r/sphere_compute_cluster_vm_group`: Updates to allow for additional virtual machines to be adding or removed from a VM Group.

### References

Closes #1878 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
