### PR TITLE
chore(gh): update to goreleaser v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+version: 2
 archives:
   - files:
       # Ensure only built binary and license file are archived
       - src: 'LICENSE'
-        dst: 'LICENSE.txt'    
-    format: zip
+        dst: 'LICENSE.txt'
+    formats: ['zip']
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 builds:
   - # Special binary naming is only necessary for Terraform CLI 0.12
@@ -85,4 +86,4 @@ signs:
       --out ${signature}
     artifacts: checksum
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"


### PR DESCRIPTION
### Description

Updates the GoReleaser configuration to v2.

**Before:**

```shell
terraform-provider-vsphere on  main via 🐹 v1.23.8 
➜ goreleaser check
  • only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
  • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

**After:**

```shell
terraform-provider-vsphere on  main via 🐹 v1.23.8 
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```