### PR TITLE
Fix typo in virtual_machine.html.markdown

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -854,7 +854,7 @@ Virtual disks are managed by adding one or more instance of the `disk` block.
 
 At a minimum, both the `label` and `size` attributes must be provided.  The `unit_number` is required for any disk other than the first, and there must be at least one resource with the implicit number of `0`.
 
-The following example demonstrates and abridged multi-disk configuration:
+The following example demonstrates an abridged multi-disk configuration:
 
 **Example**:
 


### PR DESCRIPTION
### Description

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix typo in disk arguments section of `vsphere_virtual_machine` resource docs.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
