### PR TITLE
refactor: host base images drop else and outdent

### DIFF
--- a/vsphere/data_source_vsphere_host_base_images.go
+++ b/vsphere/data_source_vsphere_host_base_images.go
@@ -25,15 +25,17 @@ func dataSourceVSphereHostBaseImages() *schema.Resource {
 
 func dataSourceVSphereHostBaseImagesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client).restClient
-	if images, err := depots.NewManager(client).ListBaseImages(); err != nil {
-		return err
-	} else {
-		versions := make([]string, len(images))
-		for i, image := range images {
-			versions[i] = image.Version
-		}
 
-		d.SetId(versions[0])
-		return d.Set("version", versions)
+	images, err := depots.NewManager(client).ListBaseImages()
+	if err != nil {
+		return err
 	}
+
+	versions := make([]string, len(images))
+	for i, image := range images {
+		versions[i] = image.Version
+	}
+
+	d.SetId(versions[0])
+	return d.Set("version", versions)
 }


### PR DESCRIPTION
### Description

This pull request refactors the `dataSourceVSphereHostBaseImagesRead` function in `vsphere/data_source_vsphere_host_base_images.go` to improve readability and error handling. The changes primarily involve restructuring the code to eliminate the use of an inline `if-else` statement and ensure a cleaner flow.

* Replaced the inline `if-else` statement with separate variable assignment and error handling for the `ListBaseImages` method. This improves code clarity and separates concerns for better readability.
* Removed an unnecessary closing brace at the end of the function, simplifying the code structure.