### PR TITLE
refactor: simplify boolean comparisons in conditions

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -464,7 +464,7 @@ loopInterfaces:
 				// Check for the SriovEnabled property of the SRIOV PCIPassthrough
 				if nicType.Id == sriovPhysicalAdapters[adapterIdx] {
 					foundAdapter = true
-					if nicType.SriovEnabled == true {
+					if nicType.SriovEnabled {
 						foundSriovEnabled = true
 						log.Printf("[DEBUG] found SR-IOV enabled NIC with name %s", sriovPhysicalAdapters[adapterIdx])
 						adapterIdx++

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -1077,7 +1077,7 @@ func getMemoryReservationLockedToMax(d *schema.ResourceData) *bool {
 		return structure.BoolPtr(false)
 	}
 
-	if memory == memoryReservation && memoryLockMax == true {
+	if memory == memoryReservation && memoryLockMax {
 		return structure.BoolPtr(true)
 	}
 


### PR DESCRIPTION
### Description

Replaced explicit boolean comparisons like `if condition == true` with the simpler and more idiomatic Go form `if condition`. This improves code readability and adheres to standard Go conventions.

