### PR TITLE
fix: add 8.0.3 to dvsVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## .Next (Not Released)
 
+IMPROVEMENTS:
+
+- `resource/distributed_virtual_switch`: Added support for vSphere distributed switch version `8.0.3` in vSphere 8.0 U3. [(2306](https://github.com/hashicorp/terraform-provider-vsphere/pull/2306))
+
 CHORE:
 
 - `provider`: Updated `golang/go` to v1.22.8.

--- a/vsphere/distributed_virtual_switch_helper.go
+++ b/vsphere/distributed_virtual_switch_helper.go
@@ -27,6 +27,7 @@ var dvsVersions = []string{
 	"7.0.2",
 	"7.0.3",
 	"8.0.0",
+	"8.0.3",
 }
 
 // dvsFromUUID gets a DVS object from its UUID.

--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -756,7 +756,7 @@ func schemaDVSCreateSpec() map[string]*schema.Schema {
 		"version": {
 			Type:         schema.TypeString,
 			Computed:     true,
-			Description:  "The version of this virtual switch. Allowed versions are 8.0.0, 7.0.3, 7.0.2, 7.0.0, 6.6.0, 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
+			Description:  "The version of this virtual switch. Allowed versions are 8.0.3, 8.0.0, 7.0.3, 7.0.2, 7.0.0, 6.6.0, 6.5.0, 6.0.0, 5.5.0, 5.1.0, and 5.0.0.",
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice(dvsVersions, false),
 		},


### PR DESCRIPTION
### Description

Adds 8.0.3 to the allowed `dvsVersions` to support vSphere 8.0 U3.

