### PR TITLE
fix: `r/vsphere_host` thumbprint error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
-## 2.9.3 (Not Released)
+## 2.9.3 (October 8, 2024)
 
 BUG FIX:
 
 - `r/vsphere_tag_category`: Updates resource not to `ForceNew` for cardinality. This will allow the `tag_category` to updated.
-  [#2263](https://github.com/hashicorp/terraform-provider-vsphere/pull/2263)
+  ([#2263](https://github.com/hashicorp/terraform-provider-vsphere/pull/2263))
+- `r/vsphere_host`: Updates resource to check thumbprint of the ESXI host thumbprint before adding the host to a cluster or vCenter Server.
+  ([#2266](https://github.com/hashicorp/terraform-provider-vsphere/pull/2266))
 
 DOCUMENTATION:
 
 - `resource/vsphere_resource_pool`: Updates to include steps to create resource pool on standalone ESXi hosts.
-  [#2264](https://github.com/hashicorp/terraform-provider-vsphere/pull/2264)
+  ([#2264](https://github.com/hashicorp/terraform-provider-vsphere/pull/2264))
 
 ## 2.9.2 (September 16, 2024)
 
@@ -18,12 +20,12 @@ BUG FIX:
 
 - `resource/vsphere_compute_cluster_vm_group`: Updates resource to allow for additional virtual
   machines to be adding or removed from a VM Group. Must be ran in conjunction with and import.
-  ([#2260]https://github.com/hashicorp/terraform-provider-vsphere/pull/2260)
+  ([#2260](https://github.com/hashicorp/terraform-provider-vsphere/pull/2260))
 
 FEATURES:
 
 - `resource\vsphere_tag`: Adds a format validation for `catagory_id`.
-  ([#2261]https://github.com/hashicorp/terraform-provider-vsphere/pull/2261)
+  ([#2261](https://github.com/hashicorp/terraform-provider-vsphere/pull/2261))
 
 ## 2.9.1 (September 9, 2024)
 
@@ -31,19 +33,19 @@ BUG FIX:
 
 - `resource/vsphere_resource_pool`: Removes the default setting for `scale_descendants_shares` to
   allows for inheritance from the parent resource pool.
-  ([#2255]https://github.com/hashicorp/terraform-provider-vsphere/pull/2255)
+  ([#2255](https://github.com/hashicorp/terraform-provider-vsphere/pull/2255))
 
 DOCUMENTATION:
 
 - `resource/vsphere_virtual_machine`: Updates to clarify assignment of `network_interface`
-  resources. ([#2256]https://github.com/hashicorp/terraform-provider-vsphere/pull/2256)
+  resources. ([#2256](https://github.com/hashicorp/terraform-provider-vsphere/pull/2256))
 - `resource/vsphere_host`: Updates to clarify import of `vsphere_hosts`.
-  ([#2257]https://github.com/hashicorp/terraform-provider-vsphere/pull/2257)
+  ([#2257](https://github.com/hashicorp/terraform-provider-vsphere/pull/2257))
 - `resource/vsphere_compute_cluster`: Updates to clarify import of `vsphere_compute_cluster`
-  resources. ([#2257]https://github.com/hashicorp/terraform-provider-vsphere/pull/2257)
+  resources. ([#2257](https://github.com/hashicorp/terraform-provider-vsphere/pull/2257))
 - `resource/vsphere_virtual_machine`: Updates to clarify the `vm` path in the import of
   `virtual_machine` resources.
-  ([#2257]https://github.com/hashicorp/terraform-provider-vsphere/pull/2257)
+  ([#2257](https://github.com/hashicorp/terraform-provider-vsphere/pull/2257))
 
 ## 2.9.0 (September 3, 2024)
 

--- a/vsphere/data_source_vsphere_host_thumbprint.go
+++ b/vsphere/data_source_vsphere_host_thumbprint.go
@@ -30,6 +30,7 @@ func dataSourceVSphereHostThumbprint() *schema.Resource {
 			"insecure": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Default:     false,
 				Description: "Boolean that can be set to true to disable SSL certificate verification.",
 			},
 		},

--- a/website/docs/d/host_thumbprint.html.markdown
+++ b/website/docs/d/host_thumbprint.html.markdown
@@ -10,9 +10,14 @@ description: |-
 # vsphere\_host\_thumbprint
 
 The `vsphere_thumbprint` data source can be used to discover the host thumbprint
-of an ESXi host. This can be used when adding the `vsphere_host` resource. If
-the ESXi host is using a certificate chain, the first one returned will be used
-to generate the thumbprint.
+of an ESXi host. This can be used when adding the `vsphere_host` resource to a
+cluster or a vCenter Server instance.
+
+* If the ESXi host is using a certificate chain, the first one returned will be
+used to generate the thumbprint.
+
+* If the ESXi host has a certificate issued by a certificate authority, ensure
+that the the certificate authority is trusted on the system running the plan.
 
 ## Example Usage
 
@@ -28,9 +33,8 @@ The following arguments are supported:
 
 * `address` - (Required) The address of the ESXi host to retrieve the thumbprint
   from.
+* `insecure` - (Optional) Disables SSL certificate verification. Default: `false`
 * `port` - (Optional) The port to use connecting to the ESXi host. Default: 443
-* `insecure` - (Optional) Disables SSL certificate verification.
-  Default: `false`
 
 ## Attribute Reference
 

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -79,6 +79,10 @@ The following arguments are supported:
   to the host.
 * `password` - (Required) Password that will be used by vSphere to authenticate
   to the host.
+* `thumbprint` - (Optional) Host's certificate SHA-1 thumbprint. If not set the
+  CA that signed the host's certificate should be trusted. If the CA is not
+  trusted and no thumbprint is set then the operation will fail. See data source
+  [`vsphere_host_thumbprint`][docs-host-thumbprint-data-source].
 * `datacenter` - (Optional) The ID of the datacenter this host should
   be added to. This should not be set if `cluster` is set.
 * `cluster` - (Optional) The ID of the Compute Cluster this host should
@@ -87,10 +91,6 @@ The following arguments are supported:
 * `cluster_managed` - (Optional) Can be set to `true` if compute cluster
   membership will be managed through the `compute_cluster` resource rather
   than the`host` resource. Conflicts with: `cluster`.
-* `thumbprint` - (Optional) Host's certificate SHA-1 thumbprint. If not set the
-  CA that signed the host's certificate should be trusted. If the CA is not
-  trusted and no thumbprint is set then the operation will fail. See data source
-  [`vsphere_host_thumbprint`][docs-host-thumbprint-data-source].
 * `license` - (Optional) The license key that will be applied to the host.
   The license key is expected to be present in vSphere.
 * `force` - (Optional) If set to `true` then it will force the host to be added,


### PR DESCRIPTION
### Description

Adds validation of the ESXI host thumbprint before adding the host to a cluster or vCenter Server.

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereHost_rootFolder$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	0.900s
```

```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereHost_connection$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	0.907s
```
```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereHost_maintenance$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	0.950s
```

### Release Note

`resource/vsphere_host`: Adds validation of the ESXI host thumbprint before adding the host to a cluster or vCenter Server.

### References

Closes #1549 

