### PR TITLE
fix: staticcheck S1039

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,9 +143,6 @@ linters:
         text: S1017
       - linters:
           - staticcheck
-        text: S1039
-      - linters:
-          - staticcheck
         text: S1040
       - linters:
           - staticcheck

--- a/vsphere/resource_vsphere_virtual_machine_class_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_class_test.go
@@ -4,7 +4,6 @@
 package vsphere
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -39,18 +38,18 @@ func TestAccResourceVSphereVmClass_vgpu(t *testing.T) {
 }
 
 func testAccVSphereVmClassConfig() string {
-	return fmt.Sprintf(`
+	return `
 		resource "vsphere_virtual_machine_class" "vm_class_1" {
 			name = "test-class-11"
 			cpus = 4
 			memory = 4096
 			memory_reservation = 100
 		}
-`)
+`
 }
 
 func testAccVSphereVmClassConfig_vgpu() string {
-	return fmt.Sprintf(`
+	return `
 		resource "vsphere_virtual_machine_class" "vm_class_1" {
 			name = "test-class-11"
 			cpus = 4
@@ -58,5 +57,5 @@ func testAccVSphereVmClassConfig_vgpu() string {
 			memory_reservation = 100
 			vgpu_devices = [ "mockup-vmiop" ]
 		}
-`)
+`
 }


### PR DESCRIPTION
### Description

Fixes unnecessary use of `fmt.Sprint`.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/staticcheck-S1039]
golangci-lint run
vsphere/resource_vsphere_virtual_machine_class_test.go:42:9: S1039: unnecessary use of fmt.Sprintf (staticcheck)
        return fmt.Sprintf(`
               ^
vsphere/resource_vsphere_virtual_machine_class_test.go:53:9: S1039: unnecessary use of fmt.Sprintf (staticcheck)
        return fmt.Sprintf(`

2 issues:
* staticcheck: 2
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/staticcheck-S1039]
golangci-lint run
0 issues.
```