### PR TITLE
fix: `r/vsphere_tag_category` cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
+## 2.9.3 (not release)
+
+BUG FIX:
+
+- `r/vsphere_tag_category`: Updates resource not to `ForceNew` for cardinality. This will allow the `tag_category` to updated.
+   [#2263](https://github.com/hashicorp/terraform-provider-vsphere/pull/2263)
+   
 ## 2.9.2 (September 16, 2024)
 
 BUG FIX:

--- a/vsphere/resource_vsphere_tag_category.go
+++ b/vsphere/resource_vsphere_tag_category.go
@@ -51,7 +51,6 @@ func resourceVSphereTagCategory() *schema.Resource {
 			"cardinality": {
 				Type:        schema.TypeString,
 				Description: "The associated cardinality of the category. Can be one of SINGLE (object can only be assigned one tag in this category) or MULTIPLE (object can be assigned multiple tags in this category).",
-				ForceNew:    true,
 				Required:    true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{


### PR DESCRIPTION
### Description

There was a bug that resulted in the tag being replaced when changing cardinality from Single to Multiple, I have remove the `ForceNew`.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```console
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereTagCategory_basic$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	(cached)
```

### Release Note

`r/vsphere_tag_category`: Updates resource not to `ForceNew` for cardinality. This will allow the `tag_category` to updated.

### References

Closes #1959 
