### PR TITLE
fix: staticcheck SA1006

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,9 +131,6 @@ linters:
         text: QF1003
       - linters:
           - staticcheck
-        text: SA1006
-      - linters:
-          - staticcheck
         text: SA4006
       - linters:
           - staticcheck

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -549,12 +549,14 @@ func (o *OvfHelper) GetImportSpec(client *govmomi.Client) (*types.OvfCreateImpor
 		return nil, fmt.Errorf("while getting ovf import spec: %s", err)
 	}
 	if len(is.Error) > 0 {
-		out := "while creating import spec: \n"
+		errs := make([]error, 0, len(is.Error))
 		for _, e := range is.Error {
-			out = fmt.Sprintf("%s\n- %s", out, e.LocalizedMessage)
+			errs = append(errs, errors.New(e.LocalizedMessage))
 		}
-		return nil, fmt.Errorf(out)
+		allErrors := errors.Join(errs...)
+		return nil, fmt.Errorf("while creating import spec: %w", allErrors)
 	}
+
 	return is, nil
 }
 


### PR DESCRIPTION
### Description

Refactors to use the `errors.Join` with and `%w` for context wrapping. `fmt.Errorf`.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/staticcheck-SA1006]
golangci-lint run
vsphere/internal/helper/ovfdeploy/ovf_helper.go:556:15: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
                return nil, fmt.Errorf(out)
                            ^

1 issues:
* staticcheck: 1
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/staticcheck-SA1006]
golangci-lint run
0 issues.
```