### PR TITLE
refactor: simplify access to methods/fields via direct calls

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -514,8 +514,8 @@ func newClientWithKeepAlive(ctx context.Context, u *url.URL, insecure bool, keep
 		SessionManager: session.NewManager(vimClient),
 	}
 
-	k := session.KeepAlive(c.Client.RoundTripper, time.Duration(keepAlive)*time.Minute)
-	c.Client.RoundTripper = k
+	k := session.KeepAlive(c.RoundTripper, time.Duration(keepAlive)*time.Minute)
+	c.RoundTripper = k
 
 	// Only login if the URL contains user information.
 	if u.User != nil {

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -126,7 +126,7 @@ func DeployOvfAndGetResult(client *govmomi.Client, ovfCreateImportSpecResult *ty
 }
 
 func upload(ctx context.Context, client *govmomi.Client, item types.OvfFileItem, f io.Reader, rawUrl string, size int64, totalBytesRead *int64) error {
-	u, err := client.Client.ParseURL(rawUrl)
+	u, err := client.ParseURL(rawUrl)
 	if err != nil {
 		return err
 	}

--- a/vsphere/internal/helper/viapi/vim_helper.go
+++ b/vsphere/internal/helper/viapi/vim_helper.go
@@ -202,7 +202,7 @@ func parseVersionFromAboutInfo(info types.AboutInfo) VSphereVersion {
 // ParseVersionFromClient returns a populated VSphereVersion from a client
 // connection.
 func ParseVersionFromClient(client *govmomi.Client) VSphereVersion {
-	return parseVersionFromAboutInfo(client.Client.ServiceContent.About)
+	return parseVersionFromAboutInfo(client.ServiceContent.About)
 }
 
 // String implements stringer for VSphereVersion.

--- a/vsphere/resource_vsphere_datacenter.go
+++ b/vsphere/resource_vsphere_datacenter.go
@@ -252,7 +252,7 @@ func resourceVSphereDatacenterDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	req := &types.Destroy_Task{
-		This: dc.Common.Reference(),
+		This: dc.Reference(),
 	}
 
 	_, err = methods.Destroy_Task(context.TODO(), client, req)

--- a/vsphere/resource_vsphere_file.go
+++ b/vsphere/resource_vsphere_file.go
@@ -179,7 +179,7 @@ func fileUpload(client *govmomi.Client, dc *object.Datacenter, ds *object.Datast
 	dsurl := ds.NewURL(destination)
 
 	p := soap.DefaultUpload
-	err = client.Client.UploadFile(context.TODO(), source, dsurl, &p)
+	err = client.UploadFile(context.TODO(), source, dsurl, &p)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Refactored multiple instances where methods or fields were accessed through an intermediate field (e.g., `obj.Common.Reference()`). These have been simplified to use direct access where applicable.

