### PR TITLE
feat: add in-cluster datastores in `d/datastore_stats`

### DIFF
--- a/vsphere/data_source_vsphere_datastore_stats.go
+++ b/vsphere/data_source_vsphere_datastore_stats.go
@@ -4,10 +4,12 @@
 package vsphere
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod"
 	"github.com/vmware/govmomi/object"
 )
 
@@ -36,6 +38,7 @@ func dataSourceVSphereDatastoreStats() *schema.Resource {
 }
 
 func dataSourceVSphereDatastoreStatsRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.Background()
 	client := meta.(*Client).vimClient
 	var dc *object.Datacenter
 	if dcID, ok := d.GetOk("datacenter_id"); ok {
@@ -48,6 +51,23 @@ func dataSourceVSphereDatastoreStatsRead(d *schema.ResourceData, meta interface{
 	dss, err := datastore.List(client)
 	if err != nil {
 		return fmt.Errorf("error listing datastores: %s", err)
+	}
+	storagePods, err := storagepod.List(client)
+	if err != nil {
+		return fmt.Errorf("error retrieving storage pods: %s", err)
+	}
+	for s := range storagePods {
+		childDatastores, err := storagePods[s].Children(ctx)
+		if err != nil {
+			return fmt.Errorf("error retrieving datastores in datastore cluster: %s", err)
+		}
+		for c := range childDatastores {
+			ds, err := datastore.FromID(client, childDatastores[c].Reference().Value)
+			if err != nil {
+				return fmt.Errorf("error retrieving datastore: %s", err)
+			}
+			dss = append(dss, ds)
+		}
 	}
 	for i := range dss {
 		ds, err := datastore.FromPath(client, dss[i].Name(), dc)
@@ -66,6 +86,5 @@ func dataSourceVSphereDatastoreStatsRead(d *schema.ResourceData, meta interface{
 		d.Set("free_space", fr)
 	}
 	d.SetId(fmt.Sprintf("%s_stats", dc.Reference().Value))
-
 	return nil
 }

--- a/vsphere/data_source_vsphere_datastore_stats_test.go
+++ b/vsphere/data_source_vsphere_datastore_stats_test.go
@@ -24,10 +24,10 @@ func TestAccDataSourceVSphereDatastoreStats_basic(t *testing.T) {
 				Config: testAccDataSourceVSphereDatastoreStatsConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.vsphere_datastore_stats.datastore_stats", "datacenter_id", os.Getenv("VSPHERE_DATACENTER"),
+						"data.vsphere_datastore_stats.datastore_stats", "datacenter_id", os.Getenv("TF_VAR_VSPHERE_DATACENTER"),
 					),
 					resource.TestCheckResourceAttr(
-						"data.vsphere_datastore_stats.datastore_stats", "id", fmt.Sprintf("%s_stats", os.Getenv("VSPHERE_DATACENTER")),
+						"data.vsphere_datastore_stats.datastore_stats", "id", fmt.Sprintf("%s_stats", os.Getenv("TF_VAR_VSPHERE_DATACENTER")),
 					),
 					testCheckOutputBool("found_free_space", "true"),
 					testCheckOutputBool("found_capacity", "true"),
@@ -40,13 +40,13 @@ func TestAccDataSourceVSphereDatastoreStats_basic(t *testing.T) {
 }
 
 func testAccDataSourceVSphereDatastoreStatsPreCheck(t *testing.T) {
-	if os.Getenv("VSPHERE_DATACENTER") == "" {
+	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
 		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_datastore_stats acceptance tests")
 	}
-	if os.Getenv("VSPHERE_USER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_datastore_stats acceptance tests")
+	if os.Getenv("TF_VAR_VSPHERE_USER") == "" {
+		t.Skip("set TF_VAR_VSPHERE_USER to run vsphere_datastore_stats acceptance tests")
 	}
-	if os.Getenv("VSPHERE_PASSWORD") == "" {
+	if os.Getenv("TF_VAR_VSPHERE_PASSWORD") == "" {
 		t.Skip("set TF_VAR_VSPHERE_PASSWORD to run vsphere_datastore_stats acceptance tests")
 	}
 }
@@ -82,5 +82,5 @@ output "capacity_values_exist" {
 		free >= 1
 	])
 }
-`, os.Getenv("VSPHERE_DATACENTER"))
+`, os.Getenv("TF_VAR_VSPHERE_DATACENTER"))
 }


### PR DESCRIPTION
### Description

With the previous introduction of `d/datastore_stats` only local datastores were included in the output. Now, all datastores are fetched, even those under clusters, by accessing every storage pod object and retrieving all datastores that are set as childs to it.

### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccDataSourceVSphereDatastoreStats_basic"                                                
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceVSphereDatastoreStats_basic -timeout 360m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
=== RUN   TestAccDataSourceVSphereDatastoreStats_basic
--- PASS: TestAccDataSourceVSphereDatastoreStats_basic (45.03s)
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere 30.142s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  (cached) [no tests to run]

```

### Release Note

`data/vsphere_datastore_stats`: Added the ability to return all data stores, both local and under a datastore cluster, in the datastore list.

### Example Usage

main.tf:

```hcl
data "vsphere_datacenter" "dc" {
  name = var.vsphere_dc
}

data "vsphere_datastore_stats" "datastore_stats" {
  datacenter_id = data.vsphere_datacenter.dc.id
}
```

providers.tf:

```hcl
provider "vsphere" {
  user                 = var.vcenter_name
  password             = var.vcenter_password
  vsphere_server       = var.vsphere_server
  allow_unverified_ssl = var.allow_unverified_ssl
}

terraform {
  required_providers {
    vsphere = {
      source  = "localhost/test/vsphere"
      version = "1.0.0"
    }
  }
}
```

outputs.tf:

```hcl
output "max_free_space_name" {
  value = local.max_free_space_name
}

output "max_free_space" {
  value = local.max_free_space
}
```

variables.tf:

```hcl
variable "vcenter_name" {
  description = "Vsphere username"
  type        = string
}

variable "vcenter_password" {
  description = "Password for Vcenter"
  type        = string
  sensitive   = true
}

variable "allow_unverified_ssl" {
  description = "Allow unverified ssl(true or false)"
  type        = bool
  default     = true
}
```

### References

Close #2159 
