### PR TITLE
fix: `r/vsphere_virtual_machine` skip updating attributes if no diff

### DIFF
--- a/vsphere/internal/helper/customattribute/custom_attributes_helper.go
+++ b/vsphere/internal/helper/customattribute/custom_attributes_helper.go
@@ -126,6 +126,9 @@ func (p *DiffProcessor) ProcessDiff(subject object.Reference) error {
 }
 
 func GetDiffProcessorIfAttributesDefined(client *govmomi.Client, d *schema.ResourceData) (*DiffProcessor, error) {
+	if !d.HasChange(ConfigKey) {
+		return nil, nil
+	}
 	old, newValue := d.GetChange(ConfigKey)
 	if len(old.(map[string]interface{})) > 0 || len(newValue.(map[string]interface{})) > 0 {
 		if err := VerifySupport(client); err != nil {


### PR DESCRIPTION
### Description

`GetDiffProcessorIfAttributesDefined` function is missing a `HasChange` check which is causing the provider to always update custom attributes regardless if there is a diff or not.

This may cause problems in some cases, such as when you want to restrict the permissions the terraform account has on vsphere. If the permissions are locked down you'll end up getting a permission denied error.

In our case we were not setting the `custom_attributes` parameter at all but the provider still tried to update the remote object which was causing the error:
```
[ERROR] vertex vsphere_virtual_machine.vm[0]" error: error setting attributes for object ID "vm-181897": ServerFaultCode: Permission to perform this operation was denied.
```

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIX:
* `r/vsphere_virtual_machine` skip updating custom attributes if there is no diff
```

### References

None
