### PR TITLE
fix: delete datastore

### DIFF
--- a/vsphere/internal/helper/provider/provider_helper.go
+++ b/vsphere/internal/helper/provider/provider_helper.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultAPITimeout is a default timeout value that is passed to functions
 // requiring contexts, and other various waiters.
-const DefaultAPITimeout = time.Minute * time.Duration(5)
+const DefaultAPITimeout = time.Minute * 5
 
 func Error(id string, function string, err error) error {
 	return fmt.Errorf("%s: RESOURCE (%s), ACTION (%s)", err, id, function)

--- a/vsphere/internal/helper/provider/provider_helper.go
+++ b/vsphere/internal/helper/provider/provider_helper.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultAPITimeout is a default timeout value that is passed to functions
 // requiring contexts, and other various waiters.
-const DefaultAPITimeout = time.Minute * 5
+const DefaultAPITimeout = time.Minute * time.Duration(5)
 
 func Error(id string, function string, err error) error {
 	return fmt.Errorf("%s: RESOURCE (%s), ACTION (%s)", err, id, function)

--- a/vsphere/resource_vsphere_vmfs_datastore.go
+++ b/vsphere/resource_vsphere_vmfs_datastore.go
@@ -378,7 +378,7 @@ func resourceVSphereVmfsDatastoreDelete(d *schema.ResourceData, meta interface{}
 		Pending:    []string{retryDeletePending},
 		Target:     []string{retryDeleteCompleted},
 		Refresh:    deleteRetryFunc,
-		Timeout:    30 * time.Second,
+		Timeout:    defaultAPITimeout,
 		MinTimeout: 2 * time.Second,
 		Delay:      2 * time.Second,
 	}


### PR DESCRIPTION
### Description

Fixes #2249: Deleting datastores would fail before they were actually deleted, with an error like "Error: could not delete datastore: timeout while waiting for state to become 'retryDeleteCompleted' (timeout: 30s)"

Apologies for not creating an acceptance test but this was my first fix using Go, without knowing Go.

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
