### PR TITLE
refactor: software depot drop else and outdent

### DIFF
--- a/vsphere/resource_vsphere_offline_software_depot_test.go
+++ b/vsphere/resource_vsphere_offline_software_depot_test.go
@@ -34,14 +34,15 @@ func TestAccResourceVSphereOfflineSoftwareDepot_basic(t *testing.T) {
 
 func testAccResourceVSphereOfflineSoftwareDepotCheckFunc() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if tVars, err := testClientVariablesForResource(s, "vsphere_offline_software_depot.depot"); err != nil {
+		tVars, err := testClientVariablesForResource(s, "vsphere_offline_software_depot.depot")
+		if err != nil {
 			return err
-		} else {
-			location, _ := tVars.resourceAttributes["location"]
-			expected := os.Getenv("TF_VAR_VSPHERE_SOFTWARE_DEPOT_LOCATION")
-			if location != expected {
-				return fmt.Errorf("depot location is incorrect. Expected %s but got %s", expected, location)
-			}
+		}
+
+		location, _ := tVars.resourceAttributes["location"]
+		expected := os.Getenv("TF_VAR_VSPHERE_SOFTWARE_DEPOT_LOCATION")
+		if location != expected {
+			return fmt.Errorf("depot location is incorrect. Expected %s but got %s", expected, location)
 		}
 
 		return nil


### PR DESCRIPTION
### Description

Refactors error handling to simplify the code and improve readability.

The changes involve removing unnecessary else blocks following error returns and restructuring the code for better clarity.

* Refactored error-handling in `resourceVsphereOfflineSoftwareDepotCreate`, `resourceVsphereOfflineSoftwareDepotRead`, and `resourceVsphereOfflineSoftwareDepotDelete` functions to use a linear structure instead of nested `if-else` blocks, improving readability. (`vsphere/resource_vsphere_offline_software_depot.go`: [[1]](diffhunk://#diff-82e43dd65758c12fe69acba711cc17ca00a38de664e60e71dbd0f65bbb170a51L71-R85) [[2]](diffhunk://#diff-82e43dd65758c12fe69acba711cc17ca00a38de664e60e71dbd0f65bbb170a51L86-L99) [[3]](diffhunk://#diff-82e43dd65758c12fe69acba711cc17ca00a38de664e60e71dbd0f65bbb170a51L109-R119)

* Updated `TestAccResourceVSphereOfflineSoftwareDepot_basic` to use a linear error-checking pattern, making the test function easier to follow. (`vsphere/resource_vsphere_offline_software_depot_test.go`: [vsphere/resource_vsphere_offline_software_depot_test.goL37-L45](diffhunk://#diff-6773afd8f0639667a9bccfb41f199c7dbffc908b8b6062f05d531da483827788L37-L45))