### PR TITLE
feat: support retry in `d/vsphere_network`

### DIFF
--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
   the distributed virtual switch ID.
 * `filter` - (Optional) Apply a filter for the discovered network.
   * `network_type`: This is required if you have multiple port groups with the same name. This will be one of `DistributedVirtualPortgroup` for distributed port groups, `Network` for standard (host-based) port groups, or `OpaqueNetwork` for networks managed externally, such as those managed by NSX.
+* `retry_timeout` - (Optional) The timeout duration in seconds for the data source to retry read operations.
+* `retry_interval` - (Optional) The interval in milliseconds to retry the read operation if `retry_timeout` is set. Default: 500.
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

When nsxt and vsphere configurations are applied in one go, we need a way to wait for nsxt network to be realized on VC, otherwise network data source will fail.

This change adds two parameters to network data source - `retry_timeout` and `retry_interval`. If `retry_timeout` is unset, there would be no change to the data source behavior. Otherwise data source will retry according to the specified parameters. Retry will only occur for `NotFound` error.


### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceVSphereNetwork_'

=== RUN   TestAccDataSourceVSphereNetwork_dvsPortgroup
--- PASS: TestAccDataSourceVSphereNetwork_dvsPortgroup (106.63s)
=== RUN   TestAccDataSourceVSphereNetwork_withTimeout
--- PASS: TestAccDataSourceVSphereNetwork_withTimeout (103.90s)
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`d/vsphere_network`: add `retry_timeout` and `retry_interval` attributes that enable retry if network is not found
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
