### PR TITLE
fix: exported type name stutter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,9 +116,6 @@ linters:
         text: range
       - linters:
           - revive
-        text: exported
-      - linters:
-          - revive
         text: empty-block
       - linters:
           - staticcheck

--- a/vsphere/data_source_vsphere_network.go
+++ b/vsphere/data_source_vsphere_network.go
@@ -112,7 +112,7 @@ func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) erro
 			// Handle distributed virtual switch port group
 			net, err = network.FromNameAndDVSUuid(client, name, dc, dvSwitchUUID)
 			if err != nil {
-				if _, ok := err.(network.NetworkNotFoundError); ok {
+				if _, ok := err.(network.NotFoundError); ok {
 					return struct{}{}, waitForNetworkPending, nil
 				}
 
@@ -123,7 +123,7 @@ func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) erro
 		// Handle standard switch port group
 		net, err = network.FromName(vimClient, name, dc, filters) // Pass the *vim25.Client
 		if err != nil {
-			if _, ok := err.(network.NetworkNotFoundError); ok {
+			if _, ok := err.(network.NotFoundError); ok {
 				return struct{}{}, waitForNetworkPending, nil
 			}
 			return struct{}{}, waitForNetworkError, err

--- a/vsphere/internal/helper/network/network_helper.go
+++ b/vsphere/internal/helper/network/network_helper.go
@@ -24,12 +24,12 @@ var NetworkType = []string{
 	"OpaqueNetwork",
 }
 
-type NetworkNotFoundError struct {
+type NotFoundError struct {
 	Name string
 	ID   string
 }
 
-func (e NetworkNotFoundError) Error() string {
+func (e NotFoundError) Error() string {
 	if len(e.ID) > 0 {
 		return fmt.Sprintf("Network with ID %s not found", e.ID)
 	}
@@ -70,7 +70,7 @@ func FromNameAndDVSUuid(client *govmomi.Client, name string, dc *object.Datacent
 		return nil, err
 	}
 	if len(networks) == 0 {
-		return nil, NetworkNotFoundError{Name: name}
+		return nil, NotFoundError{Name: name}
 	}
 
 	switch {
@@ -103,7 +103,7 @@ func FromNameAndDVSUuid(client *govmomi.Client, name string, dc *object.Datacent
 		}
 		return nil, fmt.Errorf("error while getting Network with name %s and Distributed virtual switch %s", name, dvsUUID)
 	}
-	return nil, NetworkNotFoundError{Name: name}
+	return nil, NotFoundError{Name: name}
 }
 
 func List(client *govmomi.Client) ([]*object.VmwareDistributedVirtualSwitch, error) {
@@ -182,7 +182,7 @@ func FromID(client *govmomi.Client, id string) (object.NetworkReference, error) 
 			return nref.(object.NetworkReference), nil
 		}
 	}
-	return nil, NetworkNotFoundError{ID: id}
+	return nil, NotFoundError{ID: id}
 }
 
 func dvsFromMOID(client *govmomi.Client, id string) (*object.VmwareDistributedVirtualSwitch, error) {
@@ -231,7 +231,7 @@ func FromName(client *vim25.Client, name string, dc *object.Datacenter, filters 
 	// Find the network by name
 	networks, err := finder.NetworkList(ctx, name)
 	if err != nil {
-		return nil, NetworkNotFoundError{Name: name}
+		return nil, NotFoundError{Name: name}
 	}
 
 	// If multiple networks are found and no filters are specified, return an error
@@ -268,5 +268,5 @@ func FromName(client *vim25.Client, name string, dc *object.Datacenter, filters 
 		}
 	}
 
-	return nil, NetworkNotFoundError{Name: name}
+	return nil, NotFoundError{Name: name}
 }


### PR DESCRIPTION
### Description

Refactors exported type name `network.NetworkNotFoundError` to `network.NotFoundError` to remove name stutter.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/exported-type-name-stutter]
golangci-lint run
vsphere/internal/helper/network/network_helper.go:27:6: exported: type name will be used as network.NetworkNotFoundError by other packages, and that stutters; consider calling this NotFoundError (revive)
type NetworkNotFoundError struct {
     ^

1 issues:
* revive: 1
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/exported-type-name-stutter]
golangci-lint run
0 issues.
```