### PR TITLE
refactor: host thumbprint insecure option

### DIFF
--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -891,18 +891,12 @@ func getHostThumbprint(d *schema.ResourceData) (string, error) {
 	// Otherwise, use the default value of false.
 	if thumbprint, ok := d.Get("thumbprint").(string); ok && thumbprint != "" {
 		return thumbprint, nil
-	} else {
-		if insecure, ok := d.GetOk("allow_unverified_ssl"); ok {
-			if insecureBool, ok := insecure.(bool); ok {
-				config.InsecureSkipVerify = insecureBool
-				if config.InsecureSkipVerify {
-				}
-			} else {
-				config.InsecureSkipVerify = false
-			}
-		} else {
-			config.InsecureSkipVerify = false
-		}
+	}
+
+	config.InsecureSkipVerify = false
+
+	if insecure, ok := d.Get("allow_unverified_ssl").(bool); ok {
+		config.InsecureSkipVerify = insecure
 	}
 
 	conn, err := tls.Dial("tcp", address+":"+port, config)


### PR DESCRIPTION
### Description

Simplifies the logic for determining the `InsecureSkipVerify` configuration in the `getHostThumbprint` function of `vsphere/resource_vsphere_host.go`.

Removed nested conditionals and redundant checks for the `allow_unverified_ssl` attribute, streamlining the logic for setting `config.InsecureSkipVerify`. The updated code directly assigns the value of `allow_unverified_ssl` if it exists and is of type `bool`.