### PR TITLE
[wip] fix: normalize annotation for diff suppression

### DIFF
--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -1062,3 +1062,13 @@ func ValidateHardwareVersion(current, target int) error {
 	}
 	return nil
 }
+
+// NormalizeAnnotation normalizes a string by replacing Windows newlines with Unix newlines and trimming leading and/or
+// trailing whitespace.
+func NormalizeAnnotation(s string) string {
+	// Replace Windows newlines with Unix newlines
+	normalized := strings.ReplaceAll(s, "\r\n", "\n")
+	// Trim leading/trailing whitespace from the entire block
+	normalized = strings.TrimSpace(normalized)
+	return normalized
+}

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -8,8 +8,6 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/mitchellh/copystructure"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -17,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"
+	"github.com/mitchellh/copystructure"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -274,6 +273,12 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 			Description: "User-provided description of the virtual machine.",
+			DiffSuppressFunc: func(k, oldAnnotation, newAnnotation string, d *schema.ResourceData) bool {
+				normalizedOld := virtualmachine.NormalizeAnnotation(oldAnnotation)
+				normalizedNew := virtualmachine.NormalizeAnnotation(newAnnotation)
+				normalizedMatch := normalizedOld == normalizedNew
+				return normalizedMatch
+			},
 		},
 		"guest_id": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
### Description

> [!WARNING]
> **TESTING IS PENDING** 

Adds a `DiffSuppressFunc` for the `annotation`attribute. The function utilizes a new helper, `virtualmachine.NormalizeAnnotation`, to standardize newline characters to `\n` and trim surrounding whitespace from both the configured value and the state value before comparison. 

This prevents Terraform from detecting changes based solely on formatting differences.

### Reference

Closed #2252

