### PR TITLE
fix: remove superfluous-else

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,9 +70,6 @@ linters:
           - revive
         text: var-naming
       - linters:
-          - revive
-        text: superfluous-else
-      - linters:
           - staticcheck
         text: S1002
       - linters:

--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -709,13 +709,11 @@ powerLoop:
 				}
 				err = task.WaitEx(ctx)
 				if err != nil {
-					if err.Error() == "The operation is not allowed in the current state." {
+					if err != nil && err.Error() == "The operation is not allowed in the current state." {
 						log.Printf("[DEBUG] vm %q cannot be powered on in the current state", vmPath)
 						continue powerLoop
-					} else {
-						log.Printf("[DEBUG] PowerOn task for vm %q failed. Error: %s", vmPath, err)
-						return fmt.Errorf("powerOn task for vm %q failed: %s", vmPath, err)
 					}
+					return fmt.Errorf("powerOn task for vm %q failed: %w", vmPath, err)
 				}
 				log.Printf("[DEBUG] PowerOn task for VM %q was successful.", vmPath)
 				break powerLoop


### PR DESCRIPTION
### Description

Removes superfluous else.

```shell
~/Downloads/terraform-provider-vsphere git:[fix/remove-superfluous-else]
golangci-lint run
vsphere/internal/helper/virtualmachine/virtual_machine_helper.go:715:13: superfluous-else: if block ends with a continue statement, so drop this else and outdent its block (revive)
                                        } else {
                                                log.Printf("[DEBUG] PowerOn task for vm %q failed. Error: %s", vmPath, err)
                                                return fmt.Errorf("powerOn task for vm %q failed: %s", vmPath, err)
                                        }
1 issues:
* revive: 1


~/Downloads/terraform-provider-vsphere git:[fix/remove-superfluous-else]
golangci-lint run
0 issues.
```