### PR TITLE
fix: prevent panic when both `ParentVApp` and `ResourcePool` are nil

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -467,14 +467,16 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	if vprops.ResourcePool != nil {
 		_ = d.Set("resource_pool_id", vprops.ResourcePool.Value)
 	}
+
 	// If the VM is part of a vApp, InventoryPath will point to a host path
 	// rather than a VM path, so this step must be skipped.
 	var vmContainer string
 	if vprops.ParentVApp != nil {
 		vmContainer = vprops.ParentVApp.Value
-	} else {
+	} else if vprops.ResourcePool != nil {
 		vmContainer = vprops.ResourcePool.Value
 	}
+
 	if !vappcontainer.IsVApp(client, vmContainer) {
 		f, err := folder.RootPathParticleVM.SplitRelativeFolder(vm.InventoryPath)
 		if err != nil {


### PR DESCRIPTION
### Description

Fixes a nil pointer dereference in `resourceVSphereVirtualMachineRead `when both `ParentVApp` and `ResourcePool` are `nil`. The now safely checks for `nil` before accessing `.Value`, and explicitly sets `vmContainer` to an empty string if neither is present.

### Reference

Closes #2304

Ref: #2304, #2305
