### PR TITLE
feat: d/vsphere_network add support for network_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
+## 2.10.0 (Not Released)
+
+FEATURES:
+
+- `data/vsphere_network`: Adds ability to add `filter` to find port groups based on network type of standard virtual port
+  group, distributed virtual port group, or network port group.
+  [#2281](https://github.com/hashicorp/terraform-provider-vsphere/pull/2281)
+
 ## 2.9.3 (October 8, 2024)
 
 BUG FIX:

--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -29,6 +29,23 @@ data "vsphere_network" "network" {
 }
 ```
 
+## Example Usage
+
+```hcl
+
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_network" "my_port_group" {
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+  name          = "VM Network"
+  filter {
+     network_type = "Network"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -43,7 +60,8 @@ The following arguments are supported:
   network objects, the ID of the distributed virtual switch for which the port
   group belongs. It is useful to differentiate port groups with same name using
   the distributed virtual switch ID.
-
+* `filter` - (Optional) Apply a filter for the discovered network.
+  * `network_type`: This is required if you have multiple port groups with the same name. This will be one of `DistributedVirtualPortgroup` for distributed port groups, `Network` for standard (host-based) port groups, or `OpaqueNetwork` for networks managed externally, such as those managed by NSX.
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Attribute Reference


### PR DESCRIPTION

### Description
Added the feature to allow for port group to be found if there are two port groups with the same name but one is standard virtual port group vs distributed virtual port group.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccDataSourceVSphereNetwork_hostPortgroups$ github.com/hashicorp/terraform-provider-vsphere/vsphere
```

ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	0.847s
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References
Closes #1143
Closes #1410 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
