### PR TITLE
fix: unnecessary conversion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,9 +100,6 @@ linters:
           - staticcheck
         text: QF1005
       - linters:
-          - unconvert
-        text: unnecessary conversion
-      - linters:
           - unused
         text: is unused
       - linters:

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -187,9 +187,9 @@ func upload(ctx context.Context, client *govmomi.Client, item types.OvfFileItem,
 }
 
 func uploadDisksFromLocal(client *govmomi.Client, filePath string, ovfFileItem types.OvfFileItem, deviceObj types.HttpNfcLeaseDeviceUrl, currBytesRead *int64) error {
-	absoluteFilePath := ""
+	var absoluteFilePath string
 	if strings.Contains(filePath, string(os.PathSeparator)) {
-		absoluteFilePath = string(filePath[0 : strings.LastIndex(filePath, string(os.PathSeparator))+1])
+		absoluteFilePath = filePath[:strings.LastIndex(filePath, string(os.PathSeparator))+1]
 	}
 	vmdkFilePath := absoluteFilePath + ovfFileItem.Path
 	log.Print(" [DEBUG] Absolute vmdk path: " + vmdkFilePath)
@@ -210,9 +210,9 @@ func uploadDisksFromLocal(client *govmomi.Client, filePath string, ovfFileItem t
 
 func uploadDisksFromURL(client *govmomi.Client, filePath string, ovfFileItem types.OvfFileItem, deviceObj types.HttpNfcLeaseDeviceUrl, currBytesRead *int64,
 	allowUnverifiedSSL bool) error {
-	absoluteFilePath := ""
+	var absoluteFilePath string
 	if strings.Contains(filePath, "/") {
-		absoluteFilePath = string(filePath[0 : strings.LastIndex(filePath, "/")+1])
+		absoluteFilePath = filePath[:strings.LastIndex(filePath, "/")+1]
 	}
 	vmdkFilePath := absoluteFilePath + ovfFileItem.Path
 	httpClient := getClient(allowUnverifiedSSL)


### PR DESCRIPTION
### Description

Fixes unnecessary conversion.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/unnecessary-conversion]
golangci-lint run

vsphere/internal/helper/ovfdeploy/ovf_helper.go:192:28: unnecessary conversion (unconvert)
                absoluteFilePath = string(filePath[0 : strings.LastIndex(filePath, string(os.PathSeparator))+1])
                                         ^
vsphere/internal/helper/ovfdeploy/ovf_helper.go:215:28: unnecessary conversion (unconvert)
                absoluteFilePath = string(filePath[0 : strings.LastIndex(filePath, "/")+1])
                                         ^
2 issues:
* unconvert: 2
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/unnecessary-conversion]
golangci-lint run
0 issues.
```