### PR TITLE
docs: `r/vsphere_virtual_machine` updated disks info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ DOCUMENTATION:
 
 - `resource/vsphere_resource_pool`: Updates to include steps to create resource pool on standalone ESXi hosts.
   ([#2264](https://github.com/hashicorp/terraform-provider-vsphere/pull/2264))
+- `resource/vsphere_virtual_machine`: Updates to fix examples of `disk0` to reflect that during import the disk get set back to default like `Hard Disk 1`.
+  [#2272](https://github.com/hashicorp/terraform-provider-vsphere/pull/2272)
 
 ## 2.9.2 (September 16, 2024)
 

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -23,12 +23,12 @@ data "vsphere_datacenter" "datacenter" {
 }
 
 data "vsphere_host_thumbprint" "thumbprint" {
-  address  = "esx-01.example.com"
+  address  = "esxi-01.example.com"
   insecure = true
 }
 
 resource "vsphere_host" "esx-01" {
-  hostname   = "esx-01.example.com"
+  hostname   = "esxi-01.example.com"
   username   = "root"
   password   = "password"
   license    = "00000-00000-00000-00000-00000"
@@ -50,12 +50,12 @@ data "vsphere_compute_cluster" "cluster" {
 }
 
 data "vsphere_host_thumbprint" "thumbprint" {
-  address  = "esx-01.example.com"
+  address  = "esxi-01.example.com"
   insecure = true
 }
 
 resource "vsphere_host" "esx-01" {
-  hostname   = "esx-01.example.com"
+  hostname   = "esxi-01.example.com"
   username   = "root"
   password   = "password"
   license    = "00000-00000-00000-00000-00000"
@@ -143,7 +143,7 @@ data "vsphere_datacenter" "datacenter" {
 }
 
 data "vsphere_host" "host" {
-  name          = "esx-01.example.com"
+  name          = "esxi-01.example.com"
   datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 
@@ -160,12 +160,12 @@ data "vsphere_datacenter" "datacenter" {
 }
 
 data "vsphere_host_thumbprint" "thumbprint" {
-  address = "esx-01.example.com"
+  address = "esxi-01.example.com"
   insecure = true
 }
 
 resource "vsphere_host" "esx-01" {
-  hostname   = "esx-01.example.com"
+  hostname   = "esxi-01.example.com"
   username   = "root"
   password   = "password"
   thumbprint = data.vsphere_host_thumbprint.thumbprint.id
@@ -177,7 +177,7 @@ resource "vsphere_host" "esx-01" {
 
 ```hcl
 resource "vsphere_host" "esx-01" {
-  hostname   = "esx-01.example.com"
+  hostname   = "esxi-01.example.com"
   username   = "root"
   password   = "password"
   license    = "00000-00000-00000-00000-00000"
@@ -198,4 +198,4 @@ All information will be added to the Terraform state after import.
 terraform import vsphere_host.esx-01 host-123
 ```
 
-The above would import the host `esx-01.example.com` with the host ID `host-123`.
+The above would import the host `esxi-01.example.com` with the host ID `host-123`.

--- a/website/docs/r/resource_pool.html.markdown
+++ b/website/docs/r/resource_pool.html.markdown
@@ -84,12 +84,12 @@ data "vsphere_datacenter" "datacenter" {
 }
 
 data "vsphere_host_thumbprint" "thumbprint" {
-  address = "esx-01.example.com"
+  address = "esxi-01.example.com"
   insecure = true
 }
 
 resource "vsphere_host" "esx-01" {
-  hostname = "esx-01.example.com"
+  hostname = "esxi-01.example.com"
   username   = "root"
   password   = "password"
   license    = "00000-00000-00000-00000-00000"

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -104,7 +104,7 @@ resource "vsphere_virtual_machine" "vm" {
     network_id = data.vsphere_network.network.id
   }
   disk {
-    label = "disk0"
+    label = "Hard Disk 1"
     size  = 20
   }
 }
@@ -160,7 +160,7 @@ resource "vsphere_virtual_machine" "vm" {
     adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
   disk {
-    label            = "disk0"
+    label            = "Hard Disk 1"
     size             = data.vsphere_virtual_machine.template.disks.0.size
     thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
   }
@@ -541,7 +541,7 @@ resource "vsphere_virtual_machine" "vm" {
     adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
   disk {
-    name             = "disk0"
+    name             = "Hard Disk 1"
     size             = data.vsphere_virtual_machine.template_from_ovf.disks.0.size
     thin_provisioned = data.vsphere_virtual_machine.template_from_ovf.disks.0.thin_provisioned
   }
@@ -610,7 +610,7 @@ resource "vsphere_virtual_machine" "vm" {
     network_id = data.vsphere_network.network.id
   }
   disk {
-    label = "disk0"
+    label = "Hard Disk 1"
     size  = 20
   }
 }
@@ -862,11 +862,11 @@ The following example demonstrates and abridged multi-disk configuration:
 resource "vsphere_virtual_machine" "vm" {
   # ... other configuration ...
   disk {
-    label       = "disk0"
+    label       = "Hard Disk 1"
     size        = "10"
   }
   disk {
-    label       = "disk1"
+    label       = "Hard Disk 2"
     size        = "100"
     unit_number = 1
   }
@@ -1545,12 +1545,12 @@ resource "vsphere_virtual_machine" "vm" {
   # ... other configuration ...
   datastore_id = data.vsphere_datastore.vm_datastore.id
   disk {
-    label = "disk0"
+    label = "Hard Disk 1"
     size  = 10
   }
   disk {
     datastore_id = data.vsphere_datastore.pinned_datastore.id
-    label        = "disk1"
+    label        = "Hard Disk 2"
     size         = 100
     unit_number  = 1
   }
@@ -1661,7 +1661,9 @@ Many of the requirements for [cloning](#additional-requirements-and-notes-for-cl
 
 The following requirements apply to import:
 
-* The disks must have a [`label`](#label) argument assigned in a convention matching `diskN`, starting with disk number 0, based on each virtual disk order on the SCSI bus. As an example, a disk on SCSI controller `0` with a unit number of `0` would be labeled as `disk0`, a disk on the same controller with a unit number of `1` would be `disk1`, but the next disk, which is on SCSI controller `1` with a unit number of `0`, still becomes `disk2`.
+* The disks must have a [`label`](#label) argument assigned in a convention matching `Hard Disk`, starting with disk number 0, based on each virtual disk order on the SCSI bus. As an example, a disk on SCSI controller `0` with a unit number of `0` would be labeled as `Hard Disk 0`, a disk on the same controller with a unit number of `1` would be `Hard Disk 1`, but the next disk, which is on SCSI controller `1` with a unit number of `0`, still becomes `Hard Disk 2`.
+
+~> **NOTE:** Any custom `label` set at deployment of machine through Terraform, on import will not have the custom `label` and will default to `Hard Disk _x_`.
 
 * Disks are always imported with [`keep_on_remove`](#keep_on_remove) enabled until the first `terraform apply` run which will remove the setting for known disks. This process safeguards against naming or accounting mistakes in the disk configuration.
 


### PR DESCRIPTION
### Description

`resource/vsphere_virtual_machine`: Updates to fix examples of `disk0` to reflect that during import the disk get set back to default like `Hard Disk 1`.

### References

Closes #2199 
