### PR TITLE
feat: add support for vtpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,33 @@
 
 FEATURES:
 
-- `data/vsphere_network`: Adds ability to add `filter` to find port groups based on network type of standard virtual port
-  group, distributed virtual port group, or network port group.
+- `data/vsphere_network`: Adds ability to add `filter` to find port groups based on network type of
+  standard virtual port group, distributed virtual port group, or network port group.
   [#2281](https://github.com/hashicorp/terraform-provider-vsphere/pull/2281)
+- `resource/vsphere_virtual_machine`: Adds ability to add a virtual Trusted Platform Module (`vtpm`)
+  to virtual machine on creation or clone.
+  [#2279](https://github.com/hashicorp/terraform-provider-vsphere/pull/2279)
+- `data/vsphere_virtual_machine`: Adds ability read the configuration of a virtual Trusted Platform
+  Module (`vtpm`) on virtual machine; will return `true` or `false` based on the configuration.
+  [#2279](https://github.com/hashicorp/terraform-provider-vsphere/pull/2279)
 
 ## 2.9.3 (October 8, 2024)
 
 BUG FIX:
 
-- `r/vsphere_tag_category`: Updates resource not to `ForceNew` for cardinality. This will allow the `tag_category` to updated.
+- `resource/vsphere_tag_category`: Updates resource not to `ForceNew` for cardinality. This will
+  allow the `tag_category` to updated.
   ([#2263](https://github.com/hashicorp/terraform-provider-vsphere/pull/2263))
-- `r/vsphere_host`: Updates resource to check thumbprint of the ESXI host thumbprint before adding the host to a cluster or vCenter Server.
+- `resource/vsphere_host`: Updates resource to check thumbprint of the ESXI host thumbprint before
+  adding the host to a cluster or vCenter Server.
   ([#2266](https://github.com/hashicorp/terraform-provider-vsphere/pull/2266))
 
 DOCUMENTATION:
 
-- `resource/vsphere_resource_pool`: Updates to include steps to create resource pool on standalone ESXi hosts.
-  ([#2264](https://github.com/hashicorp/terraform-provider-vsphere/pull/2264))
-- `resource/vsphere_virtual_machine`: Updates to fix examples of `disk0` to reflect that during import the disk get set back to default like `Hard Disk 1`.
+- `resource/vsphere_resource_pool`: Updates to include steps to create resource pool on standalone
+  ESXi hosts. ([#2264](https://github.com/hashicorp/terraform-provider-vsphere/pull/2264))
+- `resource/vsphere_virtual_machine`: Updates to fix examples of `disk0` to reflect that during
+  import the disk get set back to default like `Hard Disk 1`.
   [#2272](https://github.com/hashicorp/terraform-provider-vsphere/pull/2272)
 
 ## 2.9.2 (September 16, 2024)
@@ -215,7 +224,7 @@ CHORES:
 
 ## 2.7.0 (March 06, 2024)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fixed support for SR-IOV passthrough virtual machine network adapters.
   ([#2133](https://github.com/terraform-providers/terraform-provider-vsphere/pull/2133))
@@ -264,7 +273,7 @@ CHORES:
 
 ## 2.6.1 (December 11, 2023)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/guest_os_customization`: Fixed incorrect path for `RequiredWith` and `ConflictsWith`
   attribute identifiers for `windows_options`.
@@ -274,7 +283,7 @@ BUG Fixed:
 
 ## 2.6.0 (November 29, 2023)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fixed upload error when deploying an OVF/OVA directly to an ESXi
   host. ([#1813](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1813))
@@ -299,7 +308,7 @@ FEATURES:
 
 ## 2.5.1 (October 12, 2023)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fixed cloning regression on datastore cluster. Restored behavior not to send relocate specs for the virtual disks when it is cloned on datastore cluster with exception when `datastore_id` is explicitly specified for the virtual disk. ([#2037](https://github.com/hashicorp/terraform-provider-vsphere/pull/2037))
 - `resource/vsphere_virtual_disk`: Fixed improper disk type handling forcing disks to be recreated. ([#2033](https://github.com/hashicorp/terraform-provider-vsphere/pull/2033))
@@ -314,7 +323,7 @@ CHORES:
 
 ## 2.5.0 (October 09, 2023)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Removes the validation for `eagerly_scrubbed` and `thin_provision` fields for a disk subresource so that `ignore_changes` Fixed a deployment. ([#2028](https://github.com/hashicorp/terraform-provider-vsphere/pull/2028))
 - `resource/virtual_machine`: Added a differential between the disk properties specified and those existing on the source virtual machine disk, allowing changes to be sent to the API for disk subresource. ([#2028](https://github.com/hashicorp/terraform-provider-vsphere/pull/2028))
@@ -329,7 +338,7 @@ CHORES:
 
 ## 2.4.3 (September 08, 2023)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fixed hardware version conversion. ([#2011](https://github.com/hashicorp/terraform-provider-vsphere/pull/2011))
 
@@ -340,7 +349,7 @@ CHORES:
 
 ## 2.4.2 (August 21, 2023)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fixed hardware version error when cloning and/or configuring a VM/Template. ([#1995](https://github.com/hashicorp/terraform-provider-vsphere/pull/1995))
 - `resource/virtual_machine`: Fixed invalid operation for device '0' when reconfiguring a VM. ([#1996](https://github.com/hashicorp/terraform-provider-vsphere/pull/1996))
@@ -352,7 +361,7 @@ CHORES:
 
 ## 2.4.1 (June 26, 2023)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/compute_cluster`: Added version check for [vSphere 7.0.1 or later](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vsan.doc/GUID-9113BBD6-5428-4287-9F61-C8C3EE51E07E.html) when enabling vSAN HCI Mesh. ([#1931](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1931))
 
@@ -363,7 +372,7 @@ FEATURES:
 - `datasource/virtual_machine`: Added support for lookup by moid. ([#1868](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1868))
 - `resource/vnic`: Added support for services on vmkernel adapter/vnic. ([#1855](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1855))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/nas_datastore`: Fixed issue mounting and/or unmounting NFS datastores when updating `host_system_ids` as a day-two operation. ([#1860](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1860))
 - `resource/virtual_machine_storage_policy`: Updated the `resourceVMStoragePolicyDelete` method to check the response of `pbmClient.DeleteProfile()` API for errors. If a storage policy is in use and cannot be deleted, the destroy operation will fail and the storage policy will remain in the state. ([#1863](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1863))
@@ -383,7 +392,7 @@ CHORES:
 
 **If you are using v2.3.0, please upgrade to this new version as soon as possible.**
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/compute_cluster`: Fixed panic when reading vSAN. ([#1835](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1835))
 - `resource/vsphere_file`: Fixed a provider crash by updating the `createDirectory` method to check if the provided file path has any parent folder(s). If no folders need to be created `FileManager.MakeDirectory` is not invoked. ([#1866](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1866))
@@ -402,7 +411,7 @@ FEATURES:
 - `resource/compute_cluster`: Added support for vSAN Data-in-Transit Encryption. ([#1820](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1820))
 - `resource/role`: Added support for import. ([#1822](https://github.com/terraform-providers/terraform-provider-vsphere/pull/1822))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/datastore_cluster`: Fixed error parsing string as enum type for `sdrs_advanced_options`. [(1749](https://github.com/hashicorp/terraform-provider-vsphere/pull/1749))
 - `provider`: Reverts a linting update from #1416 back to SHA1. SHA1 is used by `vmware/govmomi` for the session file. This will allow session reuse from govc. [(1808](https://github.com/hashicorp/terraform-provider-vsphere/pull/1808))
@@ -424,7 +433,7 @@ CHORES:
 
 ## 2.2.0 (June 16, 2022)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fixed ability to clone and import virtual machine resources with SATA and IDE controllers. ([#1629](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1629))
 - `resource/dvs`: Prevent setting unsupported traffic classes. ([#1633](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1633))
@@ -457,7 +466,7 @@ IMPROVEMENTS:
 
 **If you are using v2.1.0, please upgrade to this new version as soon as possible.**
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/compute_cluster`: Reverts ([#1432](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1432)) switching `vsan_disk_group` back to `TypeList`. Switching from `TypeList` to `TypeSet` is a sore spot when it comes to what is considered a breaking change to provider configuration. Generally we accept that users may use list indices within their config. When this attribute switched to `TypeSet` this caused a breaking change for configurations doing that, as `TypeSet` is indexed by a hash value that Terraform calculates. Furthermore other code around type assertions was not changed and this attribute actually crashed the provider in `v2.1.0`, we will address the now re-opened ([#1205](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1205)) in `v3.0.0` of the provider. ([#1615](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1615))
 
@@ -467,7 +476,7 @@ FEATURES:
 
 ## 2.1.0 (February 28, 2022)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/compute_cluster`: Updated `ha_datastore_apd_response_delay` to the API default (180) for `vmTerminateDelayForAPDSec`. Previously set to 3 (minutes) however the codebase uses this value as seconds. Users who had the field left blank may see a warning about the state value drifting from 3 to 180, after applying this should go away. ([#1542](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1542))
 - `resource/virtual_machine`: Don't read `storage_policy_id` if vCenter is not configured. This is not a scenario we test or support explicitly ([#1408](https://github.com/terraform-providers/terraform-provider-vsphere/issues/1408))
@@ -512,7 +521,7 @@ IMPROVEMENTS:
 
 ## 2.0.2 (June 25, 2021)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fix logic bug that caused the provider to set unsupported fields when talking to vSphere 6.5. ([1430](https://github.com/hashicorp/terraform-provide-vsphere/pull/1430))
 - `resource/virtual_machine`: Fix resource diff bug where it was not possible to ignore changes to `cdrom` subresource. ([1433](https://github.com/hashicorp/terraform-provide-vsphere/pull/1433))
@@ -523,7 +532,7 @@ IMPROVEMENTS:
 
 ## 2.0.1 (June 09, 2021)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Only set vvtd/vbs if vSphere version is newer than 6.5. ([1423](https://github.com/hashicorp/terraform-provider-vsphere/pull/1423))
 
@@ -534,7 +543,7 @@ BREAKING CHANGES:
 - `provider`: Moving forward this provider will only work with Terraform version v0.12 and later.
 - `resource/virtual_machine`: [Deprecated attribute `name`](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md#130-january-26-2018) has been removed from the `disk` subresource.
 
-BUG Fixed:
+BUG FIX:
 
 - `datasource/ovf_datasource`: Fix validation error when importing OVF spec. ([1398](https://github.com/hashicorp/terraform-provider-vsphere/pull/1398))
 - `resource/virtual_machine`: Fix post-import VM regression. ([1361](https://github.com/hashicorp/terraform-provider-vsphere/pull/1361))
@@ -553,7 +562,7 @@ IMPROVEMENTS:
 
 ## 1.26.0 (April 20, 2021)
 
-BUG Fixed:
+BUG FIX:
 
 - Minor Fixed of issues that came up during testing against vSphere 7.0
 - Change the way we set the timeout for maintenance mode ([#1392](https://github.com/hashicorp/terraform-provider-vsphere/pull/1392))
@@ -565,7 +574,7 @@ IMPROVEMENTS:
 
 ## 1.25.0 (March 17, 2021)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_entity_permissions`: Sorting permission objects on user name/group name before storing. ([#1311](https://github.com/hashicorp/terraform-provider-vsphere/pull/1311))
 - `resource/virtual_machine`: Limit netmask length for ipv4 and ipv6 netmask. ([#1321](https://github.com/hashicorp/terraform-provider-vsphere/pull/1321))
@@ -582,14 +591,14 @@ IMPROVEMENTS:
 
 ## 1.24.3 (December 14, 2020)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Support for no disks in config ([#1241](https://github.com/hashicorp/terraform-provider-vsphere/pull/1241))
 - `resource/virtual_machine`: Make API timeout configurable when building VMs ([#1278](https://github.com/hashicorp/terraform-provider-vsphere/pull/1278))
 
 ## 1.24.2 (October 16, 2020)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Prevent `guest_id`` nil condition. ([#1234](https://github.com/hashicorp/terraform-provider-vsphere/pull/1234))
 
@@ -604,7 +613,7 @@ IMPROVEMENTS:
 - `resource/virtual_machine`: Allow more config options to be changed from OVF. ([#1218](https://github.com/hashicorp/terraform-provider-vsphere/pull/1218))
 - `resource/virtual_machine`: Convert folder path to MOID. ([#1207](https://github.com/hashicorp/terraform-provider-vsphere/pull/1207))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/datastore_cluster`: Fix missing field in import. ([#1203](https://github.com/hashicorp/terraform-provider-vsphere/pull/1203))
 - `resource/virtual_machine`: Change default OS method on bare VMs. ([#1217](https://github.com/hashicorp/terraform-provider-vsphere/pull/1217))
@@ -612,7 +621,7 @@ BUG Fixed:
 
 ## 1.24.0 (September 02, 2020)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Skip SCSI controller check when empty. ([#1179](https://github.com/hashicorp/terraform-provider-vsphere/pull/1179))
 - `resource/virtual_machine`: Make storage_policy_id computed to prevent flapping when unset. ([#1185](https://github.com/hashicorp/terraform-provider-vsphere/pull/1185))
@@ -630,7 +639,7 @@ IMPROVEMENTS:
 
 ## 1.23.0 (August 21, 2020)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vnic`: Fix missing fields on vnic import. ([#1162](https://github.com/hashicorp/terraform-provider-vsphere/pull/1162))
 - `resource/virtual_machine`: Ignore thin_provisioned and eagerly_scrub during DiskPostCloneOperation. ([#1161](https://github.com/hashicorp/terraform-provider-vsphere/pull/1161))
@@ -652,7 +661,7 @@ FEATURES:
 
 ## 1.21.1 (July 20, 2020)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Set guest_id before customization. ([#1139](https://github.com/hashicorp/terraform-provider-vsphere/pull/1139))
 
@@ -668,7 +677,7 @@ FEATURES:
 
 - `resource/virtual_machine`: Add support for OVA deployment. ([#1105](https://github.com/hashicorp/terraform-provider-vsphere/pull/1105))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Delete disks on destroy when deployed from OVA/OVF. ([#1106](https://github.com/hashicorp/terraform-provider-vsphere/pull/1106))
 - `resource/virtual_machine`: Skip PCI passthrough operations if there are no changes. ([#1112](https://github.com/hashicorp/terraform-provider-vsphere/pull/1112))
@@ -707,7 +716,7 @@ IMPROVEMENTS:
 
 ## 1.18.1 (May 12, 2020)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Skip unexpected NIC entries. ([#1067](https://github.com/hashicorp/terraform-provider-vsphere/pull/1067))
 - Respect `session_persistence` for REST sessions. ([#1077](https://github.com/hashicorp/terraform-provider-vsphere/pull/1077))
@@ -726,7 +735,7 @@ IMPROVEMENTS:
 - `resource/virtual_machine`: Mark `product_key` as sensitive. ([#1045](https://github.com/hashicorp/terraform-provider-vsphere/pull/1045))
 - `resource/virtual_machine`: Increase max `hardware_version` for vSphere v7.0. ([#1056](https://github.com/hashicorp/terraform-provider-vsphere/pull/1056))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fix to disk bus sorting. ([#1039](https://github.com/hashicorp/terraform-provider-vsphere/pull/1039))
 - `resource/virtual_machine`: Only include `hardware_version` in CreateSpecs. ([#1055](https://github.com/hashicorp/terraform-provider-vsphere/pull/1055))
@@ -743,7 +752,7 @@ IMPROVEMENTS:
 
 - `resource/virtual_disk`: Support VMDK files. ([#987](https://github.com/hashicorp/terraform-provider-vsphere/pull/987))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fix disk controller sorting. ([#1032](https://github.com/hashicorp/terraform-provider-vsphere/pull/1032))
 
@@ -756,7 +765,7 @@ IMPROVEMENTS:
 - `datasource/vsphere_network`: Handle cases of network port groups with same name
   using `distributed_virtual_switch_uuid`. ([#1001](https://github.com/hashicorp/terraform-provider-vsphere/pull/1001))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Fix working with orphaned devices. ([#1005](https://github.com/hashicorp/terraform-provider-vsphere/pull/1005))
 - `resource/virtual_machine`: Ignore `guest_id` with content library. ([#1014](https://github.com/hashicorp/terraform-provider-vsphere/pull/1014))
@@ -784,7 +793,7 @@ IMPROVEMENTS:
 
 ## 1.16.1 (February 06, 2020)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Set `storage_policy_id` based off of VM rather
   than template. ([#970](https://github.com/hashicorp/terraform-provider-vsphere/pull/970))
@@ -806,7 +815,7 @@ IMPROVEMENTS:
 
 - `resource/virtual_machine`: Do not throw error when disk path is not known yet. ([#944](https://github.com/hashicorp/terraform-provider-vsphere/pull/944))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Do not set `datastoreID` in `RelocateSpec` when `datastore_cluster`` is set. ([#933](https://github.com/hashicorp/terraform-provider-vsphere/pull/933))
 - `resource/vapp_container`: Fix handling of child vApp containers. ([#941](https://github.com/hashicorp/terraform-provider-vsphere/pull/941))
@@ -824,7 +833,7 @@ FEATURES:
 
 - **New Resource:** `vsphere_vnic` ([#876](https://github.com/hashicorp/terraform-provider-vsphere/pull/876))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Allow blank networkID in order to support cloning
   into clusters that do not include the source network. ([#787](https://github.com/hashicorp/terraform-provider-vsphere/pull/787))
@@ -847,7 +856,7 @@ FEATURES:
 
 - **New Resource:** `vsphere_host` ([#836](https://github.com/hashicorp/terraform-provider-vsphere/pull/836))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Change the way we detect if a VM is in a vApp. ([#825](https://github.com/hashicorp/terraform-provider-vsphere/pull/825))
 - Delete tags and tag_categories when they are removed. ([#801](https://github.com/hashicorp/terraform-provider-vsphere/pull/801))
@@ -859,7 +868,7 @@ IMPROVEMENTS:
 - `resource/virtual_machine`: Allow cloning of powered on virtual machines. ([#785](https://github.com/hashicorp/terraform-provider-vsphere/pull/785))
 - Add keep alive timer for VIM sessions. ([#792](https://github.com/hashicorp/terraform-provider-vsphere/pull/792))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Ignore validation when interpolation is not
   available. ([#784](https://github.com/hashicorp/terraform-provider-vsphere/pull/784))
@@ -894,7 +903,7 @@ IMPROVEMENTS:
 - `resource/virtual_machine`: Add support for using guest.ipAddress for older
   versions of VM Tools. ([#684](https://github.com/hashicorp/terraform-provider-vsphere/issues/684))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Do not set optional `ignored_guest_ips` on read ([#726](https://github.com/hashicorp/terraform-provider-vsphere/pull/726))
 
@@ -907,7 +916,7 @@ IMPROVEMENTS:
 - `resource/virtual_machine`: Unlock `memory_reservation` from maximum when
   `memory_reservation` is not equal to `memory`. ([#680](https://github.com/hashicorp/terraform-provider-vsphere/issues/680))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Return zero instead of nil for memory allocation
   and reservation values ([#655](https://github.com/hashicorp/terraform-provider-vsphere/issues/655))
@@ -926,7 +935,7 @@ IMPROVEMENTS:
 
 - `resource/virtual_disk`: Update existing and add additional tests ([#635](https://github.com/hashicorp/terraform-provider-vsphere/issues/635))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_disk`: Ignore "already exists" errors when creating
   directories on vSAN. ([#639](https://github.com/hashicorp/terraform-provider-vsphere/issues/639))
@@ -947,7 +956,7 @@ FEATURES:
 
 - **New Data Source:** `vsphere_vapp_container` ([#610](https://github.com/hashicorp/terraform-provider-vsphere/issues/610))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/virtual_machine`: Only relocate after create if `host_system_id` is
   set and does not match host the VM currently resides on. ([#609](https://github.com/hashicorp/terraform-provider-vsphere/issues/609))
@@ -975,7 +984,7 @@ IMPROVEMENTS:
 - `resource/vsphere_virtual_machine`: Check if relocation is necessary after
   creation. ([#583](https://github.com/hashicorp/terraform-provider-vsphere/issues/583))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: The resource no longer attempts to set
   ResourceAllocation on virtual ethernet cards when the vSphere version is under 6.0. ([#579](https://github.com/hashicorp/terraform-provider-vsphere/issues/579))
@@ -997,7 +1006,7 @@ IMPROVEMENTS:
   cluster's root resource pool in the event the host is a member of a cluster.
   ([#535](https://github.com/hashicorp/terraform-provider-vsphere/issues/535))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Scenarios that force a new resource will
   no longer create diff mismatches when external disks are attached with the
@@ -1038,7 +1047,7 @@ IMPROVEMENTS:
   network waiter waits on an address that matches the virtual machine's
   configured default gateway. ([#470](https://github.com/hashicorp/terraform-provider-vsphere/issues/470))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: The resource now correctly blocks `clone`
   workflows on direct ESXi connections, where cloning is not supported. ([#476](https://github.com/hashicorp/terraform-provider-vsphere/issues/476))
@@ -1107,7 +1116,7 @@ IMPROVEMENTS:
   to the resource, exporting the managed object ID of the virtual machine.
   ([#390](https://github.com/hashicorp/terraform-provider-vsphere/issues/390))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Fixed a crash scenario that can happen
   when a virtual machine is deployed to a cluster that does not have any hosts,
@@ -1120,7 +1129,7 @@ BUG Fixed:
 
 ## 1.3.2 (February 07, 2018)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Changed the update implemented in ([#377](https://github.com/hashicorp/terraform-provider-vsphere/issues/377))
   to use a local filter implementation. This corrects situations where virtual
@@ -1131,7 +1140,7 @@ BUG Fixed:
 
 ## 1.3.1 (February 01, 2018)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Looking up templates by their UUID now
   functions correctly for vSphere 6.0 and earlier. ([#377](https://github.com/hashicorp/terraform-provider-vsphere/issues/377))
@@ -1204,7 +1213,7 @@ IMPROVEMENTS:
   `name` coming from a value that is still unavailable at plan time (such as a
   computed value from a resource). ([#329](https://github.com/hashicorp/terraform-provider-vsphere/issues/329))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Fixed an issue that was causing crashes
   when working with virtual machines or templates when no network interface was
@@ -1290,7 +1299,7 @@ For a more complete example, see the [cloning and customization
 example](https://www.terraform.io/docs/providers/vsphere/r/virtual_machine.html#cloning-and-customization-example)
 in the documentation.
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Fixed a bug with NIC device assignment
   logic that was causing a crash when adding more than 3 NICs to a VM. ([#280](https://github.com/hashicorp/terraform-provider-vsphere/issues/280))
@@ -1302,14 +1311,14 @@ BUG Fixed:
 
 ## 1.0.3 (December 06, 2017)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Fixed an issue in the post-clone process
   when a CDROM device exists in configuration. ([#276](https://github.com/hashicorp/terraform-provider-vsphere/issues/276))
 
 ## 1.0.2 (December 05, 2017)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Fixed issues related to correct processing
   VM templates with no network interfaces, or fewer network interfaces than the
@@ -1320,7 +1329,7 @@ BUG Fixed:
 
 ## 1.0.1 (December 02, 2017)
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Corrected an issue that was preventing the
   use of this resource on standalone ESXi. ([#263](https://github.com/hashicorp/terraform-provider-vsphere/issues/263))
@@ -1366,7 +1375,7 @@ IMPROVEMENTS:
 - `resource/vsphere_virtual_machine`: Several other minor improvements, see
   documentation for more details. ([#244](https://github.com/hashicorp/terraform-provider-vsphere/issues/244))
 
-BUG Fixed:
+BUG FIX:
 
 - `resource/vsphere_virtual_machine`: Several long-standing issues have been fixed,
   namely surrounding virtual disk and network device management. ([#244](https://github.com/hashicorp/terraform-provider-vsphere/issues/244))
@@ -1398,7 +1407,7 @@ IMPROVEMENTS:
   and more interface types will follow in later versions of the provider.
   ([#193](https://github.com/hashicorp/terraform-provider-vsphere/issues/193))
 
-BUG Fixed:
+BUG FIX:
 
 - resource/vsphere_virtual_machine: Fixed a regression with network discovery
   that was causing Terraform to crash while the VM was in a powered off state.
@@ -1409,7 +1418,7 @@ BUG Fixed:
 
 ## 0.4.1 (October 02, 2017)
 
-BUG Fixed:
+BUG FIX:
 
 - resource/vsphere_folder: Migration of state from a version of this resource
   before v0.4.0 now works correctly. ([#187](https://github.com/hashicorp/terraform-provider-vsphere/issues/187))
@@ -1446,7 +1455,7 @@ IMPROVEMENTS:
 - resource/vsphere_virtual_machine: Adjusted the customization timeout to 10
   minutes ([#168](https://github.com/hashicorp/terraform-provider-vsphere/issues/168))
 
-BUG Fixed:
+BUG FIX:
 
 - resource/vsphere_virtual_machine: This resource can now be used with networks
   with unescaped slashes in its network name. ([#181](https://github.com/hashicorp/terraform-provider-vsphere/issues/181))
@@ -1477,7 +1486,7 @@ IMPROVEMENTS:
   Terraform will trigger a diff if the VM is powered off or suspended, and power
   it back on during the next apply. ([#152](https://github.com/hashicorp/terraform-provider-vsphere/issues/152))
 
-BUG Fixed:
+BUG FIX:
 
 - resource/vsphere_virtual_machine: Fixed customization behavior to watch
   customization events for success, rather than returning immediately when the
@@ -1506,7 +1515,7 @@ IMPROVEMENTS:
 
 - resource/vsphere_virtual_machine: Allow customization of hostname ([#79](https://github.com/hashicorp/terraform-provider-vsphere/issues/79))
 
-BUG Fixed:
+BUG FIX:
 
 - resource/vsphere_virtual_machine: Fix IPv4 address mapping issues causing
   spurious diffs, in addition to IPv6 normalization issues that can lead to spurious
@@ -1528,7 +1537,7 @@ IMPROVEMENTS:
 
 - resource/vsphere_virtual_machine: Add annotation argument ([#111](https://github.com/hashicorp/terraform-provider-vsphere/issues/111))
 
-BUG Fixed:
+BUG FIX:
 
 - Updated [govmomi](https://github.com/vmware/govmomi) to v0.15.0 ([#114](https://github.com/hashicorp/terraform-provider-vsphere/issues/114))
 - Updated network interface discovery behavior in refresh. [[#129](https://github.com/hashicorp/terraform-provider-vsphere/issues/129)]. This Fixed

--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -165,6 +165,11 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 			Computed:    true,
 			Description: "Instance UUID of this virtual machine.",
 		},
+		"vtpm": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether a virtual Trusted Platform Module (TPM) device is present on the virtual machine.",
+		},
 	}
 
 	// Merge the VirtualMachineConfig structure so that we can include the number of
@@ -283,6 +288,16 @@ func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("error setting guest IP addresses: %s", err)
 		}
 	}
+
+	var isVTPMPresent bool
+	for _, dev := range props.Config.Hardware.Device {
+		if _, ok := dev.(*types.VirtualTPM); ok {
+			isVTPMPresent = true
+			break
+		}
+	}
+	_ = d.Set("vtpm_present", isVTPMPresent)
+
 	log.Printf("[DEBUG] VM search for %q completed successfully (UUID %q)", name, props.Config.Uuid)
 	return nil
 }

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -159,6 +159,7 @@ The following attributes are exported:
   the VM is powered off, this value will be blank.
 * `guest_ip_addresses` - A list of IP addresses as reported by VMware Tools.
 * `instance_uuid` - The instance UUID of the virtual machine or template.
+* `vtpm` - Indicates whether a virtual Trusted Platform Module (TPM) device is present on the virtual machine.
 
 ~> **NOTE:** Keep in mind when using the results of `scsi_type` and
 `network_interface_types`, that the `vsphere_virtual_machine` resource only

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1518,6 +1518,24 @@ When cloning from a template, there are additional requirements in both the reso
 
 You can use the [`vsphere_virtual_machine`][tf-vsphere-virtual-machine-ds] data source, which provides disk attributes, network interface types, SCSI bus types, and the guest ID of the source template, to return this information. See the section on [cloning and customization](#cloning-and-customization) for more information.
 
+## Trusted Platform Module
+
+When creating a virtual machine or cloning one from a template, you have the option to add a virtual Trusted Platform Module device. Refer to the requirements in the VMware vSphere [product documentation](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-6F811A7A-D58B-47B4-84B4-73391D55C268.html).
+
+**Example**:
+
+```hcl
+resource "vsphere_virtual_machine" "vm" {
+  # ... other configuration ...
+   vtpm {
+    version = "2.0"
+  }
+  # ... other configuration ...
+}
+```
+
+~> **NOTE:** Supported versions include 1.2 or 2.0.
+
 ## Virtual Machine Migration
 
 The `vsphere_virtual_machine` resource supports live migration both on the host and storage level. You can migrate the virtual machine to another host, cluster, resource pool, or datastore. You can also migrate or pin a virtual disk to a specific datastore.
@@ -1602,6 +1620,7 @@ The virtual machine will be rebooted if any of the following parameters are chan
 * `tools_upgrade_policy`
 * `vbs_enabled`
 * `vvtd_enabled`
+* `vtpm`
 
 ## Attribute Reference
 


### PR DESCRIPTION

### Description
Added Support for vTPM on creation and clone of virtual machine.
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereVirtualMachine_basic$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	1.076s
```
```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereVirtualMachine_hardwareVersionBare$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	0.981s
```
```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereVirtualMachine_addDevices$ github.com/hashicorp/terraform-provider-vsphere/vsphere

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	0.983s
```
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References
Closes #1599 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
