### PR TITLE
fix: file format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,9 +151,6 @@ linters:
           - staticcheck
         text: S1005
       - linters:
-          - goimports
-        text: File is not properly formatted
-      - linters:
           - errcheck
         path: vsphere/data_source_vsphere_datacenter.go
         text: Error return value of `view.Destroy` is not checked
@@ -161,10 +158,6 @@ linters:
           - errcheck
         path: vsphere/distributed_virtual_switch_helper.go
         text: Error return value of `task.Wait` is not checked
-      - linters:
-          - gofmt
-        path: vsphere/resource_vsphere_compute_cluster.go
-        text: File is not properly formatted
 
     paths:
       - third_party$

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere"
 )

--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -5,12 +5,12 @@ package vmworkflow
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore"
+	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -1237,7 +1237,7 @@ func getComponentsToAdd(old, new map[string]interface{}) map[string]string {
 func getComponentsToRemove(old, new map[string]interface{}) []string {
 	result := make([]string, 0)
 
-	for k, _ := range old {
+	for k := range old {
 		if _, contains := new[k]; !contains {
 			result = append(result, k)
 		}

--- a/vsphere/resource_vsphere_guest_os_customization.go
+++ b/vsphere/resource_vsphere_guest_os_customization.go
@@ -5,12 +5,13 @@ package vsphere
 
 import (
 	"context"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/vmware/govmomi/object"
-	"log"
 )
 
 func resourceVSphereGuestOsCustomization() *schema.Resource {

--- a/vsphere/resource_vsphere_offline_software_depot.go
+++ b/vsphere/resource_vsphere_offline_software_depot.go
@@ -6,6 +6,7 @@ package vsphere
 import (
 	"context"
 	"errors"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/govmomi/vapi/cis/tasks"

--- a/vsphere/resource_vsphere_virtual_machine_class.go
+++ b/vsphere/resource_vsphere_virtual_machine_class.go
@@ -5,6 +5,7 @@ package vsphere
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/govmomi/vapi/namespace"
 )


### PR DESCRIPTION
### Description

Fix file format.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/file-format]
golangci-lint run
vsphere/resource_vsphere_compute_cluster.go:1240:1: File is not properly formatted (gofmt)
        for k, _ := range old {
^
main.go:7:1: File is not properly formatted (goimports)
        "flag"
^
vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go:8:1: File is not properly formatted (goimports)
        "github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations"
^
vsphere/resource_vsphere_guest_os_customization.go:7:1: File is not properly formatted (goimports)
        "context"
^
vsphere/resource_vsphere_offline_software_depot.go:8:1: File is not properly formatted (goimports)
        "errors"
^
vsphere/resource_vsphere_virtual_machine_class.go:7:1: File is not properly formatted (goimports)
        "context"
^
6 issues:
* gofmt: 1
* goimports: 5
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/file-format]
golangci-lint run
0 issues.
```