### PR TITLE
refactor: use switch statement for os customization type

### DIFF
--- a/vsphere/internal/helper/guestoscustomizations/customizations_helper.go
+++ b/vsphere/internal/helper/guestoscustomizations/customizations_helper.go
@@ -318,7 +318,8 @@ func FlattenGuestOsCustomizationSpec(d *schema.ResourceData, specItem *types.Cus
 	specData["dns_server_list"] = specItem.Spec.GlobalIPSettings.DnsServerList
 	specData["dns_suffix_list"] = specItem.Spec.GlobalIPSettings.DnsSuffixList
 
-	if specItem.Info.Type == GuestOsCustomizationTypeLinux {
+	switch specItem.Info.Type {
+	case GuestOsCustomizationTypeLinux:
 		linuxPrep := specItem.Spec.Identity.(*types.CustomizationLinuxPrep)
 		linuxOptions, err := flattenLinuxOptions(linuxPrep)
 		if err != nil {
@@ -326,7 +327,7 @@ func FlattenGuestOsCustomizationSpec(d *schema.ResourceData, specItem *types.Cus
 		}
 
 		specData["linux_options"] = linuxOptions
-	} else if specItem.Info.Type == GuestOsCustomizationTypeWindows {
+	case GuestOsCustomizationTypeWindows:
 		sysprepText := flattenSysprepText(specItem.Spec.Identity)
 		if len(sysprepText) > 0 {
 			specData["windows_sysprep_text"] = sysprepText


### PR DESCRIPTION
### Description

Replaced the if-else if chain checking `specItem.Info.Type` with a switch statement.

Using `switch` on the type variable is more idiomatic Go and often improves readability when dispatching logic based on the value of a single variable, especially when more cases might be added later.

