### PR TITLE
feat: add support for ntp servers to r/vsphere_supervisor

### DIFF
--- a/vsphere/resource_vsphere_supervisor.go
+++ b/vsphere/resource_vsphere_supervisor.go
@@ -69,7 +69,7 @@ func resourceVsphereSupervisor() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-			},				
+			},
 			"worker_dns": {
 				Type:        schema.TypeList,
 				Required:    true,
@@ -77,7 +77,7 @@ func resourceVsphereSupervisor() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-			},					
+			},
 			"edge_cluster": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -348,7 +348,6 @@ func buildClusterEnableSpec(d *schema.ResourceData) *namespace.EnableClusterSpec
 	dnsSearchDomains := d.Get("search_domains").([]interface{})
 	storagePolicy := d.Get("storage_policy").(string)
 	serviceCidrs := d.Get("service_cidr").([]interface{})
-	
 
 	spec := &namespace.EnableClusterSpec{
 		EphemeralStoragePolicy: storagePolicy,
@@ -362,8 +361,8 @@ func buildClusterEnableSpec(d *schema.ResourceData) *namespace.EnableClusterSpec
 		NcpClusterNetworkSpec:                  &ncpNetworkSpec,
 		MasterDNS:                              structure.SliceInterfacesToStrings(mainDns),
 		WorkerDNS:                              structure.SliceInterfacesToStrings(workerDns),
-		MasterNTPServers:						structure.SliceInterfacesToStrings(mainNtp),
-		WorkloadNTPServers:						structure.SliceInterfacesToStrings(workerNtp),
+		MasterNTPServers:                       structure.SliceInterfacesToStrings(mainNtp),
+		WorkloadNTPServers:                     structure.SliceInterfacesToStrings(workerNtp),
 		DefaultKubernetesServiceContentLibrary: contentLib,
 		MasterDNSSearchDomains:                 structure.SliceInterfacesToStrings(dnsSearchDomains),
 	}

--- a/vsphere/resource_vsphere_supervisor.go
+++ b/vsphere/resource_vsphere_supervisor.go
@@ -54,6 +54,22 @@ func resourceVsphereSupervisor() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"main_ntp": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "List of NTP servers to use on the Kubernetes API server.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"worker_ntp": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "List of NTP servers to use on the worker nodes.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},				
 			"worker_dns": {
 				Type:        schema.TypeList,
 				Required:    true,
@@ -61,7 +77,7 @@ func resourceVsphereSupervisor() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-			},
+			},					
 			"edge_cluster": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -327,9 +343,12 @@ func buildClusterEnableSpec(d *schema.ResourceData) *namespace.EnableClusterSpec
 	contentLib := d.Get("content_library").(string)
 	mainDns := d.Get("main_dns").([]interface{})
 	workerDns := d.Get("worker_dns").([]interface{})
+	mainNtp := d.Get("main_ntp").([]interface{})
+	workerNtp := d.Get("worker_ntp").([]interface{})
 	dnsSearchDomains := d.Get("search_domains").([]interface{})
 	storagePolicy := d.Get("storage_policy").(string)
 	serviceCidrs := d.Get("service_cidr").([]interface{})
+	
 
 	spec := &namespace.EnableClusterSpec{
 		EphemeralStoragePolicy: storagePolicy,
@@ -343,6 +362,8 @@ func buildClusterEnableSpec(d *schema.ResourceData) *namespace.EnableClusterSpec
 		NcpClusterNetworkSpec:                  &ncpNetworkSpec,
 		MasterDNS:                              structure.SliceInterfacesToStrings(mainDns),
 		WorkerDNS:                              structure.SliceInterfacesToStrings(workerDns),
+		MasterNTPServers:						structure.SliceInterfacesToStrings(mainNtp),
+		WorkloadNTPServers:						structure.SliceInterfacesToStrings(workerNtp),
 		DefaultKubernetesServiceContentLibrary: contentLib,
 		MasterDNSSearchDomains:                 structure.SliceInterfacesToStrings(dnsSearchDomains),
 	}

--- a/website/docs/r/supervisor.html.markdown
+++ b/website/docs/r/supervisor.html.markdown
@@ -83,6 +83,8 @@ resource "vsphere_supervisor" "supervisor" {
 * `content_library` - The identifier of the subscribed content library.
 * `main_dns` - The list of addresses of the primary DNS servers.
 * `worker_dns` - The list of addresses of the DNS servers to use for the worker nodes.
+* `main_ntp` - The list of addresses of the primary NTP servers.
+* `worker_ntp` - The list of addresses of the NTP servers to use for the worker nodes.
 * `edge_cluster` - The identifier of the NSX Edge Cluster.
 * `dvs_uuid` - The UUID of the distributed switch.
 * `sizing_hint` - The size of the Kubernetes API server.


### PR DESCRIPTION
### Description

Adds support for ntp_main and ntp_workers to the vsphere supervisor, 
the supervisor would not be able to create clusters without it.

They were already supported by govmomi so it was a simple change.

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
me@mymachine terraform-provider-vsphere % make testacc TESTARGS='-run=TestAccResourceVSphereSupervisor_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccResourceVSphereSupervisor_basic -timeout 360m
?   	github.com/hashicorp/terraform-provider-vsphere	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider	[no test files]
=== RUN   TestAccResourceVSphereSupervisor_basic
    provider_test.go:46: TF_VAR_STORAGE_POLICY must be set for this acceptance test
--- SKIP: TestAccResourceVSphereSupervisor_basic (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere	(cached)
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient	[no test files]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice	(cached) [no tests to run]
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```release-note
Added support for ntp servers to r/vsphere_supervisor
```

### References

No
