### PR TITLE
chore(gh): add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+---
+name: Check Documentation
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Install Tools
+      run: make tools
+    - name: Check Structure
+      run: make docs-check
+    - name: Check HCL Formatting
+      run: make docs-hcl-lint

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -2,7 +2,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-docs=$(find ../docs -type f -name "*.md")
+docs=$(find ./docs -type f -name "*.md")
 error=false
 
 for doc in $docs; do
@@ -44,4 +44,5 @@ if $error; then
   exit 1
 fi
 
+echo "==> Done."
 exit 0


### PR DESCRIPTION
### Description

- Removes legacy `terraform-website` context from makefile.
- Updates options to check the documentation structure in the makefile.
- Adds options to check and fix the hcl formatting in the makefile.
- Adds workflow to check the structure and hcl formatting.

```shell
terraform-provider-vsphere on  chore(gh)/add-docs-workflow [✘!?] via 🐹 v1.24.2 
➜ make docs-check
==> Checking structure...
==> Done.

terraform-provider-vsphere on  chore(gh)/add-docs-workflow [✘!?] via 🐹 v1.24.2 took 2.9s 
➜ make docs-hcl-lint
GO111MODULE=on go install -mod=mod github.com/katbyte/terrafmt
go: finding module for package github.com/katbyte/terrafmt
==> Checking HCL formatting...

terraform-provider-vsphere on  chore(gh)/add-docs-workflow [✘!?] via 🐹 v1.24.2 
➜ make docs-hcl-fix 
GO111MODULE=on go install -mod=mod github.com/katbyte/terrafmt
==> Applying HCL formatting...
```
