### PR TITLE
fix: don't destroy VMs when adding network_interface blocks to a `clone` block

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1085,6 +1085,13 @@ func resourceVSphereVirtualMachineCustomizeDiff(_ context.Context, d *schema.Res
 				if k == "clone.0.timeout" {
 					continue
 				}
+
+				// Network interfaces do not need to ForceNew since they can be added to the VM
+				// without interruption.
+				if strings.HasPrefix(k, "clone.0.customize.0.network_interface") {
+					continue
+				}
+
 				_ = d.ForceNew(k)
 			}
 		}


### PR DESCRIPTION
### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

`r/virtual_machine` is implemented with a diff customization function which evaluates the contents of the `clone` attribute and flags the resource for destruction based on certain criteria.

This is necessary because some options really need the machine to be re-created, for example OS-level customizations.

The criteria however is too broad and causes the resource to be destroyed automatically even under conditions where that is not necessary.

I have added the `network_interface` blocks to the list of attributes which do not force Terraform to destroy the resource.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [X] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [X] Tests have been completed.

<details>

<summary>Acceptance Test Output:</summary>

```
cat gotest.log | grep -E "PASS|FAIL" | gotestfmt
📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccResourceVSphereVirtualMachine_addDevices (28.45s)
  ✅ TestAccResourceVSphereVirtualMachine_attachExistingVmdk (10.48s)
  ✅ TestAccResourceVSphereVirtualMachine_basic (20.93s)
  ✅ TestAccResourceVSphereVirtualMachine_cpuTopology (46.3s)
  ✅ TestAccResourceVSphereVirtualMachine_deployOvaFromUrl (29.52s)
  ✅ TestAccResourceVSphereVirtualMachine_evc (16.33s)
  ✅ TestAccResourceVSphereVirtualMachine_extraConfig (27.15s)
  ✅ TestAccResourceVSphereVirtualMachine_extraConfigSwapKeys (28.11s)
  ✅ TestAccResourceVSphereVirtualMachine_growDisk (26.02s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionBare (16.66s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionClone (1m10.68s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionDowngrade (13.9s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionInvalidVersion (750ms)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade (29.76s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers (18.33s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController (39.85s)
  ✅ TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue (1.49s)
  ✅ TestAccResourceVSphereVirtualMachine_inFolder (9.09s)
  ✅ TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs (15.66s)
  ✅ TestAccResourceVSphereVirtualMachine_modifyAnnotation (21.67s)
  ✅ TestAccResourceVSphereVirtualMachine_moveToFolder (16.02s)
  ✅ TestAccResourceVSphereVirtualMachine_multiDevice (15.49s)
  ✅ TestAccResourceVSphereVirtualMachine_multipleTags (14.85s)
  ✅ TestAccResourceVSphereVirtualMachine_nvmeController (14.78s)
  ✅ TestAccResourceVSphereVirtualMachine_reCreateOnDeletion (20.74s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevices (31.12s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit (33.08s)
  ✅ TestAccResourceVSphereVirtualMachine_resourcePoolMove (18.18s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharing (55.4s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate (1m12.81s)
  ✅ TestAccResourceVSphereVirtualMachine_shutdownOK (15.14s)
  ✅ TestAccResourceVSphereVirtualMachine_singleTag (14.85s)
  ✅ TestAccResourceVSphereVirtualMachine_staticMAC (8.18s)
  ✅ TestAccResourceVSphereVirtualMachine_swapSCSIBus (24.93s)
  ✅ TestAccResourceVSphereVirtualMachine_switchTags (17.21s)
  ✅ TestAccResourceVSphereVirtualMachine_videoCardClone (1m26.08s)
  ✅ TestAccResourceVSphereVirtualMachine_videoCardCreate (14.26s)
```

</details>

#### Manual Testing:

##### Setup

Prepared a .tf configuration with 2 virtual machines where one serves as a source and the other is a clone.
Configured a local override for the "vmware/terraform-provider-vsphere" binary and loaded a build without this fix

##### Steps

1. Ran `terraform apply` without making changes to the configuration. Verified that no state changes are detected.
2. Added 1 new `network_interface` to the cloned VM's configuration and to its `clone.0.customize` block.
3. Ran `terraorm apply` and verified that Terraform wants to destroy the virtual machine and create a new one in its place. This is expected since I am still running the binary without the fix. Cancelled the operation.
4. Applied the fix and recompiled the provider binary.
5. Ran `terraform apply` and verified that Terraform wants to update the resource in-place.

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Fixes #1313 

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

```
- `r/virtual_machine` - Don't destroy VMs when adding network_interface blocks to a "clone" block. (#1313)
```

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
