### PR TITLE
fix: error not checked

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -140,7 +140,6 @@ linters:
           - errcheck
         path: vsphere/distributed_virtual_switch_helper.go
         text: Error return value of `task.Wait` is not checked
-
     paths:
       - third_party$
       - builtin$

--- a/vsphere/data_source_vsphere_datacenter.go
+++ b/vsphere/data_source_vsphere_datacenter.go
@@ -6,6 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/govmomi/find"
@@ -50,7 +51,11 @@ func dataSourceVSphereDatacenterRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return fmt.Errorf("error fetching datacenter: %s", err)
 	}
-	defer view.Destroy(ctx)
+	defer func() {
+		if err := view.Destroy(ctx); err != nil {
+			log.Printf("[WARN] Error destroying view during cleanup: %v", err)
+		}
+	}()
 	var vms []mo.VirtualMachine
 	err = view.Retrieve(ctx, []string{"VirtualMachine"}, []string{"name"}, &vms)
 	if err != nil {

--- a/vsphere/distributed_virtual_switch_helper.go
+++ b/vsphere/distributed_virtual_switch_helper.go
@@ -173,7 +173,10 @@ func updateDVSPvlanMappings(dvs *object.VmwareDistributedVirtualSwitch, pvlanCon
 	// Wait for ReconfigureDvs_Task to finish
 	tctx, tcancel := context.WithTimeout(context.Background(), defaultAPITimeout)
 	defer tcancel()
-	task.Wait(tctx)
+	err = task.Wait(tctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for reconfigure DVS task to finish: %s", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Description

Fixes error not checked identified by `golangci-lint`.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/error-not-checked]
golangci-lint run
vsphere/data_source_vsphere_datacenter.go:53:20: Error return value of `view.Destroy` is not checked (errcheck)
        defer view.Destroy(ctx)
                          ^
vsphere/distributed_virtual_switch_helper.go:176:11: Error return value of `task.Wait` is not checked (errcheck)
        task.Wait(tctx)
                 ^
2 issues:
* errcheck: 2
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/error-not-checked]
golangci-lint run
0 issues.
```