### PR TITLE
feat: add datastore information under datastore cluster

### DIFF
--- a/vsphere/data_source_vsphere_datastore_cluster.go
+++ b/vsphere/data_source_vsphere_datastore_cluster.go
@@ -4,9 +4,11 @@
 package vsphere
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore"
 )
 
 func dataSourceVSphereDatastoreCluster() *schema.Resource {
@@ -24,15 +26,39 @@ func dataSourceVSphereDatastoreCluster() *schema.Resource {
 				Optional:    true,
 				Description: "The managed object ID of the datacenter the cluster is located in. Not required if using an absolute path.",
 			},
+			"datastores": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "The names of datastores included in the datastore cluster.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
 
 func dataSourceVSphereDatastoreClusterRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.Background()
+	client := meta.(*Client).vimClient
 	pod, err := resourceVSphereDatastoreClusterGetPodFromPath(meta, d.Get("name").(string), d.Get("datacenter_id").(string))
 	if err != nil {
 		return fmt.Errorf("error loading datastore cluster: %s", err)
 	}
 	d.SetId(pod.Reference().Value)
+	dsNames := []string{}
+	childDatastores, err := pod.Children(ctx)
+	if err != nil {
+		return fmt.Errorf("error retrieving datastores in datastore cluster: %s", err)
+	}
+	for d := range childDatastores {
+		ds, err := datastore.FromID(client, childDatastores[d].Reference().Value)
+		if err != nil {
+			return fmt.Errorf("error retrieving datastore: %s", err)
+		}
+		dsNames = append(dsNames, ds.Name())
+	}
+	err = d.Set("datastores", dsNames)
+	if err != nil {
+		return fmt.Errorf("cannot set datastores: %s", err)
+	}
 	return nil
 }

--- a/website/docs/d/datastore_cluster.html.markdown
+++ b/website/docs/d/datastore_cluster.html.markdown
@@ -45,9 +45,22 @@ The following arguments are supported:
   For default datacenters, use the id attribute from an empty
   `vsphere_datacenter` data source.
 
+
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Attribute Reference
 
-The only exported attribute from this data source is `id`, which represents the
-ID of the datastore cluster.
+The following attributes are exported:
+
+* `id` - The [managed objectID][docs-about-morefs] of the vSphere datastore cluster object.
+
+* `datastores` - (Optional) The names of the datastores included in the specific 
+  cluster.
+
+### Example Usage for `datastores` attribute:
+
+```hcl
+output "datastores" {
+  value = data.vsphere_datastore_cluster.datastore_cluster.datastores
+}
+```


### PR DESCRIPTION
### Description

Currently the datastore cluster object only returns the id of the cluster. There is need to access the children of the cluster ( like supported in the gui under the tab datastores). With this PR we will enable the filtering of datastores based on the cluster object

### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```shell
$ make testacc TESTARGS="-run=TestAccDataSourceVSphereDatastoreCluster_getDatastores"                                                                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceVSphereDatastoreCluster_getDatastores -timeout 360m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
=== RUN   TestAccDataSourceVSphereDatastoreCluster_getDatastores
--- PASS: TestAccDataSourceVSphereDatastoreCluster_getDatastores (18.62s)
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere 18.647s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  (cached) [no tests to run]

...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

`data/datasource_cluster`: Return datastore names under from a datasource cluster.


### Example Usage

main.tf:

```hcl
data "vsphere_datastore_cluster" "datastore_cluster_data" {
  name          = var.vsphere_cluster_name
  datacenter_id = var.vsphere_dc_id
}
```

providers.tf:

```hcl
provider "vsphere" {
  user                 = var.vcenter_name
  password             = var.vcenter_password
  vsphere_server       = var.vsphere_server
  allow_unverified_ssl = var.allow_unverified_ssl
}

terraform {
  required_providers {
    vsphere = {
      source  = "localhost/test/vsphere"
      version = "1.0.0"
    }
  }
}
```

outputs.tf:

```hcl
output "all_ds" {
  value = data.vsphere_datastore_cluster.datastore_cluster_data.datastores
}

```

variables.tf:

```hcl
variable "vsphere_cluster_name" {
  description = "Name of the vSpher cluster."
  type        = string
}

variable "vsphere_dc" {
  description = "Name of the vSpher datacenter you want to deploy the VM to."
  type        = string
}

variable "vsphere_dc_id" {
  description = "ID of the vSpher datacenter you want to deploy the VM to."
  type        = string
}

variable "vcenter_name" {
  description = "vSphere username"
  type        = string
}

variable "vcenter_password" {
  description = "Password for vCenter"
  type        = string
  sensitive   = true
}

variable "allow_unverified_ssl" {
  description = "Allow unverified ssl(true or false)"
  type        = bool
  default     = true
}
```

### References

Closes #2284 
