### PR TITLE
refactor: clean file paths

### DIFF
--- a/vsphere/internal/helper/contentlibrary/content_library_helper.go
+++ b/vsphere/internal/helper/contentlibrary/content_library_helper.go
@@ -338,6 +338,7 @@ func (uploadSession libraryUploadSession) uploadLocalFile(file string) error {
 }
 
 func openLocalFile(file string) (*io.Reader, *int64, error) {
+	file = filepath.Clean(file)
 	openFile, err := os.Open(file)
 	if err != nil {
 		return nil, nil, err

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -193,6 +194,7 @@ func uploadDisksFromLocal(client *govmomi.Client, filePath string, ovfFileItem t
 	}
 	vmdkFilePath := absoluteFilePath + ovfFileItem.Path
 	log.Print(" [DEBUG] Absolute vmdk path: " + vmdkFilePath)
+	vmdkFilePath = filepath.Clean(vmdkFilePath)
 	file, err := os.Open(vmdkFilePath)
 	if err != nil {
 		return err
@@ -268,6 +270,7 @@ func GetOvfDescriptor(filePath string, deployOva bool, fromLocal bool, allowUnve
 	ovfDescriptor := ""
 	if !deployOva {
 		if fromLocal {
+			filePath = filepath.Clean(filePath)
 			fileBuffer, err := os.ReadFile(filePath)
 			if err != nil {
 				return "", err
@@ -293,6 +296,7 @@ func GetOvfDescriptor(filePath string, deployOva bool, fromLocal bool, allowUnve
 		}
 	} else {
 		if fromLocal {
+			filePath = filepath.Clean(filePath)
 			ovaFile, err := os.Open(filePath)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
### Description

This pull request introduces changes to improve file path handling by ensuring all file paths are sanitized using `filepath.Clean`. This helps prevent potential issues with malformed or unsafe paths.

Improvements to file path handling:

* `vsphere/internal/helper/contentlibrary/content_library_helper.go`:
  - Added `filepath.Clean` to sanitize the input file path in the `openLocalFile` function.

* `vsphere/internal/helper/ovfdeploy/ovf_helper.go`:
  - Added `filepath.Clean` to sanitize file paths in the following functions:
    - `uploadDisksFromLocal` for cleaning the `vmdkFilePath`.
    - `GetOvfDescriptor` for cleaning `filePath` when reading the OVF descriptor from a local file. [[1]](diffhunk://#diff-26b5fa249e72aa266e3b5c47124d3ea8bb5e2aa26cc61869e378b4b6dc5b63adR273) [[2]](diffhunk://#diff-26b5fa249e72aa266e3b5c47124d3ea8bb5e2aa26cc61869e378b4b6dc5b63adR299)
  - Included the `path/filepath` package in the imports to enable the use of `filepath.Clean`.