### PR TITLE
chore(deps): pin govmomi to v0.53.0-alpha.0.0.20251206181948-b345718843b2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/vmware/govmomi v0.53.0-alpha.0.0.20251127155234-4da134ecba9f
+	github.com/vmware/govmomi v0.53.0-alpha.0.0.20251206181948-b345718843b2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/vmware/govmomi v0.53.0-alpha.0.0.20251127155234-4da134ecba9f h1:q8ZK3gOqVjLqLPTCe/j5tOX7QPQr7fMgEjRk31cqIDU=
 github.com/vmware/govmomi v0.53.0-alpha.0.0.20251127155234-4da134ecba9f/go.mod h1:FM3GTg002dFFN7l2/hNS0YWC4f78HTw4kvgUwAE52cM=
+github.com/vmware/govmomi v0.53.0-alpha.0.0.20251206181948-b345718843b2 h1:gDCsc2/eyLEiie04ObVKCE5cBdxt2H3btqxH00PyMpg=
+github.com/vmware/govmomi v0.53.0-alpha.0.0.20251206181948-b345718843b2/go.mod h1:FM3GTg002dFFN7l2/hNS0YWC4f78HTw4kvgUwAE52cM=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

Yet another bump similar to https://github.com/vmware/terraform-provider-vsphere/pull/2635
Pinning `vmware/govmomi` to its latest commit to unblock work on new features.

A proper dependency bump to v0.53.0 will have to be made prior to releasing a new version of the provider

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [X] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [X] Tests have been completed.


There are a few failures in the runlist which are not caused by this change
<details>
<summary>Output:</summary>

```
📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccDataSourceVSphereAlarm_EventExpWithActions (1.41s)
  ✅ TestAccDataSourceVSphereAlarm_MetricExpWithActions (1.41s)
  ✅ TestAccDataSourceVSphereAlarm_StateExpWithActions (1.35s)
  ✅ TestAccDataSourceVSphereComputeClusterHostGroup_basic (2.16s)
  ✅ TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter (9.74s)
  ✅ TestAccDataSourceVSphereComputeCluster_basic (1.73s)
  ✅ TestAccDataSourceVSphereContentLibrary_basic (6.56s)
  ✅ TestAccDataSourceVSphereCustomAttribute_basic (1.76s)
  ✅ TestAccDataSourceVSphereDatacenter_basic (1.96s)
  ✅ TestAccDataSourceVSphereDatacenter_defaultDatacenter (1.87s)
  ✅ TestAccDataSourceVSphereDatacenter_getVirtualMachines (14.39s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter (3.1s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_basic (2.57s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_getDatastores (2.97s)
  ✅ TestAccDataSourceVSphereDatastoreStats_basic (2.27s)
  ✅ TestAccDataSourceVSphereDatastore_basic (1.66s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup (3.33s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified (3.26s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_basic (3.46s)
  ✅ TestAccDataSourceVSphereDynamic_multiResult (14.26s)
  ✅ TestAccDataSourceVSphereDynamic_multiTag (17.76s)
  ✅ TestAccDataSourceVSphereDynamic_regexAndTag (17.78s)
  ✅ TestAccDataSourceVSphereDynamic_typeFilter (17.75s)
  ✅ TestAccDataSourceVSphereFolder_basic (2.78s)
  ✅ TestAccDataSourceVSphereGOSC_basic (1.87s)
  ✅ TestAccDataSourceVSphereHostThumbprint_basic (1.02s)
  ✅ TestAccDataSourceVSphereHost_basic (1.79s)
  ✅ TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter (2.96s)
  ✅ TestAccDataSourceVSphereNetwork_dvsPortgroup (3.11s)
  ✅ TestAccDataSourceVSphereNetwork_hostPortgroups (1.69s)
  ✅ TestAccDataSourceVSphereNetwork_withTimeout (3.56s)
  ✅ TestAccDataSourceVSphereResourcePool_basic (2.62s)
  ✅ TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath (2.66s)
  ✅ TestAccDataSourceVSphereResourcePool_withParentId (2.94s)
  ✅ TestAccDataSourceVSphereRole_basic (1.4s)
  ✅ TestAccDataSourceVSphereRole_systemRoleData (1.02s)
  ✅ TestAccDataSourceVSphereTagCategory_basic (3.13s)
  ✅ TestAccDataSourceVSphereTag_basic (3.73s)
  ✅ TestAccDataSourceVSphereVAppContainer_basic (2.69s)
  ✅ TestAccDataSourceVSphereVAppContainer_path (2.9s)
  ✅ TestAccDataSourceVSphereVirtualMachine_basic (15.67s)
  ✅ TestAccDataSourceVSphereVirtualMachine_moid (15.87s)
  ✅ TestAccDataSourceVSphereVirtualMachine_nameAndFolder (13.59s)
  ✅ TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath (14.71s)
  ✅ TestAccDataSourceVSphereVirtualMachine_uuid (14.73s)
  ✅ TestAccDataSourceVSphereVmfsDisks_basic (2.87s)
  ✅ TestAccDataSourceVSphereZone_associations (13.56s)
  ✅ TestAccDataSourceVSphereZone_basic (3.84s)
  ✅ TestAccResourceVMStoragePolicy_basic (5.52s)
  ✅ TestAccResourceVSpherGOSC_linux (2.07s)
  ✅ TestAccResourceVSpherGOSC_sysprep (2.04s)
  ✅ TestAccResourceVSpherGOSC_windows_basic (2.14s)
  ✅ TestAccResourceVSphereComputeClusterHostGroup_basic (2.5s)
  ✅ TestAccResourceVSphereComputeClusterHostGroup_update (3.51s)
  ✅ TestAccResourceVSphereComputeClusterVMAffinityRule_basic (18.59s)
  ✅ TestAccResourceVSphereComputeClusterVMAffinityRule_updateCount (31.67s)
  ✅ TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled (18.34s)
  ✅ TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic (15.22s)
  ✅ TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateCount (28.79s)
  ✅ TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled (18.28s)
  ✅ TestAccResourceVSphereComputeClusterVMGroup_basic (16.71s)
  ✅ TestAccResourceVSphereComputeClusterVMGroup_update (31.33s)
  ✅ TestAccResourceVSphereContentLibrary_basic (6.78s)
  ✅ TestAccResourceVSphereCustomAttribute_basic (2s)
  ✅ TestAccResourceVSphereCustomAttribute_changeType (3.12s)
  ✅ TestAccResourceVSphereCustomAttribute_rename (2.63s)
  ✅ TestAccResourceVSphereCustomAttribute_withType (1.76s)
  ✅ TestAccResourceVSphereDPMHostOverride_basic (3.32s)
  ✅ TestAccResourceVSphereDPMHostOverride_overrides (3.01s)
  ✅ TestAccResourceVSphereDPMHostOverride_update (4.35s)
  ✅ TestAccResourceVSphereDRSVMOverride_automationLevel (14.69s)
  ✅ TestAccResourceVSphereDRSVMOverride_drs (16.03s)
  ❌ TestAccResourceVSphereDRSVMOverride_update (20.09s)
  ✅ TestAccResourceVSphereDatacenter_createOnRootFolder (13.37s)
  ✅ TestAccResourceVSphereDatacenter_createOnSubfolder (13.32s)
  ✅ TestAccResourceVSphereDatacenter_modifyTags (15.06s)
  ✅ TestAccResourceVSphereDatacenter_singleTag (13.35s)
  ✅ TestAccResourceVSphereDatastoreCluster_basic (3.81s)
  ✅ TestAccResourceVSphereDatastoreCluster_inFolder (3.41s)
  ✅ TestAccResourceVSphereDatastoreCluster_moveToFolder (5.21s)
  ✅ TestAccResourceVSphereDatastoreCluster_rename (6.01s)
  ✅ TestAccResourceVSphereDistributedPortGroup_basic (5.5s)
  ✅ TestAccResourceVSphereDistributedPortGroup_overrideVlan (3.8s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitchPvlanMapping_basic (5.86s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_basic (6.78s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_networkResourceControl (7.26s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_noHosts (4.1s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_removeNIC (11.67s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion (10.46s)
  ❌ TestAccResourceVSphereFile_basic (3.31s)
  ❌ TestAccResourceVSphereFile_uploadWithCreateDirectories (5.11s)
  ✅ TestAccResourceVSphereFolder_datacenterFolder (4.15s)
  ✅ TestAccResourceVSphereFolder_datastoreFolder (3.56s)
  ✅ TestAccResourceVSphereFolder_hostFolder (3.36s)
  ✅ TestAccResourceVSphereFolder_moveToSubfolder (5.82s)
  ✅ TestAccResourceVSphereFolder_networkFolder (3.47s)
  ✅ TestAccResourceVSphereFolder_subfolder (3.63s)
  ✅ TestAccResourceVSphereFolder_vmFolder (4.51s)
  ✅ TestAccResourceVSphereHAVMOverride_basic (12.78s)
  ✅ TestAccResourceVSphereHostNtpService (0s)
  ✅ TestAccResourceVSphereHostPortGroup_basic (4.42s)
  ✅ TestAccResourceVSphereHostPortGroup_basicToComplex (6.96s)
  ✅ TestAccResourceVSphereHostPortGroup_complexWithOverrides (5.08s)
  ✅ TestAccResourceVSphereHostVirtualSwitch_basic (4.01s)
  ✅ TestAccResourceVSphereResourcePool_basic (5.02s)
  ✅ TestAccResourceVSphereResourcePool_updateParent (7s)
  ✅ TestAccResourceVSphereTagCategory_addType (5.58s)
  ✅ TestAccResourceVSphereTagCategory_basic (4.04s)
  ✅ TestAccResourceVSphereTag_basic (4.73s)
  ✅ TestAccResourceVSphereVAppContainer_basic (5.43s)
  ✅ TestAccResourceVSphereVAppEntity_basic (18.54s)
  ✅ TestAccResourceVSphereVNic_dvs_default (1m29.22s)
  ✅ TestAccResourceVSphereVirtualDisk_basic (3.08s)
  ❌ TestAccResourceVSphereVirtualMachine_addDevices (26.34s)
  ✅ TestAccResourceVSphereVirtualMachine_basic (16.44s)
  ✅ TestAccResourceVSphereVirtualMachine_cpuTopology (45.41s)
  ✅ TestAccResourceVSphereVirtualMachine_deployOvaFromUrl (30.23s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionBare (16.24s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionClone (52.37s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade (33.43s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers (19.33s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController (37.54s)
  ✅ TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue (1.45s)
  ✅ TestAccResourceVSphereVirtualMachine_moveToFolder (14.84s)
  ✅ TestAccResourceVSphereVirtualMachine_multiDevice (17.4s)
  ✅ TestAccResourceVSphereVirtualMachine_reCreateOnDeletion (33.73s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevices (33.9s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit (35.28s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharing (55.68s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate (1m12.77s)
  ✅ TestAccResourceVSphereVirtualMachine_shutdownOK (16.61s)
  ✅ TestAccResourceVSphereVmfsDatastore_basic (13.58s)
  ✅ TestAccResourceVSphereZone_createAssociations (12.17s)
  ✅ TestAccResourceVSphereZone_createBasic (4.81s)
  ✅ TestAccResourceVSphereZone_updateAddAssociation (16.03s)
  ✅ TestAccResourceVSphereZone_updateAssociations (18.55s)
  ✅ TestAccResourceVSphereZone_updateBasic (12.01s)
  ✅ TestAccResourceVSphereZone_updateRemoveAssociation (16.09s)
  ✅ TestAccResourceVsphereAlarm_advancedAction (1.55s)
  ✅ TestAccResourceVsphereAlarm_basicEvent (1.57s)
  ✅ TestAccResourceVsphereAlarm_emailAction (1.44s)
  ✅ TestAccResourceVsphereAlarm_metricExpression (1.35s)
  ✅ TestAccResourceVsphereAlarm_snmpAction (1.48s)
  ✅ TestAccResourceVsphereAlarm_stateExpression (1.36s)
  ✅ TestAccResourceVsphereRole_addPrivileges (3.3s)
  ✅ TestAccResourceVsphereRole_createRole (2.12s)
  ✅ TestAccResourceVsphereRole_removePrivileges (2.75s)
  ✅ TestAccResourcevsphereEntityPermissions_basic (2.06s)
```

</details>

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
