### PR TITLE
chore(deps): bump github.com/vmware/govmomi from 0.46.1 to 0.46.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/vmware/govmomi v0.46.1
+	github.com/vmware/govmomi v0.46.2
 )
 
 require (


### PR DESCRIPTION
### Description

Iam aware that dependabot has already tried to merge this change a while ago and the minor version was skipped, and that 47.1 is in the pipeline but it has breaking changes that need to be respected so it may take a while. 

In the meantime 46.2 fixes a critical bug that makes it impossible to create a r/vsphere_computer_cluster with disk_groups, i have put the issue into references.

I cannot re open the pull request so here it is again.

### References

https://github.com/vmware/govmomi/issues/3615
