### PR TITLE
fix: error string punctuation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,9 +110,6 @@ linters:
         text: indent-error-flow
       - linters:
           - revive
-        text: error-strings
-      - linters:
-          - revive
         text: range
       - linters:
           - revive

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -1861,7 +1861,7 @@ func buildVsanRemoveWitnessHostReq(d *schema.ResourceData, cluster types.Managed
 
 	res, err := vsanclient.GetWitnessHosts(client, cluster.Reference())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get witness_node when removing witness!")
+		return nil, fmt.Errorf("failed to get witness node when removing witness")
 	}
 
 	return &vsantypes.VSANVcRemoveWitnessHost{


### PR DESCRIPTION
### Description

Fixes error string ending with punctuation.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/error-string-punctuation]
golangci-lint run
vsphere/resource_vsphere_compute_cluster.go:1864:26: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
                return nil, fmt.Errorf("failed to get witness_node when removing witness!")
                                       ^

1 issues:
* revive: 1
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/error-string-punctuation]
golangci-lint run
0 issues.
```