### PR TITLE
docs: updated `resource_pool` for standalone hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
-## 2.9.3 (not release)
+## 2.9.3 (Not Released)
 
 BUG FIX:
 
 - `r/vsphere_tag_category`: Updates resource not to `ForceNew` for cardinality. This will allow the `tag_category` to updated.
-   [#2263](https://github.com/hashicorp/terraform-provider-vsphere/pull/2263)
-   
+  [#2263](https://github.com/hashicorp/terraform-provider-vsphere/pull/2263)
+
+DOCUMENTATION:
+
+- `resource/vsphere_resource_pool`: Updates to include steps to create resource pool on standalone ESXi hosts.
+  [#2264](https://github.com/hashicorp/terraform-provider-vsphere/pull/2264)
+
 ## 2.9.2 (September 16, 2024)
 
 BUG FIX:

--- a/website/docs/r/resource_pool.html.markdown
+++ b/website/docs/r/resource_pool.html.markdown
@@ -75,6 +75,42 @@ resource "vsphere_resource_pool" "resource_pool_child" {
 }
 ```
 
+The following example set up a parent resource pool on a standalone ESXi host with the default
+settings for CPU and memory reservations, shares, and limits.
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_host_thumbprint" "thumbprint" {
+  address = "esx-01.example.com"
+  insecure = true
+}
+
+resource "vsphere_host" "esx-01" {
+  hostname = "esx-01.example.com"
+  username   = "root"
+  password   = "password"
+  license    = "00000-00000-00000-00000-00000"
+  thumbprint = data.vsphere_host_thumbprint.thumbprint.id
+  datacenter = data.vsphere_datacenter.datacenter.id
+}
+```hcl
+
+After the hosts are added to the datacenter, a resource pool can then be created on the host.
+
+```hcl
+data "vsphere_host" "host" {
+  name          = "esxi-01.example.com"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+resource "vsphere_resource_pool" "resource_pool" {
+  name                    = "site1-resource-pool"
+  parent_resource_pool_id = data.vsphere_host.host.resource_pool_id
+}
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
### Description

Updated `resource/vsphere_resource_pool` documentation to show the steps for creating resource pool on standalone ESXi hosts

### Release Note

`resource/vsphere_resource_pool`: Updates to include steps to create resource pool on standalone ESXi hosts.

### References

Closes #1846