### PR TITLE
feat: use `ForceNew` for` entity_id` and `entity_type` on `r/vsphere_entity_permission`

### DIFF
--- a/vsphere/resource_vsphere_entity_permissions.go
+++ b/vsphere/resource_vsphere_entity_permissions.go
@@ -24,11 +24,13 @@ func resourceVsphereEntityPermissions() *schema.Resource {
 		"entity_id": {
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew:    true,
 			Description: "The managed object id or uuid of the entity.",
 		},
 		"entity_type": {
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew:    true,
 			Description: "The entity managed object type.",
 		},
 		"permissions": {
@@ -42,12 +44,11 @@ func resourceVsphereEntityPermissions() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Create:        resourceEntityPermissionsCreate,
-		Read:          resourceEntityPermissionsRead,
-		Update:        resourceEntityPermissionsUpdate,
-		Delete:        resourceEntityPermissionsDelete,
-		CustomizeDiff: resourceVSphereEntityPermissionsCustomizeDiff,
-		Schema:        sch,
+		Create: resourceEntityPermissionsCreate,
+		Read:   resourceEntityPermissionsRead,
+		Update: resourceEntityPermissionsUpdate,
+		Delete: resourceEntityPermissionsDelete,
+		Schema: sch,
 	}
 }
 
@@ -213,22 +214,6 @@ func resourceEntityPermissionsDelete(d *schema.ResourceData, meta interface{}) e
 	}
 	d.SetId("")
 	log.Printf("[DEBUG] %s: Delete complete for Entity Permissions", d.Id())
-	return nil
-}
-
-func resourceVSphereEntityPermissionsCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
-	if d.HasChange("entity_id") {
-		oldEntityID, newEntityID := d.GetChange("entity_id")
-		if oldEntityID.(string) != "" {
-			return fmt.Errorf("change %s in entity id is not allowed post creation", newEntityID)
-		}
-	}
-	if d.HasChange("entity_type") {
-		oldEntityType, newEntityType := d.GetChange("entity_type")
-		if oldEntityType.(string) != "" {
-			return fmt.Errorf("change in entity type %s is not allowed post creation", newEntityType)
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
### Description

Changes to `entity_id` and `entity_type` block `terraform apply`. This PR removes this restriction and forces a re-creation of the resource if either of these properties is changed.

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

```release-note
`r/vsphere_entity_permission`: Changes to `entity_id` and `entity_type` will cause instances to be recreated.
```

### References

Closes #2385