### PR TITLE
feat: add `virtual_machines` list in `d/datacenter`

### DIFF
--- a/vsphere/data_source_vsphere_datacenter.go
+++ b/vsphere/data_source_vsphere_datacenter.go
@@ -4,9 +4,13 @@
 package vsphere
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25/mo"
 )
 
 func dataSourceVSphereDatacenter() *schema.Resource {
@@ -19,11 +23,18 @@ func dataSourceVSphereDatacenter() *schema.Resource {
 				Description: "The name of the datacenter. This can be a name or path. Can be omitted if there is only one datacenter in your inventory.",
 				Optional:    true,
 			},
+			"virtual_machines": {
+				Type:        schema.TypeSet,
+				Description: "List of all virtual machines included in the vSphere datacenter object.",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
 
 func dataSourceVSphereDatacenterRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.Background()
 	client := meta.(*Client).vimClient
 	datacenter := d.Get("name").(string)
 	dc, err := getDatacenter(client, datacenter)
@@ -32,6 +43,26 @@ func dataSourceVSphereDatacenterRead(d *schema.ResourceData, meta interface{}) e
 	}
 	id := dc.Reference().Value
 	d.SetId(id)
-
+	finder := find.NewFinder(client.Client)
+	finder.SetDatacenter(dc)
+	viewManager := view.NewManager(client.Client)
+	view, err := viewManager.CreateContainerView(ctx, dc.Reference(), []string{"VirtualMachine"}, true)
+	if err != nil {
+		return fmt.Errorf("error fetching datacenter: %s", err)
+	}
+	defer view.Destroy(ctx)
+	var vms []mo.VirtualMachine
+	err = view.Retrieve(ctx, []string{"VirtualMachine"}, []string{"name"}, &vms)
+	if err != nil {
+		return fmt.Errorf("error fetching virtual machines: %s", err)
+	}
+	vmNames := []string{}
+	for v := range vms {
+		vmNames = append(vmNames, vms[v].Name)
+	}
+	err = d.Set("virtual_machines", vmNames)
+	if err != nil {
+		return fmt.Errorf("error setting virtual_machines: %s", err)
+	}
 	return nil
 }

--- a/vsphere/data_source_vsphere_datacenter_test.go
+++ b/vsphere/data_source_vsphere_datacenter_test.go
@@ -66,6 +66,30 @@ func testAccDataSourceVSphereDatacenterPreCheck(t *testing.T) {
 	}
 }
 
+func TestAccDataSourceVSphereDatacenter_getVirtualMachines(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+			testAccDataSourceVSphereDatacenterPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDatacenterConfigGetVirtualMachines(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_datacenter.dc",
+						"id",
+						testAccDataSourceVSphereDatacenterExpectedRegexp,
+					),
+					testCheckOutputBool("found_virtual_machines", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceVSphereDatacenterConfig() string {
 	return fmt.Sprintf(`
 data "vsphere_datacenter" "dc" {
@@ -77,3 +101,15 @@ data "vsphere_datacenter" "dc" {
 const testAccDataSourceVSphereDatacenterConfigDefault = `
 data "vsphere_datacenter" "dc" {}
 `
+
+func testAccDataSourceVSphereDatacenterConfigGetVirtualMachines() string {
+	return fmt.Sprintf(`
+data "vsphere_datacenter" "dc" {
+  name = "%s"
+}
+output "found_virtual_machines" {
+	value = "${length(data.vsphere_datacenter.dc.virtual_machines) >= 1 ? "true" : "false" }"
+}
+`, os.Getenv("TF_VAR_VSPHERE_DATACENTER"),
+	)
+}

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -38,7 +38,9 @@ instance. Hence, the `name` attribute is completely ignored.
 
 ## Attribute Reference
 
-The only exported attribute is `id`, which is the [managed object
-ID][docs-about-morefs] of this datacenter.
+The following attributes are exported:
+
+* `id` - The [managed objectID][docs-about-morefs] of the vSphere datacenter object.
+* `virtual_machines` - List of all virtual machines included in the vSphere datacenter object.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider


### PR DESCRIPTION
* Add a list of virtual machine names under the specified datacenter

### Description

There is a need to have a list of vm names in a datacenter. An example of it could be a number used as suffx for new vms, that depends on the names of the existing. In the GUI there is a tab with VMs in the datacenter view. So in the datasource datacenter a new attribute is added with `virtual_machines`.

### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:


```
$ make testacc TESTARGS="-run=TestAccDataSourceVSphereDatacenter_getVirtualMachines"                                                                                  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceVSphereDatacenter_getVirtualMachines -timeout 360m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow	[no test files]
=== RUN   TestAccDataSourceVSphereDatacenter_getVirtualMachines
2024-10-04T14:36:32.579+0300 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_rpc=Configure tf_req_id=c88486fc-2d4e-724b-cc2d-8c8599420a85 tf_provider_addr=registry.terraform.io/hashicorp/vsphere
2024-10-04T14:36:33.443+0300 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_rpc=Configure tf_req_id=0d8fa8b5-a68e-74d7-8bd3-f773bfc910dc tf_provider_addr=registry.terraform.io/hashicorp/vsphere
2024-10-04T14:36:34.327+0300 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_req_id=ce3a82ae-25bc-1ac4-4b00-acf6000674e2 tf_provider_addr=registry.terraform.io/hashicorp/vsphere tf_rpc=Configure
2024-10-04T14:36:35.156+0300 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_req_id=590ff106-4155-b520-0bf9-7dfbb7c9a95d tf_provider_addr=registry.terraform.io/hashicorp/vsphere tf_rpc=Configure
2024-10-04T14:36:36.042+0300 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_rpc=Configure tf_provider_addr=registry.terraform.io/hashicorp/vsphere tf_req_id=38610c63-6e73-1e4b-9a78-47270a914953
--- PASS: TestAccDataSourceVSphereDatacenter_getVirtualMachines (34.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	34.993s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice	(cached) [no tests to run]


...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):


```release-note
- data/vsphere_datacenter: Fetch the list of virtual machine names for the specified datacenter.

```

### References

-  Closes: #2283 
